### PR TITLE
Fix #168: handle empty command gracefully

### DIFF
--- a/launcher
+++ b/launcher
@@ -310,7 +310,7 @@ RUBY
   install_docker
 }
 
-[ $command == "cleanup" ] && {
+[ "$command" == "cleanup" ] && {
   echo
   echo "The following command will"
   echo "- Delete all docker images for old containers"


### PR DESCRIPTION
I verified this fixes the issue by running `./launcher` without arguments.