### PR TITLE
launcher: silence which error when looking for docker/docker.io

### DIFF
--- a/launcher
+++ b/launcher
@@ -65,7 +65,7 @@ config_file=containers/"$config".yml
 cidbootstrap=cids/"$config"_bootstrap.cid
 local_discourse=local_discourse
 image=discourse/discourse:1.3.7
-docker_path=`which docker.io || which docker`
+docker_path=`which docker.io 2>/dev/null || which docker 2>/dev/null`
 git_path=`which git`
 
 if [ "${SUPERVISED}" = "true" ]; then


### PR DESCRIPTION
One liner to silence the warning from which when it cannot find docker.io / docker. There is later a check for the docker_path being non empty, so the warning is not required and just noise for anyone (like me) without docker.io but with docker in their path.