### PR TITLE
Fix empty arguments on launcher rerun after git pull

### DIFF
--- a/launcher
+++ b/launcher
@@ -644,7 +644,12 @@ case "$command" in
         elif [ $LOCAL = $BASE ]; then
           echo "Updating Launcher"
           git pull || (echo 'failed to update' && exit 1)
-          exec /bin/bash $0 $@
+          
+          for (( i=${#BASH_ARGV[@]}-1,j=0; i>=0,j<${#BASH_ARGV[@]}; i--,j++ ))
+          do
+            args[$j]=${BASH_ARGV[$i]}
+          done
+          exec /bin/bash $0 "${args[@]}" # $@ is empty, because of shift at the beginning. Use BASH_ARGV instead.
 
         elif [ $REMOTE = $BASE ]; then
           echo "Your version of Launcher is ahead of origin"


### PR DESCRIPTION
Running `./launcher rebuild app` after discourse_docker changes results in return code 1.

```
root:/var/discourse# ./launcher rebuild app
Ensuring launcher is up to date
Fetching origin
remote: Counting objects: 35, done.
remote: Compressing objects: 100% (4/4), done.
remote: Total 35 (delta 19), reused 19 (delta 19), pack-reused 12
Unpacking objects: 100% (35/35), done.
From https://github.com/discourse/discourse_docker
   18d87dd..c857317  master     -> origin/master
Updating Launcher
Updating 18d87dd..c857317
Fast-forward
 ...
 4 files changed, 98 insertions(+), 40 deletions(-)
Usage: launcher COMMAND CONFIG [--skip-prereqs] [--docker-args STRING]
...
root:/var/discourse# echo $?
1
```

Variable $@ cannot be used to get arguments for launcher rerun, because the usage of the shift command at line 44 removes all entries from $@. Instead $BASH_ARGV can be used, but $BASH_ARGV contains arguments in reversed order.

Fix can be checked by following commands:
```
root:/var/discourse# git reset --hard HEAD^
root:/var/discourse# ./launcher rebuild app
```