### PR TITLE
Produce random-but-stable MAC addresses, take 2

### DIFF
--- a/launcher
+++ b/launcher
@@ -800,9 +800,12 @@ run_start() {
      # docker added more hostname rules
      hostname=${hostname/_/-}
 
+     mac_address="--mac-address $($docker_path run $user_args -i --rm -a stdout -a stderr $image /bin/sh -c "echo $hostname | md5sum | sed 's/^\(..\)\(..\)\(..\)\(..\)\(..\).*$/02:\1:\2:\3:\4:\5/'")"
+
      set -x
      $docker_path run $user_args $links $attach_on_run $restart_policy "${env[@]}" -h "$hostname" \
-        -e DOCKER_HOST_IP=$docker_ip --name $config -t $ports $volumes $docker_args $run_image $boot_command
+        -e DOCKER_HOST_IP=$docker_ip --name $config -t $ports $volumes $mac_address $docker_args \
+        $run_image $boot_command
 
    )
    exit 0


### PR DESCRIPTION
This version works properly on ye olde versions of Docker (v1.7 was reported
as not working with the previous version of this patch).