### PR TITLE
Fix physical core calculation

### DIFF
--- a/discourse-setup
+++ b/discourse-setup
@@ -134,8 +134,8 @@ scale_ram_and_cpu() {
     avail_gb=$(check_osx_memory)
     avail_cores=`sysctl hw.ncpu | awk '/hw.ncpu:/ {print $2}'`
   else
-    avail_gb=$(check_linux_memory) 
-    avail_cores=`cat /proc/cpuinfo | grep "cpu cores" | uniq | awk '{print $4}'`
+    avail_gb=$(check_linux_memory)
+    avail_cores=$((`awk '/cpu cores/ {print $4;exit}' /proc/cpuinfo`*`sort /proc/cpuinfo | uniq | grep -c "physical id"`))
   fi
   echo "Found ${avail_gb}GB of memory and $avail_cores physical CPU cores"
 


### PR DESCRIPTION
Related to this thread https://meta.discourse.org/t/number-cpu-cores-incorrectly-detected-upcloud-com-vps/51950
here is fix for most architectures. There can still be some systems where cores are too slow and they should not be used as count for unicorn processes.