### PR TITLE
Fix gem configuration path

### DIFF
--- a/image/base/Dockerfile
+++ b/image/base/Dockerfile
@@ -36,7 +36,7 @@ RUN echo "debconf debconf/frontend select Teletype" | debconf-set-selections &&\
     dpkg-divert --local --rename --add /sbin/initctl &&\
     sh -c "test -f /sbin/initctl || ln -s /bin/true /sbin/initctl" &&\
     apt-get -y install redis-server haproxy openssh-server &&\
-    echo 'gem: --no-document' >> /etc/gemrc &&\
+    echo 'gem: --no-document' >> /usr/local/etc/gemrc &&\
     mkdir /src && cd /src && git clone https://github.com/sstephenson/ruby-build.git &&\
     cd /src/ruby-build && ./install.sh &&\
     cd / && rm -rf /src/ruby-build && ruby-build 2.0.0-p451 /usr/local &&\


### PR DESCRIPTION
I found that the gem configuration is not grabbing the `--no-document` instruction and is indeed installing documentation, changing the path for the gemrc file fix this behavior. I hope this helps! 
