### PR TITLE
setting default gravatar url

### DIFF
--- a/templates/web.china.template.yml
+++ b/templates/web.china.template.yml
@@ -1,3 +1,7 @@
+env:
+  DISCOURSE_GRAVATAR_URL: https://secure.gravatar.com/avatar
+
+
 hooks:
   before_web:
     - exec:

--- a/templates/web.template.yml
+++ b/templates/web.template.yml
@@ -8,6 +8,7 @@ env:
   # this ensures we have enough heap space to handle a big pile of small reqs
   RUBY_HEAP_MIN_SLOTS: 800000
 
+  DISCOURSE_GRAVATAR_URL: http://www.gravatar.com/avatar
   DISCOURSE_DB_SOCKET: /var/run/postgresql
   DISCOURSE_DB_HOST:
   DISCOURSE_DB_PORT:


### PR DESCRIPTION
I don't know whether pup overrides the env in order. It's required to make this work properly. Can you confirm this behaviour?