### PR TITLE
Corrected error in samples.

### DIFF
--- a/samples/standalone.yml
+++ b/samples/standalone.yml
@@ -39,7 +39,7 @@ env:
   #UNICORN_WORKERS: 3
   ##
   ## TODO: List of comma delimited emails that will be made admin and developer
-  ## on initial signup example 'user1@example.com, user2@example.com'
+  ## on initial signup example 'user1@example.com,user2@example.com'
   DISCOURSE_DEVELOPER_EMAILS: 'me@example.com'
   ##
   ## TODO: The domain name this Discourse instance will respond to

--- a/samples/web_only.yml
+++ b/samples/web_only.yml
@@ -27,7 +27,7 @@ env:
   DISCOURSE_REDIS_HOST: REDIS_IP_ADDRESS
   ##
   ## TODO: List of comma delimited emails that will be made admin and developer
-  ## on initial signup example 'user1@example.com, user2@example.com'
+  ## on initial signup example 'user1@example.com,user2@example.com'
   DISCOURSE_DEVELOPER_EMAILS: 'me@example.com'
   ##
   ## TODO: The domain name this Discourse instance will respond to


### PR DESCRIPTION
Examples now match actual behavior of DISCOURSE_DEVELOPER_EMAILS in web_only.yml and standalone.yml

https://meta.discourse.org/t/mini-profiler-only-visible-to-first-admin-not-second-admin/19368/3
