### PR TITLE
Use 429 error code for nginx ratelimiting

### DIFF
--- a/templates/web.ratelimited.template.yml
+++ b/templates/web.ratelimited.template.yml
@@ -11,6 +11,7 @@ run:
      to: |
        limit_req_zone $binary_remote_addr zone=flood:10m rate=$reqs_per_secondr/s;
        limit_req_zone $binary_remote_addr zone=bot:10m rate=$reqs_per_minuter/m;
+       limit_req_status 429;
        server {
   - replace:
      filename: "/etc/nginx/conf.d/discourse.conf"


### PR DESCRIPTION
The default of 503 is indistinguishable from a service outage. This change should help those writing against the api.
