### PR TITLE
Maintain support for Docker v0.9.1

### DIFF
--- a/launcher
+++ b/launcher
@@ -7,7 +7,7 @@ opt=$3
 cd "$(dirname "$0")"
 
 docker_min_version='0.9.1'
-docker_rec_version='0.11.1'
+docker_rec_version='1.2.0'
 
 config_file=containers/"$config".yml
 cidfile=cids/"$config".cid


### PR DESCRIPTION
As referenced from [this post](https://meta.discourse.org/t/how-to-update-to-discourse-1-0/19328/34?u=stealthii):
- This is the version of Docker that Ubuntu 14.04 ships with. It is supported by the vendor (Just `apt-get install docker.io` and you're done)
- 0.9.1 still even today on latest Discourse release, has had no issues since it's first use by Discourse. Newer versions on the other hand, have had their fair share of bugs, regressions, and all sorts of behaviour changes.
- Docker-hosting services (at least the two I have spoken to) are opting for a stable, vendor supported version of Docker (Ubuntu's 0.9.1 release)
- Docker is still to this day, in active development. There will be more changes in future, potentially even config changes that are not backwards compatible. It is not Discourse's job to test Docker on users' production forums. Don't change it if it's not broken.
