### PR TITLE
Add template for phpBB3 importer

### DIFF
--- a/templates/import/phpbb3.template.yml
+++ b/templates/import/phpbb3.template.yml
@@ -1,0 +1,116 @@
+# This template installs MariaDB and all dependencies needed for importing from phpBB3.
+
+params:
+  home: /var/www/discourse
+
+hooks:
+  after_web_config:
+    - exec:
+        cd: /etc/service
+        cmd:
+          - rm -R unicorn
+          - rm -R nginx
+          - rm -R cron
+
+    - exec:
+        cd: /etc/runit/3.d
+        cmd:
+          - rm 01-nginx
+          - rm 02-unicorn
+
+    - file:
+        path: /etc/apt/sources.list.d/mariadb.list
+        contents: |
+          # MariaDB 10.1 repository list
+          # http://mariadb.org/mariadb/repositories/
+          deb [arch=amd64,i386] http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.1/ubuntu trusty main
+          deb-src http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.1/ubuntu trusty main
+
+    - file:
+        path: /etc/apt/preferences.d/mariadb
+        contents: |
+          Package: *
+          Pin: release o=MariaDB
+          Pin-Priority: 1000
+
+    - file:
+        path: /etc/mysql/conf.d/import.cnf
+        contents: |
+          [mysqld]
+          # disable InnoDB since it is extremly slow in Docker container
+          default-storage-engine=MyISAM
+          default-tmp-storage-engine=MyISAM
+          innodb=OFF
+
+          datadir=/shared/import/mysql/data
+
+          skip-host-cache
+          skip-name-resolve
+
+    - exec:
+        cmd:
+          - mkdir -p /shared/import/mysql/data
+          - apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xcbcb082a1bb943db
+          - apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y nano libmariadbclient-dev mariadb-server
+          - sed -Ei 's/^log/#&/' /etc/mysql/my.cnf
+
+    - file:
+        path: /etc/service/mysql/run
+        chmod: "+x"
+        contents: |
+          #!/bin/bash
+          # Make sure the datadir exists, is accessible and contains all system tables
+          mkdir -p /shared/import/mysql/data
+          chown mysql -R /shared/import/mysql/data
+          /usr/bin/mysql_install_db --user=mysql
+
+          # Shamelessly copied from http://smarden.org/runit1/runscripts.html#mysql
+          exec 2>&1
+          exec /usr/sbin/mysqld -u mysql
+
+    - file:
+        path: /etc/runit/3.d/99-mysql
+        chmod: "+x"
+        contents: |
+          #!/bin/bash
+          sv stop mysql
+
+    - file:
+        path: /usr/local/bin/import_phpbb3.sh
+        chmod: "+x"
+        contents: |
+          #!/bin/bash
+          chown discourse /shared/import/settings.yml
+          chown discourse -R /shared/import/data
+
+          if [ -f "/shared/import/data/phpbb_mysql.sql" ]; then
+            if [ ! -f "/shared/import/mysql/imported" ]; then
+              echo "Loading database dump into MySQL..."
+              mysql -uroot -e "DROP DATABASE IF EXISTS phpbb"
+              mysql -uroot -e "CREATE DATABASE phpbb"
+              mysql -uroot --default-character-set=utf8 --database=phpbb < /shared/import/data/phpbb_mysql.sql
+              touch /shared/import/mysql/imported
+            fi
+          else
+            sv stop mysql
+          fi
+
+          cd $home
+          echo "The phpBB3 import is starting..."
+          echo
+          su discourse -c 'bundle exec ruby script/import_scripts/phpbb3.rb /shared/import/settings.yml'
+
+    - exec:
+        cd: $home
+        cmd:
+          - mkdir -p /shared/import/data
+          - chown discourse -R /shared/import
+          - cp -n script/import_scripts/phpbb3/settings.yml /shared/import/settings.yml
+
+  after_bundle_exec:
+    - exec:
+        cd: $home
+        cmd:
+          - echo "gem 'mysql2'" >> Gemfile
+          - echo "gem 'ruby-bbcode-to-md', :github => 'nlalonde/ruby-bbcode-to-md'" >> Gemfile
+          - su discourse -c 'bundle install --no-deployment --without test --without development --path vendor/bundle'


### PR DESCRIPTION
This adds a template for easier imports from phpBB3.

What's it doing?

- Disables services that aren't needed during the import (unicron, nginx, cron)
- Installs MariaDB 10.1, disables InnoDB and moves the `datadir` to `/shared/import/mysql/data`
- Installs all needed gems
- Adds a bash script that optionally imports a database dump into MariaDB and starts the import process

I'll update the [Howto on meta](https://meta.discourse.org/t/importing-from-phpbb3/30810) soon. In the meantime here's a short description of how it works:

1. Copy the `app.yml` to `import.yml` and add `"templates/import/phpbb3.template.yml"` to the list of templates
2. Stop Discourse if it is running: `./launcher stop app`
3. Start the import container: `./launcher rebuild import`
4. Configure the importer by editing `/shared/standalone/import/settings.yml`
  - You don't need to change the database settings if you want to use the internal MariaDB
  - Make sure the `phpbb_base_dir` points to `/shared/import/data`
5. _Optional_: Copy the `files` and `images` directories from your phpBB3 installation directory into `/var/discourse/shared/standalone/import/data` if you want to import attachments or avatars and custom smilies
6. _Optional_: Copy your MySQL database dump to `/var/discourse/shared/standalone/import/data/phpbb_mysql.sql` if you want to use the internal database
7. Enter the Docker container: `./launcher enter import`
8. Start the import by executing `import_phpbb3.sh`
9. Wait until the import finishes.
10. Exit the Docker container (`exit` :wink:) when the import has finished.
11. Stop the import container: `./launcher stop import`
12. Start the app container: `./launcher start app`
13. Discourse will start and Sidekiq will start postprocessing all the imported posts. This can take a considerate amount of time. You can watch the progress by logging in as admin and visiting `http://discourse.example.com/sidekiq`