### PR TITLE
Fix rails wrapper's arguments expansion problem.

### DIFF
--- a/templates/web.template.yml
+++ b/templates/web.template.yml
@@ -149,7 +149,7 @@ run:
      contents: |
        #!/bin/bash
        # If they requested a console, load pry instead
-       if [ "$@" == "c" -o "$@" == "console" ]
+       if [ "$*" == "c" -o "$*" == "console" ]
        then
         (cd /var/www/discourse && RAILS_ENV=production sudo -H -E -u discourse bundle exec pry -r ./config/environment)
        else


### PR DESCRIPTION
"$@" expands to multiple words, and breaks `[` if there are multiple
arguments. Use "$*" == "console" instead, since this expands all the
arguments to a single word, which is what we want instead.

Fixes #153 