### PR TITLE
apt-get update before install to avoid launch failure on fresh image

### DIFF
--- a/samples/standalone.yml
+++ b/samples/standalone.yml
@@ -78,7 +78,7 @@ run:
   - exec: echo "Beginning of custom commands"
 
   ## If you want to configure password login for root, uncomment and change:
-  #- exec: apt-get -y --force-yes install whois # for mkpasswd
+  #- exec: apt-get update && apt-get -y install whois # for mkpasswd
   ## Use only one of the following lines:
   #- exec: /usr/sbin/usermod -p 'PASSWORD_HASH' root
   #- exec: /usr/sbin/usermod -p "$(mkpasswd -m sha-256 'RAW_PASSWORD')" root

--- a/samples/standalone.yml
+++ b/samples/standalone.yml
@@ -78,7 +78,7 @@ run:
   - exec: echo "Beginning of custom commands"
 
   ## If you want to configure password login for root, uncomment and change:
-  #- exec: apt-get -y install whois # for mkpasswd
+  #- exec: apt-get -y --force-yes install whois # for mkpasswd
   ## Use only one of the following lines:
   #- exec: /usr/sbin/usermod -p 'PASSWORD_HASH' root
   #- exec: /usr/sbin/usermod -p "$(mkpasswd -m sha-256 'RAW_PASSWORD')" root


### PR DESCRIPTION
required if the package signature owner's public-key is not in the keyring (http://superuser.com/a/164580/35073).  This was preventing me from running './launch bootstrap app' with success on a fresh clone.