### PR TITLE
Ubuntu 14.10 hasn't been released yet, list 14.04 LTS instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ### IMPORTANT: Before You Start
 
-1. Make sure you're running a **64 bit** version of either [Ubuntu 12.04 LTS](http://releases.ubuntu.com/precise/),  or [Ubuntu 14.10](http://releases.ubuntu.com/14.04/).
+1. Make sure you're running a **64 bit** version of either [Ubuntu 12.04 LTS](http://releases.ubuntu.com/precise/), or [Ubuntu 14.04 LTS](http://releases.ubuntu.com/14.04/).
 1. Upgrade to the [latest version of Docker](http://docs.docker.io/en/latest/installation/ubuntulinux/).
 1. Create a directory for Discourse Docker (the expected path is `/var/docker`): `install -g docker -m 2775 -d /var/docker`
 1. Run the docker installation and launcher as **root** or a member of the **docker** group.


### PR DESCRIPTION
Thanks for putting this project together. Just fixing a small typo.

The link in the readme pointed to the 14.04 release, but the text said 14.10, which I think isn't coming out until October.
