### PR TITLE
Lets Encrypt Should Become Default

### DIFF
--- a/samples/standalone.yml
+++ b/samples/standalone.yml
@@ -17,11 +17,14 @@ templates:
   - "templates/postgres.template.yml"
   - "templates/redis.template.yml"
   - "templates/web.template.yml"
+  - "templates/web.ssl.template.yml"
+  - "templates/web.letsencrypt.ssl.template.yml"
   - "templates/web.ratelimited.template.yml"
 
 ## which TCP/IP ports should this container expose?
 expose:
   - "80:80"   # fwd host port 80   to container port 80 (http)
+  - "443:443" # fwd host port 443   to container port 443 (https)
 # If you want Discourse to share a port with another webserver like Apache or nginx,
 # see https://meta.discourse.org/t/17247 for instructions.
 
@@ -66,6 +69,9 @@ env:
   #DISCOURSE_SMTP_USER_NAME: user@example.com      # (optional)
   #DISCOURSE_SMTP_PASSWORD: pa$$word               # (optional, WARNING the char '#' in pw can cause problems!)
   #DISCOURSE_SMTP_ENABLE_START_TLS: true           # (optional, default true)
+  
+  ## The Lets Encrypt email will aloow you to register a FREE SSL certificate
+  LETSENCRYPT_ACCOUNT_EMAIL: email@awesomedomain.com
 
   ## The CDN address for this Discourse instance (configured to pull)
   #DISCOURSE_CDN_URL: //discourse-cdn.example.com

--- a/samples/standalone.yml
+++ b/samples/standalone.yml
@@ -26,7 +26,7 @@ templates:
 ## which TCP/IP ports should this container expose?
 expose:
   - "80:80"   # fwd host port 80   to container port 80 (http)
-  - "443:443" # fwd host port 443   to container port 443 (https)
+  - "443:443" # fwd host port 443   to container port 443 (https) (ssl ready)
 # If you want Discourse to share a port with another webserver like Apache or nginx,
 # see https://meta.discourse.org/t/17247 for instructions.
 

--- a/samples/standalone.yml
+++ b/samples/standalone.yml
@@ -17,9 +17,11 @@ templates:
   - "templates/postgres.template.yml"
   - "templates/redis.template.yml"
   - "templates/web.template.yml"
-  - "templates/web.ssl.template.yml"
-  - "templates/web.letsencrypt.ssl.template.yml"
   - "templates/web.ratelimited.template.yml"
+
+ ## Comment out the following lines if you wish to add Lets Encrypt for your Discourse install
+ # - "templates/web.ssl.template.yml"
+ # - "templates/web.letsencrypt.ssl.template.yml"
 
 ## which TCP/IP ports should this container expose?
 expose:
@@ -70,8 +72,8 @@ env:
   #DISCOURSE_SMTP_PASSWORD: pa$$word               # (optional, WARNING the char '#' in pw can cause problems!)
   #DISCOURSE_SMTP_ENABLE_START_TLS: true           # (optional, default true)
   
-  ## The Lets Encrypt email will aloow you to register a FREE SSL certificate
-  LETSENCRYPT_ACCOUNT_EMAIL: email@awesomedomain.com
+  ## The Lets Encrypt email will allow you to register a FREE SSL certificate if you added the Lets Encrypt template, comment it out if you have set this up
+  # LETSENCRYPT_ACCOUNT_EMAIL: email@awesomedomain.com
 
   ## The CDN address for this Discourse instance (configured to pull)
   #DISCOURSE_CDN_URL: //discourse-cdn.example.com


### PR DESCRIPTION
Lets make Discourse have Lets Encrypt by default.