### PR TITLE
Install pngcrush 1.7.87 instead of 1.7.85

### DIFF
--- a/image/base/install-pngcrush
+++ b/image/base/install-pngcrush
@@ -1,5 +1,5 @@
 #!/bin/bash
-PNGCRUSH_VERSION=1.7.85
+PNGCRUSH_VERSION=1.7.87
 cd /tmp
 curl -O http://iweb.dl.sourceforge.net/project/pmt/pngcrush/$PNGCRUSH_VERSION/pngcrush-$PNGCRUSH_VERSION.tar.gz
 tar zxf pngcrush-$PNGCRUSH_VERSION.tar.gz


### PR DESCRIPTION
pngcrush 1.7.85 isn't downloadable anymore

According to http://sourceforge.net/projects/pmt/files/pngcrush/
only two versions are directly available: the released 1.7.87 and up-to-come 1.7.88.

**Upstream changelog**

pngcrush-1.7.87 fixes a double-free bug in the sPLT chunk handling