### PR TITLE
Added config name check to prevent docker name errors after build.

### DIFF
--- a/launcher
+++ b/launcher
@@ -4,6 +4,16 @@ command=$1
 config=$2
 opt=$3
 
+# Docker doesn't like uppercase characters, spaces or special characters, catch it now before we build everything out and then find out
+re='[A-Z/ !@#$%^&*()+~`=]'
+if [[ $config =~ $re ]];
+  then
+    echo 
+    echo "ERROR: Config name must not contain upper case characters, spaces or special characters. Correct config name and rerun $0."
+    echo
+    exit 1
+fi
+
 cd "$(dirname "$0")"
 
 docker_min_version='1.2.0'


### PR DESCRIPTION
It's better to fail early on bad docker names instead of waiting for a build to complete before knowing you've entered a bad docker name.