### PR TITLE
Trust the real_ip header sent form socket connections

### DIFF
--- a/templates/web.socketed.template.yml
+++ b/templates/web.socketed.template.yml
@@ -16,8 +16,10 @@ run:
      from: /listen 80;/
      to: |
        listen unix:/shared/nginx.http.sock;
+       set_real_ip_from unix:;
   - replace:
      filename: "/etc/nginx/conf.d/discourse.conf"
      from: /listen 443 ssl spdy;/
      to: |
        listen unix:/shared/nginx.https.sock ssl spdy;
+       set_real_ip_from unix:;


### PR DESCRIPTION
If sockets are being used, trust the `real_ip` header sent form connections to it by default, otherwise all the connections come from the IP `unix` :smile: 