### PR TITLE
A few tar commands are verbose, other aren't.

### DIFF
--- a/image/base/Dockerfile
+++ b/image/base/Dockerfile
@@ -39,7 +39,7 @@ RUN echo "debconf debconf/frontend select Teletype" | debconf-set-selections &&\
     cd / &&\
     mkdir /jemalloc && cd /jemalloc &&\
       wget http://www.canonware.com/download/jemalloc/jemalloc-3.4.1.tar.bz2 &&\
-      tar -xvjf jemalloc-3.4.1.tar.bz2 && cd jemalloc-3.4.1 && ./configure && make &&\
+      tar -xjf jemalloc-3.4.1.tar.bz2 && cd jemalloc-3.4.1 && ./configure && make &&\
       mv lib/libjemalloc.so.1 /usr/lib && cd / && rm -rf /jemalloc &&\
     apt-get -y install runit monit socat &&\
     mkdir -p /etc/runit/1.d &&\
@@ -52,7 +52,7 @@ RUN echo "debconf debconf/frontend select Teletype" | debconf-set-selections &&\
       cp phantomjs-1.9.8-linux-x86_64/bin/phantomjs /bin/phantomjs &&\
       rm -fr phantomjs-1.9.8-linux-x86_64 &&\
     wget http://static.jonof.id.au/dl/kenutils/pngout-20130221-linux.tar.gz &&\
-      tar -xvf pngout-20130221-linux.tar.gz &&\
+      tar -xf pngout-20130221-linux.tar.gz &&\
       rm pngout-20130221-linux.tar.gz &&\
       cp pngout-20130221-linux/x86_64/pngout /bin/pngout &&\
       rm -rf pngout-20130221-linux

--- a/image/base_21/Dockerfile
+++ b/image/base_21/Dockerfile
@@ -49,7 +49,7 @@ RUN echo "debconf debconf/frontend select Teletype" | debconf-set-selections &&\
     cd / && git clone https://github.com/SamSaffron/pups.git &&\
     mkdir /jemalloc && cd /jemalloc &&\
       wget http://www.canonware.com/download/jemalloc/jemalloc-3.4.1.tar.bz2 &&\
-      tar -xvjf jemalloc-3.4.1.tar.bz2 && cd jemalloc-3.4.1 && ./configure && make &&\
+      tar -xjf jemalloc-3.4.1.tar.bz2 && cd jemalloc-3.4.1 && ./configure && make &&\
       mv lib/libjemalloc.so.1 /usr/lib && cd / && rm -rf /jemalloc &&\
     apt-get -y install runit monit socat &&\
     apt-get clean &&\
@@ -62,7 +62,7 @@ RUN echo "debconf debconf/frontend select Teletype" | debconf-set-selections &&\
       cp phantomjs-1.9.7-linux-x86_64/bin/phantomjs /bin/phantomjs &&\
       rm -fr phantomjs-1.9.7-linux-x86_64 &&\
     wget http://static.jonof.id.au/dl/kenutils/pngout-20130221-linux.tar.gz &&\
-      tar -xvf pngout-20130221-linux.tar.gz &&\
+      tar -xf pngout-20130221-linux.tar.gz &&\
       rm pngout-20130221-linux.tar.gz &&\
       cp pngout-20130221-linux/x86_64/pngout /bin/pngout &&\
       rm -rf pngout-20130221-linux


### PR DESCRIPTION
To gain in coherence, I offer to discard -v flags.  This will speed
up the output printing at image build time and make the logs easier
to read.
