### PR TITLE
Removed instruction relevant only for Mac OS X

### DIFF
--- a/image/base_21/Dockerfile
+++ b/image/base_21/Dockerfile
@@ -39,7 +39,6 @@ RUN echo "debconf debconf/frontend select Teletype" | debconf-set-selections &&\
     cd /src/ruby-build && ./install.sh &&\
     cd / && rm -rf /src/ruby-build &&\
     echo install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#5fe00cda18ca5daeb43762b80c38e06e" --if needs_yaml > /src/2.1.2.discourse &&\
-    echo install_package "openssl-1.0.1g" "https://www.openssl.org/source/openssl-1.0.1g.tar.gz#de62b43dfcd858e66a74bee1c834e959" mac_openssl --if has_broken_mac_openssl >> /src/2.1.2.discourse &&\
     echo install_package "ruby-v_2_1_2_discourse" "https://github.com/SamSaffron/ruby/archive/v_2_1_2_discourse.tar.gz#98741e3cbfd00ae2931b2c0edb0f0698" ldflags_dirs standard verify_openssl >> /src/2.1.2.discourse &&\
     apt-get -y install ruby bison &&\
     ruby-build /src/2.1.2.discourse /usr/local &&\


### PR DESCRIPTION
Legacy Dockerfileimage/base_21/Dockerfile offers to install openssl-1.0.1g if the Mac OS X only has_broken_mac_openssl flag is set, and so is never executed.
