### PR TITLE
Replace SPDY directives with HTTP/2

### DIFF
--- a/templates/web.ssl.template.yml
+++ b/templates/web.ssl.template.yml
@@ -17,8 +17,7 @@ run:
      filename: "/etc/nginx/conf.d/discourse.conf"
      from: /listen 80;\s+gzip on;/m
      to: |
-       listen 443 ssl spdy;
-       spdy_keepalive_timeout 300; # up from 180 secs default
+       listen 443 ssl http2;
        ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
        # courtesy of https://wiki.mozilla.org/Security/Server_Side_TLS#Recommended_configurations
        ssl_ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA;
@@ -29,12 +28,8 @@ run:
        ssl_dhparam /shared/ssl/dhparams.pem;
 
        ssl_session_tickets off;
+       ssl_session_timeout 1d;
        ssl_session_cache shared:SSL:1m;
-
-       # enable SPDY header compression
-       # The server CAN enable it without any known security risk:
-       # https://github.com/18F/tls-standards/issues/24
-       spdy_headers_comp 6;
 
        # remember the certificate for a year and automatically connect to HTTPS for this domain
        add_header Strict-Transport-Security 'max-age=31536000';


### PR DESCRIPTION
The upstream image we build from is using a newer, mainline build of Nginx, which no longer supports SPDY. Support for HTTP/2 has been added however, and this PR updates the configuration to reflect this change.

Tested and working on https://discourse.farsetlabs.org.uk/