### PR TITLE
Update ImageMagick security patch for CVE-2016–3714

### DIFF
--- a/templates/web.template.yml
+++ b/templates/web.template.yml
@@ -28,9 +28,14 @@ run:
       to: |
         <policymap>
           <policy domain="coder" rights="none" pattern="EPHEMERAL" />
+          <policy domain="coder" rights="none" pattern="URL" />
           <policy domain="coder" rights="none" pattern="HTTPS" />
           <policy domain="coder" rights="none" pattern="MVG" />
           <policy domain="coder" rights="none" pattern="MSL" />
+          <policy domain="coder" rights="none" pattern="TEXT" />
+          <policy domain="coder" rights="none" pattern="SHOW" />
+          <policy domain="coder" rights="none" pattern="WIN" />
+          <policy domain="coder" rights="none" pattern="PLT" />
 
   - exec: /usr/local/bin/ruby -e 'if ENV["DISCOURSE_SMTP_ADDRESS"] == "smtp.example.com"; puts "Aborting! Mail is not configured!"; exit 1; end'
   - exec: /usr/local/bin/ruby -e 'if ENV["DISCOURSE_HOSTNAME"] == "discourse.example.com"; puts "Aborting! Domain is not configured!"; exit 1; end'


### PR DESCRIPTION
The recommended policy has been updated since the initial security patch was applied.  This PR adds denials for `URL`, `TEXT`, `SHOW`, `WIN` and `PLT` coders as per the latest recommendations published at https://imagetragick.com/#policy.