### PR TITLE
Detect and use the DOCKER_HOST environment variable

### DIFF
--- a/launcher
+++ b/launcher
@@ -33,7 +33,9 @@ else
   attach_on_run="-d"
 fi
 
-if [ -x "$(which ip 2>/dev/null)" ]; then
+if [ -n "$DOCKER_HOST" ]; then
+  docker_ip=`sed -e 's/^tcp:\/\/\(.*\):.*$/\1/' <<< "$DOCKER_HOST"`
+elif [ -x "$(which ip 2>/dev/null)" ]; then
   docker_ip=`ip addr show docker0 | \
                   grep 'inet ' | \
                   awk '{ split($2,a,"/"); print a[1] }';`


### PR DESCRIPTION
Hi,

I wrote this patch while experimenting with deploying Discourse using [Docker Machine](https://docs.docker.com/machine/). I was trying to use `DOCKER_HOST_IP` for `DISCOURSE_REDIS_HOST`, but running `./launcher` I saw the message “`Device "docker0" does not exist.`” and `DOCKER_HOST_IP` was set to the empty string. This patch leverages `DOCKER_HOST` in order to set the correct `DOCKER_HOST_IP` inside the containers.

Never mind the fact that once `DOCKER_HOST` is set correctly, I was still not able to use it for `DISCOURSE_REDIS_HOST` during bootstrap. The correct way to do it is to use the [links section in container configuration](https://meta.discourse.org/t/how-to-use-docker-multiple-containers-without-exposing-ports/22283). Would you still find this patch useful nonetheless, just for completeness’ sake?

Yours,
Amir