### PR TITLE
Assign a stable but unique MAC address to each container

### DIFF
--- a/launcher
+++ b/launcher
@@ -528,9 +528,12 @@ run_start(){
      # docker added more hostname rules
      hostname=${hostname/_/-}
 
+     mac_address="--mac-address $(echo $hostname | md5sum | sed 's/^\(..\)\(..\)\(..\)\(..\)\(..\).*$/02:\1:\2:\3:\4:\5/')"
+
      set -x
      $docker_path run $user_args $links $attach_on_run $restart_policy "${env[@]}" -h "$hostname" \
-        -e DOCKER_HOST_IP=$docker_ip --name $config -t $ports $volumes $docker_args $run_image $boot_command
+        -e DOCKER_HOST_IP=$docker_ip --name $config -t $ports $volumes $mac_address $docker_args \
+        $run_image $boot_command
 
    )
    exit 0

--- a/launcher
+++ b/launcher
@@ -528,7 +528,7 @@ run_start(){
      # docker added more hostname rules
      hostname=${hostname/_/-}
 
-     mac_address="--mac-address $(echo $hostname | md5sum | sed 's/^\(..\)\(..\)\(..\)\(..\)\(..\).*$/02:\1:\2:\3:\4:\5/')"
+     mac_address="--mac-address $(echo $hostname | $docker_path run $user_args -i --rm -a stdout -a stderr $image /bin/sh -c "md5sum | sed 's/^\(..\)\(..\)\(..\)\(..\)\(..\).*$/02:\1:\2:\3:\4:\5/'")"
 
      set -x
      $docker_path run $user_args $links $attach_on_run $restart_policy "${env[@]}" -h "$hostname" \


### PR DESCRIPTION
This does Very Good Things for IPv6 addresses (at least on versions of
Docker that aren't [buggy](https://github.com/docker/docker/issues/17739)).
You get an IPv6 address which doesn't change on each reboot, and at the same
time you don't get different containers having the same IPv6 address at
different times.  Wins all round!