### PR TITLE
Add quotes around values in the generated discourse.conf file

### DIFF
--- a/templates/web.template.yml
+++ b/templates/web.template.yml
@@ -31,7 +31,7 @@ run:
         conf=/var/www/discourse/config/discourse.conf
 
         # find DISCOURSE_ env vars, strip the leader, lowercase the key
-        /usr/local/bin/ruby -e 'ENV.each{|k,v| puts "#{$1.downcase} = #{v}" if k =~ /^DISCOURSE_(.*)/}' > $conf
+        /usr/local/bin/ruby -e 'ENV.each{|k,v| puts "#{$1.downcase} = \"#{v}\"" if k =~ /^DISCOURSE_(.*)/}' > $conf
 
   - file:
      path: /etc/service/unicorn/run


### PR DESCRIPTION
Previously, if a config value contained a # character, the hash and all the
following values would be treated as a comment. Wrapping all the values with
quotes will allow for hashes, which could be useful in the case of an SMTP
password, for example.