### PR TITLE
Moved parameter test back before shift

### DIFF
--- a/launcher
+++ b/launcher
@@ -21,15 +21,14 @@ usage () {
   exit 1
 }
 
+[ $# -lt 2 ] && {
+  usage
+}
 
 command=$1
 config=$2
 shift 2
 user_args=""
-
-[ $# -lt 2 ] && {
-  usage
-}
 
 while [ ${#} -gt 0 ]; do
   case "$command" in


### PR DESCRIPTION
If the less than test is placed after the shift, usage will be shown even if two parameters are passed.