### PR TITLE
Add Dockerfile for running benchmark inside Docker

### DIFF
--- a/image/discourse_bench/Dockerfile
+++ b/image/discourse_bench/Dockerfile
@@ -1,0 +1,30 @@
+FROM samsaffron/discourse_test:latest
+
+MAINTAINER Gerhard Schlager <mail@gerhard-schlager.at>
+
+# Install ApacheBench
+RUN apt-get install -y apache2-utils libsqlite3-dev
+
+# configure Git to suppress warnings
+RUN git config --global user.email "you@example.com" &&\
+    git config --global user.name "Your Name"
+
+RUN git pull &&\
+    sudo -u discourse bundle install --standalone
+
+RUN gem install facter &&\
+    gem install mailcatcher
+
+# reconfigure PostgreSQL template databases to use UTF-8
+# otherwise rake db:create fails
+RUN pg_dropcluster --stop 9.3 main &&\
+    pg_createcluster --start -e UTF-8 9.3 main
+
+# create role "discourse"
+RUN /etc/init.d/postgresql start &&\
+    sudo -u postgres createuser --superuser discourse
+
+ADD run_bench.sh /tmp/run_bench.sh
+RUN chmod +x /tmp/run_bench.sh
+
+ENTRYPOINT ["/tmp/run_bench.sh"]

--- a/image/discourse_bench/run_bench.sh
+++ b/image/discourse_bench/run_bench.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# start Redis-Server
+redis-server /etc/redis/redis.conf
+
+# start PostgreSQL
+/etc/init.d/postgresql start
+
+# get latest source
+git pull
+
+# install needed gems
+sudo -E -u discourse bundle install
+
+# start mailcatcher
+mailcatcher --http-ip 0.0.0.0
+
+# run the benchmark
+sudo -E -u discourse ruby script/bench.rb


### PR DESCRIPTION
Uses discourse_test as a base and installs all needed software for the
benchmark. At container startup it pulls the latest source and runs the
benchmark.
