### PR TITLE
Fix upgrade instructions with a new container

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,8 +123,8 @@ The Docker setup gives you multiple upgrade options:
 1. Use the front end at http://yoursite.com/admin/docker to upgrade an already running image.
 
 2. Create a new base image by running:
-  - `./launcher bootstrap my_image`
   - `./launcher destroy my_image`
+  - `./launcher bootstrap my_image`
   - `./launcher start my_image`
 
 ### Single Container vs. Multiple Container


### PR DESCRIPTION
If you attempt to bootstrap a new container without stopping or destroying the original it will fail because postgres will detect that it is running in another container.

This fixes the documentation for #20. 
