### PR TITLE
remove commented lines of code leading space

### DIFF
--- a/samples/standalone.yml
+++ b/samples/standalone.yml
@@ -25,7 +25,7 @@ params:
 env:
   ## How many concurrent web requests are supported?
   ## With 2GB we recommend 3-4 workers, with 1GB only 2
-  # UNICORN_WORKERS: 3
+  #UNICORN_WORKERS: 3
   ##
   ## List of comma delimited emails that will be made admin on signup
   DISCOURSE_DEVELOPER_EMAILS: 'my-email-address@example.com'
@@ -35,12 +35,12 @@ env:
   ##
   ## The mailserver this Discourse instance will use
   DISCOURSE_SMTP_ADDRESS: smtp.example.com          # (mandatory)
-  # DISCOURSE_SMTP_PORT: 587                        # (optional)
-  # DISCOURSE_SMTP_USER_NAME: user@example.com      # (optional)
-  # DISCOURSE_SMTP_PASSWORD: p@ssword               # (optional)
+  #DISCOURSE_SMTP_PORT: 587                        # (optional)
+  #DISCOURSE_SMTP_USER_NAME: user@example.com      # (optional)
+  #DISCOURSE_SMTP_PASSWORD: p@ssword               # (optional)
   ##
   ## the origin pull CDN address for this Discourse instance
-  # DISCOURSE_CDN_URL: //discourse-cdn.example.com
+  #DISCOURSE_CDN_URL: //discourse-cdn.example.com
 
 ## These containers are stateless, all data is stored in /shared
 volumes:


### PR DESCRIPTION
I had problems with the installer because I wasn't used to YAML nor with its required indentation. IMHO, this way it would have been intuitively clear to me it needs it that way. https://meta.discourse.org/t/does-a-discourse-backend-trial-exist/16275/10?u=cawas
