### PR TITLE
Launcher copyedit and discourse-setup tweaks

### DIFF
--- a/discourse-setup
+++ b/discourse-setup
@@ -372,6 +372,8 @@ validate_config() {
 
   if [ "$valid_config" != "y" ]; then
     echo -e "\nSorry, these $config_file settings aren't valid -- can't continue!"
+    echo "If you have non-standard requirements, edit $config_file then: "
+    echo "./launcher bootstrap $app_name"
     exit 1
   fi
 }

--- a/discourse-setup
+++ b/discourse-setup
@@ -4,7 +4,7 @@
 ## Do we have enough memory and disk space for Discourse?
 ##
 check_disk_and_memory() {
-  
+
   avail_mem="$(LANG=C free -m | grep '^Mem:' | awk '{print $2}')"
   if [ "$avail_mem" -lt 900 ]; then
     echo "WARNING: Discourse requires 1GB RAM to run. This system does not appear"
@@ -14,7 +14,7 @@ check_disk_and_memory() {
     echo "complete successfully."
     exit 1
   fi
-    
+
   if [ "$avail_mem" -lt 1800 ]; then
     total_swap="$(LANG=C free -m | grep ^Swap: | awk '{print $2}')"
     if [ "$total_swap" -lt 1000 ]; then
@@ -25,10 +25,10 @@ check_disk_and_memory() {
       echo "upgrades of Discourse may not complete successfully."
       echo
       read -p "ENTER to create a 2GB swapfile automatically, or Ctrl-C to exit"
-      
+
       ##
       ## derived from https://meta.discourse.org/t/13880
-      ## 
+      ##
       install -o root -g root -m 0600 /dev/null /swapfile
       dd if=/dev/zero of=/swapfile bs=1k count=2048k
       mkswap /swapfile
@@ -42,7 +42,7 @@ check_disk_and_memory() {
         echo "Failed to create swap, sorry!"
         exit 1
       fi
-      
+
     fi
   fi
 
@@ -116,13 +116,13 @@ scale_ram_and_cpu() {
 }
 
 
-## 
+##
 ## standard http / https ports must not be occupied
 ##
 check_ports() {
     check_port "80"
     check_port "443"
-    echo "Ports 80 and 443 are free for use"
+    echo "Ports 80 and 443 are free for use."
 }
 
 
@@ -130,7 +130,7 @@ check_ports() {
 ## check a port to see if it is already in use
 ##
 check_port() {
-  
+
   local valid=$(netstat -tln | awk '{print $4}' | grep ":${1}\$")
 
   if [ -n "$valid" ]; then
@@ -138,7 +138,7 @@ check_port() {
     echo
     echo "If you are trying to run Discourse simultaneously with another web"
     echo "server like Apache or nginx, you will need to bind to a different port"
-    echo 
+    echo
     echo "See https://meta.discourse.org/t/17247"
     exit 1
   fi
@@ -148,7 +148,7 @@ check_port() {
 ## prompt user for typical Discourse config file values
 ##
 ask_user_for_config() {
-  
+
   local changelog=/tmp/changelog.$PPID
   local hostname="discourse.example.com"
   local developer_emails="me@example.com,you@example.com"
@@ -161,7 +161,7 @@ ask_user_for_config() {
   local new_value=""
   local config_ok="n"
   local update_ok="y"
-  
+
   echo ""
 
   while [[ "$config_ok" == "n" ]]
@@ -174,7 +174,7 @@ ask_user_for_config() {
           hostname=$new_value
       fi
     fi
-    
+
     if [ ! -z $developer_emails ]
     then
       read -p "Email address for admin account? [$developer_emails]: " new_value
@@ -183,7 +183,7 @@ ask_user_for_config() {
           developer_emails=$new_value
       fi
     fi
-    
+
     if [ ! -z $smtp_address ]
     then
       read -p "SMTP server address? [$smtp_address]: " new_value
@@ -192,17 +192,17 @@ ask_user_for_config() {
         smtp_address=$new_value
       fi
     fi
-    
+
     if [ "$smtp_address" == "smtp.sparkpostmail.com" ]
     then
     	smtp_user_name="SMTP_Injection"
     fi
-    
+
     if [ "$smtp_address" == "smtp.sendgrid.net" ]
     then
 	    smtp_user_name="apikey"
     fi
-    
+
     if [ ! -z $smtp_user_name ]
     then
       read -p "SMTP user name? [$smtp_user_name]: " new_value
@@ -211,13 +211,13 @@ ask_user_for_config() {
           smtp_user_name=$new_value
       fi
     fi
-    
+
     read -p "SMTP password? [$smtp_password]: " new_value
     if [ ! -z $new_value ]
     then
         smtp_password=$new_value
     fi
-    
+
     if [ ! -z $letsencrypt_account_email ]
     then
       read -p "Let's Encrypt account email? ($letsencrypt_status) [$letsencrypt_account_email]: " new_value
@@ -226,6 +226,7 @@ ask_user_for_config() {
           letsencrypt_account_email=$new_value
           if [ "$new_value" == "off" ]
           then
+	    # Warning: Changing this prompt breaks a test below
             letsencrypt_status="ENTER to skip"
           else
             letsencrypt_status="Enter 'OFF' to disable."
@@ -239,12 +240,12 @@ ask_user_for_config() {
     echo "SMTP address  : $smtp_address"
     echo "SMTP username : $smtp_user_name"
     echo "SMTP password : $smtp_password"
-    
+
     if [ "$letsencrypt_status" == "Enter 'OFF' to disable." ]
     then
       echo "Let's Encrypt : $letsencrypt_account_email"
     fi
-    
+
     echo ""
     read -p "ENTER to continue, 'n' to try again, or ^C to exit: " config_ok
   done
@@ -325,7 +326,7 @@ ask_user_for_config() {
         update_ok="n"
         echo "letsencrypt.ssl.template.yml NOT ENABLED -- was it on already?"
       fi
-  fi 
+  fi
 
   if [ "$update_ok" == "y" ]
   then
@@ -342,11 +343,11 @@ ask_user_for_config() {
 validate_config() {
 
   valid_config="y"
-  
+
   for x in DISCOURSE_SMTP_ADDRESS DISCOURSE_SMTP_USER_NAME DISCOURSE_SMTP_PASSWORD \
            DISCOURSE_DEVELOPER_EMAILS DISCOURSE_HOSTNAME
   do
-    config_line=`grep "^  $x:" $config_file` 
+    config_line=`grep "^  $x:" $config_file`
     local result=$?
     local default="example.com"
 
@@ -368,7 +369,7 @@ validate_config() {
       valid_config="n"
     fi
   done
-  
+
   if [ "$valid_config" != "y" ]; then
     echo -e "\nSorry, these $config_file settings aren't valid -- can't continue!"
     exit 1

--- a/discourse-setup
+++ b/discourse-setup
@@ -412,5 +412,7 @@ validate_config
 ##
 ## if we reach this point without exiting, OK to proceed
 ##
+echo "Running bootstrap in 5 seconds. ^C to check your configuration first."
+sleep 5
 ./launcher bootstrap $app_name
 ./launcher start $app_name

--- a/discourse-setup
+++ b/discourse-setup
@@ -416,5 +416,4 @@ validate_config
 ##
 echo "Running bootstrap in 5 seconds. ^C to check your configuration first."
 sleep 5
-./launcher bootstrap $app_name
-./launcher start $app_name
+./launcher bootstrap $app_name && ./launcher start $app_name

--- a/launcher
+++ b/launcher
@@ -7,7 +7,7 @@ usage () {
   echo "    stop:       Stop a running container"
   echo "    restart:    Restart a container"
   echo "    destroy:    Stop and remove a container"
-  echo "    enter:      Use nsenter to get a shell into a container"a
+  echo "    enter:      Use nsenter to get a shell into a container"
   echo "    logs:       View the Docker logs for a container"
   echo "    bootstrap:  Bootstrap a container for the config based on a template"
   echo "    rebuild:    Rebuild a container (destroy old, bootstrap, start new)"


### PR DESCRIPTION
Spurious "a" at the end of a line in `launcher`. 

## `discourse-setup` Tweaks:

- give people a chance to ^C before running bootstrap
- Tell people who don't meet config requirements to edit config and run bootstrap themselves.
- Use && to skip starting app if  bootstrap bootstrap failed
- Bonus: whitespace removal!