### PR TITLE
Add a basic Vagrantfile for local testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,23 @@ installs you can ensure they are in sync by looking at `/etc/passwd` and
 - [Linking containers for a multiple container setup](https://meta.discourse.org/t/linking-containers-for-a-multiple-container-setup/20867)
 - [Replace rubygems.org with taobao mirror to resolve network error in China](https://meta.discourse.org/t/replace-rubygems-org-with-taobao-mirror-to-resolve-network-error-in-china/21988/1)
 
+### Developing with Vagrant
+
+If you are looking to make modifications to this repository, you can easily test
+out your changes before committing, using the magic of
+[Vagrant](http://vagrantup.com).  Install Vagrant as per [the default
+instructions](http://docs.vagrantup.com/v2/installation/index.html), and
+then run:
+
+    vagrant up
+
+This will spawn a new Ubuntu VM, install Docker, and then await your
+instructions.  You can then SSH into the VM with `vagrant ssh`, become
+`root` with `sudo -i`, and then you're right to go.  Your live git repo is
+already available at `/var/discourse`, so you can just `cd /var/discourse`
+and then start running `launcher`.
+
+
 License
 ===
 MIT

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,4 +1,8 @@
 Vagrant.configure(2) do |config|
+  config.vm.provider "virtualbox" do |v|
+    v.memory = 2048
+  end
+
   config.vm.define :dockerhost do |config|
     config.vm.box = "trusty64"
     config.vm.box_url = "http://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,5 +1,5 @@
 Vagrant.configure(2) do |config|
-  config.vm.define :ubuntu do |config|
+  config.vm.define :dockerhost do |config|
     config.vm.box = "trusty64"
     config.vm.box_url = "http://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
 
@@ -15,13 +15,14 @@ Vagrant.configure(2) do |config|
       apt-get update
       apt-get -y remove --purge puppet juju
       apt-get -y autoremove --purge
+      wget -qO- https://get.docker.com/ | sh
     EOF
-  end
 
-  if ENV["http_proxy"]
-    config.vm.provision "shell", inline: <<-EOF
-      echo "Acquire::http::Proxy \\"#{ENV['http_proxy']}\\";" >/etc/apt/apt.conf.d/50proxy
-      echo "http_proxy=\"#{ENV['http_proxy']}\"" >/etc/profile.d/http_proxy.sh
-    EOF
+    if ENV["http_proxy"]
+      config.vm.provision "shell", inline: <<-EOF
+        echo "Acquire::http::Proxy \\"#{ENV['http_proxy']}\\";" >/etc/apt/apt.conf.d/50proxy
+        echo "http_proxy=\"#{ENV['http_proxy']}\"" >/etc/profile.d/http_proxy.sh
+      EOF
+    end
   end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,6 +20,8 @@ Vagrant.configure(2) do |config|
       apt-get -y remove --purge puppet juju
       apt-get -y autoremove --purge
       wget -qO- https://get.docker.com/ | sh
+
+      ln -s /vagrant /var/discourse
     EOF
 
     if ENV["http_proxy"]

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,27 @@
+Vagrant.configure(2) do |config|
+  config.vm.define :ubuntu do |config|
+    config.vm.box = "trusty64"
+    config.vm.box_url = "http://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
+
+    config.vm.provision "shell", inline: <<-EOF
+      set -e
+
+      export DEBIAN_FRONTEND=noninteractive
+
+      echo "en_US.UTF-8 UTF-8" >/etc/locale.gen
+      locale-gen
+      echo "Apt::Install-Recommends 'false';" >/etc/apt/apt.conf.d/02no-recommends
+      echo "Acquire::Languages { 'none' };" >/etc/apt/apt.conf.d/05no-languages
+      apt-get update
+      apt-get -y remove --purge puppet juju
+      apt-get -y autoremove --purge
+    EOF
+  end
+
+  if ENV["http_proxy"]
+    config.vm.provision "shell", inline: <<-EOF
+      echo "Acquire::http::Proxy \\"#{ENV['http_proxy']}\\";" >/etc/apt/apt.conf.d/50proxy
+      echo "http_proxy=\"#{ENV['http_proxy']}\"" >/etc/profile.d/http_proxy.sh
+    EOF
+  end
+end


### PR DESCRIPTION
It comes in handy when you want to poke around with things; anyone who
tries to use this for production-like deployments should be gently but
firmly dissuaded.