### PR TITLE
Removing the mailtest command from the launcher reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ Commands:
     enter:      Use nsenter to enter a container
     ssh:        Start a bash shell in a running container
     logs:       Docker logs for container
-    mailtest:   Test the mail settings in a container
     bootstrap:  Bootstrap a container for the config based on a template
     rebuild:    Rebuild a container (destroy old, bootstrap, start new)
 ```


### PR DESCRIPTION
The mailtest command was removed in [579ce85](https://github.com/discourse/discourse_docker/commit/579ce85d19f1b95151126957988122feb6cbbd8b)., should be removed from the `launcher` reference in the README.md file