### PR TITLE
Fix memory check to not account for 'free' memory

### DIFF
--- a/launcher
+++ b/launcher
@@ -155,25 +155,21 @@ prereqs() {
   # 6. sufficient available resources
   # 6a. Memory
   #
-  # This was disable cause we always need to minus the memory of running containers from
-  # this total, this is fairly hard to do without docker stat and in particular some patches
-  # to it.
-  #
-  # free_mem="$(LANG=C free -m | grep 'buffers/cache' | awk '{print $4}')"
-  # if [ "$free_mem" -lt 800 ]; then
-  #   echo "You do not appear to have sufficient memory to run Discourse."
-  #   echo
-  #   echo "See https://github.com/discourse/discourse/blob/master/docs/INSTALL-cloud.md#create-new-cloud-server"
-  #   exit 1
-  # elif [ "$free_mem" -lt 1800 ]; then
-  #   total_swap="$(LANG=C free -m | grep ^Swap: | awk '{print $2}')"
-  #   if [ "$total_swap" -lt 1000 ]; then
-  #     echo "You must have at least 1GB of swap when running in a low-memory environment."
-  #     echo
-  #     echo "See https://github.com/discourse/discourse/blob/master/docs/INSTALL-cloud.md#set-up-swap-if-needed"
-  #     exit 1
-  #   fi
-  # fi
+  avail_mem="$(LANG=C free -m | grep '^Mem:' | awk '{print $2}')"
+  if [ "$avail_mem" -lt 1000 ]; then
+    echo "You do not appear to have sufficient memory to run Discourse."
+    echo
+    echo "See https://github.com/discourse/discourse/blob/master/docs/INSTALL-cloud.md#create-new-cloud-server"
+    exit 1
+  elif [ "$avail_mem" -lt 2000 ]; then
+    total_swap="$(LANG=C free -m | grep ^Swap: | awk '{print $2}')"
+    if [ "$total_swap" -lt 1000 ]; then
+      echo "You must have at least 1GB of swap when running with less than 2GB of RAM."
+      echo
+      echo "See https://github.com/discourse/discourse/blob/master/docs/INSTALL-cloud.md#set-up-swap-if-needed"
+      exit 1
+    fi
+  fi
 
   # 6b. Disk space
   free_disk="$(df /var | tail -n 1 | awk '{print $4}')"

--- a/launcher
+++ b/launcher
@@ -155,29 +155,46 @@ prereqs() {
   # 6. sufficient available resources
   # 6a. Memory
   #
+  resources="ok"
   avail_mem="$(LANG=C free -m | grep '^Mem:' | awk '{print $2}')"
-  if [ "$avail_mem" -lt 1000 ]; then
-    echo "You do not appear to have sufficient memory to run Discourse."
+  if [ "$avail_mem" -lt 900 ]; then
+    resources="insufficient"
+    echo "WARNING: You do not appear to have sufficient memory to run Discourse."
+    echo
+    echo "Your system may not work properly, or future upgrades of Discourse may"
+    echo "not complete successfully."
     echo
     echo "See https://github.com/discourse/discourse/blob/master/docs/INSTALL-cloud.md#create-new-cloud-server"
-    exit 1
-  elif [ "$avail_mem" -lt 2000 ]; then
+  elif [ "$avail_mem" -lt 1800 ]; then
+    resources="insufficient"
     total_swap="$(LANG=C free -m | grep ^Swap: | awk '{print $2}')"
     if [ "$total_swap" -lt 1000 ]; then
-      echo "You must have at least 1GB of swap when running with less than 2GB of RAM."
+      echo "WARNING: You must have at least 1GB of swap when running with less"
+      echo "than 2GB of RAM."
+      echo
+      echo "Your system may not work properly, or future upgrades of Discourse may"
+      echo "not complete successfully."
       echo
       echo "See https://github.com/discourse/discourse/blob/master/docs/INSTALL-cloud.md#set-up-swap-if-needed"
-      exit 1
     fi
   fi
 
   # 6b. Disk space
   free_disk="$(df /var | tail -n 1 | awk '{print $4}')"
   if [ "$free_disk" -lt 5000 ]; then
-    echo "You must have at least 5GB of *free* disk space to install Discourse."
+    resources="insufficient"
+    echo "WARNING: You must have at least 5GB of *free* disk space to run Discourse."
+    echo
+    echo "Insufficient disk space may result in problems running your site, and may"
+    echo "not even allow Discourse installation to complete successfully."
     echo
     echo "Please free up some space, or expand your disk, before continuing."
     exit 1
+  fi
+
+  if [ -t 0 ] && [ "$resources" != "ok" ]; then
+    echo
+    read -p "Press ENTER to continue, or Ctrl-C to exit and give your system more resources"
   fi
 }
 


### PR DESCRIPTION
Previous, 'clever' check didn't take into account the possibility
of Discourse already running.