### PR TITLE
Test that we have enough memory and diskspace before installing

### DIFF
--- a/launcher
+++ b/launcher
@@ -151,6 +151,33 @@ prereqs() {
     echo "See: https://meta.discourse.org/t/docker-error-on-bootstrap/13657/18?u=sam"
     exit 1
   fi
+
+  # 6. sufficient available resources
+  # 6a. Memory
+  free_mem="$(LANG=C free -m | grep 'buffers/cache' | awk '{print $4}')"
+  if [ "$free_mem" -lt 800 ]; then
+    echo "You do not appear to have sufficient memory to run Discourse."
+    echo
+    echo "See https://github.com/discourse/discourse/blob/master/docs/INSTALL-cloud.md#create-new-cloud-server"
+    exit 1
+  elif [ "$free_mem" -lt 1800 ]; then
+    total_swap="$(LANG=C free -m | grep ^Swap: | awk '{print $2}')"
+    if [ "$total_swap" -lt 1000 ]; then
+      echo "You must have at least 1GB of swap when running in a low-memory environment."
+      echo
+      echo "See https://github.com/discourse/discourse/blob/master/docs/INSTALL-cloud.md#set-up-swap-if-needed"
+      exit 1
+    fi
+  fi
+
+  # 6b. Disk space
+  free_disk="$(df /var | tail -n 1 | awk '{print $4}')"
+  if [ "$free_disk" -lt 5000 ]; then
+    echo "You must have at least 5GB of *free* disk space to install Discourse."
+    echo
+    echo "Please free up some space, or expand your disk, before continuing."
+    exit 1
+  fi
 }
 
 if [ "$opt" != "--skip-prereqs" ] ; then


### PR DESCRIPTION
The minimum specs for a Discourse server are a standalone machine with 1GB
of memory + 1GB swap, or 2GB of memory.  To try and catch anyone who's doing
this on a larger machine with lots of other stuff going on, I've checked
"available" memory (used memory minus disk cache) rather than total memory.