### PR TITLE
Enclose sample smtp password in quotes

### DIFF
--- a/samples/standalone.yml
+++ b/samples/standalone.yml
@@ -63,7 +63,7 @@ env:
   DISCOURSE_SMTP_ADDRESS: smtp.example.com         # (mandatory)
   #DISCOURSE_SMTP_PORT: 587                        # (optional)
   #DISCOURSE_SMTP_USER_NAME: user@example.com      # (optional)
-  #DISCOURSE_SMTP_PASSWORD: pa$$word               # (optional, WARNING the char '#' in pw can cause problems!)
+  #DISCOURSE_SMTP_PASSWORD: "pa$$wo#rd"            # (optional, enclosed in quotes)
   #DISCOURSE_SMTP_ENABLE_START_TLS: true           # (optional, default true)
 
   ## The CDN address for this Discourse instance (configured to pull)


### PR DESCRIPTION
This tells the YML parser to ignore special characters (other than `\` and `"`) inside the quotes.