### PR TITLE
Supporting Discourse projects are MIT license

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,3 +164,7 @@ installs you can ensure they are in sync by looking at `/etc/passwd` and
 
 - [Setting up SSL with Discourse Docker](https://meta.discourse.org/t/allowing-ssl-for-your-discourse-docker-setup/13847)
 - [Multisite configuration with Docker](https://meta.discourse.org/t/multisite-configuration-with-docker/14084)
+
+License
+===
+MIT


### PR DESCRIPTION
Note: due to commit 60668406425eeb14bcec9f68cf592cad449a7061, this change is pending until @Stealthii grants permission - that change was both substantial and code, so there is a copyright concern.

Do not pull until we receive some sort of written confirmation from him.
