### PR TITLE
add hook and a template to use chinese gem mirror site

### DIFF
--- a/templates/web.china.template.yml
+++ b/templates/web.china.template.yml
@@ -1,0 +1,11 @@
+hooks:
+  before_web:
+    - exec:
+       cmd:
+         - gem sources --remove https://rubygems.org/
+         - gem sources -a https://ruby.taobao.org/
+
+  before_bundle_exec:
+    - exec:
+      cmd:
+        - su discourse -c 'bundle config mirror.https://rubygems.org https://ruby.taobao.org/'

--- a/templates/web.template.yml
+++ b/templates/web.template.yml
@@ -127,6 +127,11 @@ run:
         # ensure we are on latest bundler
         - gem update bundler
         - chown -R discourse $home
+
+  - exec:
+      cd: $home
+      hook: bundle_exec
+      cmd:
         - su discourse -c 'bundle install --deployment --verbose --without test --without development'
         - su discourse -c 'bundle exec rake db:migrate'
         - su discourse -c 'bundle exec rake assets:precompile'


### PR DESCRIPTION
This template suppose to replace rubygems with taobao mirror for Chinese discourse user. rubygems got disrupted by GFW.
