### PR TITLE
Add examples to bind to only one network interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,10 @@ This template is "composed" out of all these child templates, this allows for a 
 ```
 expose:
   - "2222:22"
+  - "127.0.0.1:20080:80"
 ```
 
-Expose port 22 inside the container on port 2222 on ALL local host interfaces.
+Expose port 22 inside the container on port 2222 on ALL local host interfaces. In order to bind to only one interface, you may specify the host's IP address as `([<host_interface>:[host_port]])|(<host_port>):]<container_port>[/udp]` as defined in the [docker port binding documentation](http://docs.docker.io/en/latest/use/port_redirection/) 
 
 
 #### volumes:


### PR DESCRIPTION
Add `- "127.0.0.1:20080:80"` to `expose` example as well as the full docker port binding syntax.
