### PR TITLE
FEATURE: change login directory to discourse home when enter a container

### DIFF
--- a/launcher
+++ b/launcher
@@ -576,7 +576,7 @@ case "$command" in
       ;;
 
   enter)
-      exec $docker_path exec -it $config /bin/bash
+      exec $docker_path exec -it $config /bin/bash --login
       ;;
 
   ssh)

--- a/templates/web.template.yml
+++ b/templates/web.template.yml
@@ -247,3 +247,10 @@ run:
           mkdir -p /shared/backups
           chown -R discourse:www-data /shared/backups
         fi
+
+  # change login directory to Discourse home
+  - file:
+     path: /root/.bash_profile
+     chmod: 644
+     contents: |
+        cd $home


### PR DESCRIPTION
Although rails commands automatically exposed in the environment in a container, it's easier to manipulate files, e.g. I update my plugins (no client assets) to minimize rebuild time.
I think it's better to point the user to the `/.

If chosen `.bach_profile`, an interactive bash is needed.