### PR TITLE
default the lets encrypt directory to the standalone setup

### DIFF
--- a/templates/web.letsencrypt.ssl.template.yml
+++ b/templates/web.letsencrypt.ssl.template.yml
@@ -1,5 +1,5 @@
 env:
-  LETSENCRYPT_DIR: "/shared/letsencrypt"
+  LETSENCRYPT_DIR: "/shared/standalone/letsencrypt"
 
 run:
   - exec:


### PR DESCRIPTION
mentioned this briefly [here](https://meta.discourse.org/t/support-for-lets-encrypt/22308/51?u=renan) on the meta discourse.

This changes the default setup assumed in the lets encrypt template. The previous configuration assumed that a user setting up letsencrypt uses a multi-container setup. However, we should push new users (who start with the standalone setup) to use SSL/HTTPS more often, easier.

Also I'd like to bring up either 
1. An update to the SSL tutorial to make it easier to set up encryption freely. 
or maybe in the future:
2. SSL on by default on a new standalone docker installation using lets encrypt.

what do we think? too much information shared with lets encrypt?