### PR TITLE
templates/web.sssl.template.yml: Disable spdy header compression

### DIFF
--- a/templates/web.ssl.template.yml
+++ b/templates/web.ssl.template.yml
@@ -24,6 +24,7 @@ run:
        ssl_certificate_key /shared/ssl/ssl.key;
 
        ssl_session_tickets off;
+       ssl_session_cache shared:SSL:1m;
 
        # disable SPDY header compression (flawed in spdy < 4)
        spdy_headers_comp 0;

--- a/templates/web.ssl.template.yml
+++ b/templates/web.ssl.template.yml
@@ -25,8 +25,8 @@ run:
 
        ssl_session_tickets off;
 
-       # enable SPDY header compression
-       spdy_headers_comp 6;
+       # disable SPDY header compression (flawed in spdy < 4)
+       spdy_headers_comp 0;
 
        # remember the certificate for a year and automatically connect to HTTPS for this domain
        add_header Strict-Transport-Security 'max-age=31536000';


### PR DESCRIPTION
As explained here:

https://github.com/18F/tls-standards/issues/24

We shouldn't use spdy header compression with spdy 1.3 (the one packaged with nginx).So, just disable it.