### PR TITLE
Adds a docker_ip pipeline for /sbin/ip

### DIFF
--- a/launcher
+++ b/launcher
@@ -16,11 +16,17 @@ local_discourse=local_discourse
 image=samsaffron/discourse:1.0.3
 docker_path=`which docker.io || which docker`
 
-docker_ip=`/sbin/ifconfig | \
-                grep -B1 "inet addr" | \
-                awk '{ if ( $1 == "inet" ) { print $2 } else if ( $2 == "Link" ) { printf "%s:" ,$1 } }' | \
-                grep docker0 | \
-                awk -F: '{ print $3 }';`
+if [ -x /sbin/ip ]; then
+  docker_ip=`/sbin/ip addr show docker0 | \
+                  grep 'inet ' | \
+                  awk '{ split($2,a,"/"); print a[1] }';`
+else
+  docker_ip=`/sbin/ifconfig | \
+                  grep -B1 "inet addr" | \
+                  awk '{ if ( $1 == "inet" ) { print $2 } else if ( $2 == "Link" ) { printf "%s:" ,$1 } }' | \
+                  grep docker0 | \
+                  awk -F: '{ print $3 }';`
+fi
 
 
 usage () {


### PR DESCRIPTION
This fixes issues with systems which don't have ifconfig configured and have fully transitioned over to solely using /sbin/ip.
