### PR TITLE
Inform the user that they can --skip-prereqs if they want to continue after port check fails

### DIFF
--- a/launcher
+++ b/launcher
@@ -208,6 +208,7 @@ check_ports() {
     echo ""
     echo "If you are trying to run Discourse simultaneously with another web server like Apache or nginx, you will need to bind to a different port."
     echo "See https://meta.discourse.org/t/17247 for help."
+    echo "To continue anyway, re-run Launcher with --skip-prereqs"
     exit 1
   fi
 }


### PR DESCRIPTION
When rebuilding the Discourse container for OSMC today, I noticed I had difficulty starting it, as launcher told me that the port was in use. I see that this is verified with:

```
local valid=$(netstat -tln | awk '{print $4}' | grep ":${1}\$")
```

We have more than one IPv4 on one our boxes, and multiple services running on port 443 across these IPs. This only became an issue recently as we used to add our additional IPv4s via socket activated services which would start later than Docker, but now add them via /etc/network/interfaces

It's theoretically possible to check containers/app.yml for the IP address the port is exposed to and see if the port is already in use on that IP, but it could be a bit messy. I think it would be better to warn the user, and attempt to proceed with launching Discourse. If this doesn't succeed, the user will still be able to see a possible reason for why this is the case. If you would prefer the aforementioned solution, I can work on that.