### PR TITLE
Upgrade Ruby to 2.0.0-p598

### DIFF
--- a/image/base/Dockerfile
+++ b/image/base/Dockerfile
@@ -60,7 +60,7 @@ RUN echo "debconf debconf/frontend select Teletype" | debconf-set-selections &&\
 RUN echo 'gem: --no-document' >> /usr/local/etc/gemrc &&\
     mkdir /src && cd /src && git clone https://github.com/sstephenson/ruby-build.git &&\
     cd /src/ruby-build && ./install.sh &&\
-    cd / && rm -rf /src/ruby-build && ruby-build 2.0.0-p594 /usr/local &&\
+    cd / && rm -rf /src/ruby-build && ruby-build 2.0.0-p598 /usr/local &&\
     gem update --system &&\
     gem install bundler &&\
     rm -rf /usr/local/share/ri/2.0.0/system &&\


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2014/11/13/rexml-dos-cve-2014-8090/ offers a new approach to the REXML expansion vulnerability.

Ruby 2.0.0-p598 fixes that.

Changelog: http://svn.ruby-lang.org/repos/ruby/tags/v2_0_0_598/ChangeLog
