### PR TITLE
Improve LETSENCRYPT_ACCOUNT_EMAIL comment

### DIFF
--- a/samples/standalone.yml
+++ b/samples/standalone.yml
@@ -76,7 +76,8 @@ env:
   #DISCOURSE_SMTP_PASSWORD: pa$$word               # (optional, WARNING the char '#' in pw can cause problems!)
   #DISCOURSE_SMTP_ENABLE_START_TLS: true           # (optional, default true)
   
-  ## The Lets Encrypt email will allow you to register a FREE SSL certificate if you added the Lets Encrypt template, comment it out if you have set this up
+  ## The Let's Encrypt email will allow you to register a FREE SSL certificate.
+  # If you added the Lets Encrypt template, uncomment below if you have set this up
   # LETSENCRYPT_ACCOUNT_EMAIL: email@awesomedomain.com
 
   ## The CDN address for this Discourse instance (configured to pull)

--- a/samples/standalone.yml
+++ b/samples/standalone.yml
@@ -77,7 +77,7 @@ env:
   #DISCOURSE_SMTP_ENABLE_START_TLS: true           # (optional, default true)
   
   ## The Let's Encrypt email will allow you to register a FREE SSL certificate.
-  # If you added the Lets Encrypt template, uncomment below if you have set this up
+  # If you added the Let's Encrypt template, uncomment below to automatically get certificates.
   # LETSENCRYPT_ACCOUNT_EMAIL: email@awesomedomain.com
 
   ## The CDN address for this Discourse instance (configured to pull)


### PR DESCRIPTION
Though this bit is still not clear:

> If you added the Let's Encrypt template, uncomment below if you have set this up

* How exactly would one "have set this up"?
* There are two ifs in the sentence
* What *exactly* does the setting do? Will the admin have to click a confirmation link emailed by Let's Encrypt?
