### PR TITLE
* Set default encoding to UTF8, not SQL_ASCII

### DIFF
--- a/templates/postgres.9.2.template.yml
+++ b/templates/postgres.9.2.template.yml
@@ -86,6 +86,11 @@ run:
   - exec: /bin/bash -c 'sudo -u postgres psql discourse <<< "alter schema public owner to discourse;"'
   - exec: /bin/bash -c 'sudo -u postgres psql discourse <<< "create extension if not exists hstore;"'
   - exec: /bin/bash -c 'sudo -u postgres psql discourse <<< "create extension if not exists pg_trgm;"'
+  - exec:
+      stdin: |
+        update pg_database set encoding = pg_char_to_encoding('UTF8') where datname = 'discourse' AND encoding = pg_encoding_to_char('SQL_ASCII');
+      cmd: sudo -u postgres psql discourse
+      raise_on_fail: false
 
   - exec:
       hook: postgres

--- a/templates/postgres.template.yml
+++ b/templates/postgres.template.yml
@@ -182,6 +182,11 @@ run:
   - exec: su postgres -c 'psql template1 -c "create extension if not exists pg_trgm;"'
   - exec: su postgres -c 'psql discourse -c "create extension if not exists hstore;"'
   - exec: su postgres -c 'psql discourse -c "create extension if not exists pg_trgm;"'
+  - exec:
+      stdin: |
+        update pg_database set encoding = pg_char_to_encoding('UTF8') where datname = 'discourse' AND encoding = pg_encoding_to_char('SQL_ASCII');
+      cmd: sudo -u postgres psql discourse
+      raise_on_fail: false
 
   - file:
      path: /var/lib/postgresql/take-database-backup


### PR DESCRIPTION
  This is a cleaned-up patch as suggested by @SamSaffron in #119.