### PR TITLE
Only use strict transport security for the discourse domain

### DIFF
--- a/templates/web.ssl.template.yml
+++ b/templates/web.ssl.template.yml
@@ -27,8 +27,8 @@ run:
        # enable SPDY header compression
        spdy_headers_comp 6;
 
-       # remember the certificate for a year and automatically connect to HTTPS
-       add_header Strict-Transport-Security 'max-age=31536000; includeSubDomains';
+       # remember the certificate for a year and automatically connect to HTTPS for this domain
+       add_header Strict-Transport-Security 'max-age=31536000';
 
        gzip on;
 


### PR DESCRIPTION
This is a minor fix to have Discourse's SSL configuration to only enforce HSTS for the domain running Discourse.

The header currently bundles `includeSubDomains`, which incorrectly enforces HSTS for any subdomain of the one used by Discourse. If your domain was `meta.discourse.org`, this would include `beta.meta.discourse.org`.

As this luckily does not affect all subdomains of the root domain, this should be considered low priority, as there is likely few users using subdomains of their discourse domain.
