### PR TITLE
Template for serving through an .onion address.

### DIFF
--- a/templates/web.onion.template.yml
+++ b/templates/web.onion.template.yml
@@ -1,0 +1,49 @@
+# Adds another server on port 80 for hidden service hosting
+
+run:
+  - exec:
+      cmd:
+        # Check DISCOURSE_ONION variable has been configured
+        - if [ -z "$DISCOURSE_ONION" ]; then echo "DISCOURSE_ONION ENV variable is required and has not been set."; exit 1; fi
+
+  - exec:
+      cmd:
+        # Copy default nginx file
+        - "cp $home/config/nginx.sample.conf /etc/nginx/conf.d/onion.conf"
+
+  # Remove duplicate entries that would crash the server
+  - replace:
+      filename: "/etc/nginx/conf.d/onion.conf"
+      from: /upstream[^\}]+\}/m
+      to: ""
+
+  - replace:
+      filename: "/etc/nginx/conf.d/onion.conf"
+      from: /map[^\}]+\}/m
+      to: ""
+
+  - replace:
+      filename: "/etc/nginx/conf.d/onion.conf"
+      from: /types[^\}]+\}/m
+      to: ""
+
+  - replace:
+      filename: "/etc/nginx/conf.d/onion.conf"
+      from: /proxy_cache_path.*$/
+      to: ""
+
+  - replace:
+      filename: "/etc/nginx/conf.d/onion.conf"
+      from: /log_format.*$/
+      to: ""
+
+  - replace:
+      filename: "/etc/nginx/conf.d/onion.conf"
+      from: /server_name.+$/
+      to: server_name $$ENV_DISCOURSE_ONION;
+
+  # Apply the same replacements done on web.template.yml to the nginx file
+  - replace:
+      filename: "/etc/nginx/conf.d/onion.conf"
+      from: /client_max_body_size.+$/
+      to: client_max_body_size $upload_size ;


### PR DESCRIPTION
Thread on meta.discourse.org:
https://meta.discourse.org/t/template-for-serving-through-an-onion-address-with-docker

It creates a new `onion.conf` file in the nginx config folder. The new `onion.conf` is created by copying `nginx.sample.conf` and editing that copy.

This new config file creates another site on nginx's port 80, that listens to requests made to the specified .onion address.

The template checks that a `DISCOURSE_ONION` ENV variable is defined.