### PR TITLE
Improve documentation of ssh launcher command

### DIFF
--- a/launcher
+++ b/launcher
@@ -44,7 +44,7 @@ usage () {
   echo "    restart:    Restart a container"
   echo "    destroy:    Stop and remove a container"
   echo "    enter:      Use nsenter to enter a container"
-  echo "    ssh:        Start a bash shell in a running container"
+  echo "    ssh:        Start bash in a container (need ssh keys when building)"
   echo "    logs:       Docker logs for container"
   echo "    mailtest:   Test the mail settings in a container"
   echo "    bootstrap:  Bootstrap a container for the config based on a template"


### PR DESCRIPTION
The access via ssh is only granted if the user building (or rebuilding) has a
ssh key. So, make that clear in the "documentation" for that command.