### PR TITLE
Add switch to override the default Docker hostname (fixes #193)

### DIFF
--- a/launcher
+++ b/launcher
@@ -502,10 +502,28 @@ run_start(){
    set_run_image
    set_boot_command
 
+   # get hostname and settings from container configuration
+   for envar in "${env[@]}"
+   do
+     if [[ $envar == DOCKER_USE_HOSTNAME* ]] || [[ $envar == DISCOURSE_HOSTNAME* ]]
+     then
+       # use as environment variable
+       eval $envar
+     fi
+   done
+
    (
      hostname=`hostname`
+     # overwrite hostname
+     if [ "$DOCKER_USE_HOSTNAME" = "true" ]
+     then
+       hostname=$DISCOURSE_HOSTNAME
+     else
+       hostname=$hostname-$config
+     fi
+
      set -x
-     $docker_path run $user_args $links $attach_on_run $restart_policy "${env[@]}" -h "$hostname-$config" \
+     $docker_path run $user_args $links $attach_on_run $restart_policy "${env[@]}" -h "$hostname" \
         -e DOCKER_HOST_IP=$docker_ip --name $config -t $ports $volumes $docker_args $run_image $boot_command
 
    )

--- a/samples/standalone.yml
+++ b/samples/standalone.yml
@@ -64,6 +64,10 @@ env:
 
   ## TODO: The domain name this Discourse instance will respond to
   DISCOURSE_HOSTNAME: 'discourse.example.com'
+  ## TODO: Uncomment if you want the container to be started with the same
+  ##       hostname (-h option) as specified above (default "$hostname-$config")
+  ## NOTE: 'true' is the only valid value here, any other will be ignored
+  #DOCKER_USE_HOSTNAME: true
 
   ## TODO: The mailserver this Discourse instance will use
   DISCOURSE_SMTP_ADDRESS: smtp.example.com         # (mandatory)

--- a/samples/web_only.yml
+++ b/samples/web_only.yml
@@ -42,6 +42,10 @@ env:
   ##
   ## TODO: The domain name this Discourse instance will respond to
   DISCOURSE_HOSTNAME: 'discourse.example.com'
+  ## TODO: Uncomment if you want the container to be started with the same
+  ##       hostname (-h option) as specified above (default "$hostname-$config")
+  ## NOTE: 'true' is the only valid value here, any other will be ignored
+  #DOCKER_USE_HOSTNAME: true
   ##
   ## TODO: The mailserver this Discourse instance will use
   DISCOURSE_SMTP_ADDRESS: smtp.example.com         # (mandatory)


### PR DESCRIPTION
A new (optional) ENV var was added to the templates that instructs the `launcher` script to use the DISCOURSE_HOSTNAME as the Docker hostname (via the -h/--hostname option) instead of the default value of `$hostname-$config`.

Successfully tested with `DOCKER_USE_HOSTNAME: true` and with the env variable commented out.

See #193.