### PR TITLE
Revert templates/web.sssl.template.yml: Disable spdy header compression

### DIFF
--- a/templates/web.ssl.template.yml
+++ b/templates/web.ssl.template.yml
@@ -26,8 +26,10 @@ run:
        ssl_session_tickets off;
        ssl_session_cache shared:SSL:1m;
 
-       # disable SPDY header compression (flawed in spdy < 4)
-       spdy_headers_comp 0;
+       # enable SPDY header compression
+       # The server CAN enable it without any known security risk:
+       # https://github.com/18F/tls-standards/issues/24
+       spdy_headers_comp 6;
 
        # remember the certificate for a year and automatically connect to HTTPS for this domain
        add_header Strict-Transport-Security 'max-age=31536000';


### PR DESCRIPTION
This reverts commit c0ed494c3acf1acf629379f33f413d7660183855. It was late and I
misread the info here:

	https://github.com/18F/tls-standards/issues/24

The first comment clearly states that the server *can* compress spdy header. And
modern browsers disable compression on responses (or chrome, maybe smarter
tricks in newer versions). In fact, Chrome 21 and Firefox 15 switched off SPDY
header compression[1] and the requirements page on discourse:

	https://github.com/discourse/discourse#requirements

are newer browsers than that. So it seems safe to enable spdy header
compression on the server.

[1]: https://www.imperialviolet.org/2012/09/21/crime.html