### PR TITLE
Avoid empty directory /var/www/discourse/plugins/plugins

### DIFF
--- a/samples/standalone.yml
+++ b/samples/standalone.yml
@@ -86,7 +86,6 @@ hooks:
     - exec:
         cd: $home/plugins
         cmd:
-          - mkdir -p plugins
           - git clone https://github.com/discourse/docker_manager.git
 
 ## Remember, this is YAML syntax - you can only have one block with a name

--- a/samples/web_only.yml
+++ b/samples/web_only.yml
@@ -68,7 +68,6 @@ hooks:
     - exec:
         cd: $home/plugins
         cmd:
-          - mkdir -p plugins
           - git clone https://github.com/discourse/docker_manager.git
 
 ## Remember, this is YAML syntax - you can only have one block with a name


### PR DESCRIPTION
Currently, the standalone and web configuration samples offer to create a plugins directory.

As the working directory at this moment is $home/plugins, this create a plugins/plugins empty directory.

Furthermore, as Discourse is shipped with two default plugins, the folder already exists.