### PR TITLE
Add easy configuration for max file upload size

### DIFF
--- a/templates/web.template.yml
+++ b/templates/web.template.yml
@@ -18,6 +18,7 @@ params:
   version: tests-passed
 
   home: /var/www/discourse
+  upload_size: 2m
 
 run:
   - file:
@@ -103,6 +104,11 @@ run:
       filename: "/etc/nginx/conf.d/discourse.conf"
       from: /server_name.+$/
       to: server_name _ ;
+
+  - replace:
+      filename: "/etc/nginx/conf.d/discourse.conf"
+      from: /client_max_body_size.+$/
+      to: client_max_body_size $upload_size ;
 
   - exec:
       cmd: echo "done configuring web"


### PR DESCRIPTION
Example, in app.yml:

```
params:
  version: tests-passed
  upload_size: 10m
```

Based on https://meta.discourse.org/t/change-the-maximum-file-upload-size/15159/5?u=riking
