### PR TITLE
Add Travis and Coala for code linting

### DIFF
--- a/.coafile
+++ b/.coafile
@@ -1,0 +1,32 @@
+[default]
+bears = FilenameBear
+files = **.rb, **.md, **.yml
+ignore =
+
+[markdown]
+bears = MarkdownBear, LineLengthBear
+files = **.md
+language = markdown
+max_line_length = 80
+ignore_length_regex = .*(https?:\/\/) # ignore long link
+markdown_strong = *
+markdown_emphasis = _
+
+[ruby]
+bears = RubySyntaxBear, RuboCopBear
+files = **.rb
+language = ruby
+rubocop_config = .rubocop.yml
+
+# Disabled because ShellCheckBear enforce rule `cd ... || exit`
+# it's cannot disabled through coala.
+#[shell]
+#bears = ShellCheckBear
+#files = **.sh, image/base/*
+#shell = bash
+
+[yaml]
+bears = YAMLLintBear
+files = **.yml
+language = yaml
+yamllint_config = .yamllint

--- a/.coafile
+++ b/.coafile
@@ -1,6 +1,6 @@
 [default]
 bears = FilenameBear
-files = **.rb, **.md, **.yml
+files = **.md, **.yml
 ignore =
 
 [markdown]

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,7 +25,7 @@ Metrics/AbcSize:
 Performance/FixedSize:
     Enabled: false
 
-# Many line is tricky or became less unreadable when splited
+# Many line is tricky or became less readable when splited
 # especially line of executing shell command via run(...).
 Metrics/LineLength:
     Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,42 @@
+Stye/GlobalVars:
+    Enabled: false
+
+Style/Documentation:
+    Enabled: false
+
+# image/build.rb:8
+# image/build.rb:30
+# Methods have too many length
+Metrics/MethodLength:
+    Enabled: false
+
+# image/build.rb:16
+# Unhandled exception
+Lint/HandleExceptions:
+    Enabled: false
+
+# image/build.rb:30
+# Assignment Branch Condition size for build is too high. [22.29/15]
+Metrics/AbcSize:
+    Enabled: false
+
+# image/build.rb:32
+# Do not compute the size of statically sized objects.
+Performance/FixedSize:
+    Enabled: false
+
+# Many line is tricky or became less unreadable when splited
+# especially line of executing shell command via run(...).
+Metrics/LineLength:
+    Enabled: false
+
+# image/monitor/src/monitor.rb:24
+# Avoid using `rescue` in its modifier form.
+Style/RescueModifier:
+    Enabled: false
+
+# image/monitor/src/monitor.rb:82
+# Favor modifier `if` usage when having a single-line body.
+# ps: maybe a false positive
+Style/IfUnlessModifier:
+    Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 services: docker
 script:
-  - docker run --volume=$(pwd):/app --workdir=/app coala/base:pre coala-ci --flush-cache
+  - docker run --volume=$(pwd):/app --workdir=/app coala/base:0.9 coala-ci --flush-cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+services: docker
+script:
+  - docker run --volume=$(pwd):/app --workdir=/app coala/base:pre coala-ci --flush-cache

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,7 @@
+---
+
+extends: relaxed
+
+rules:
+    line-length: disable
+    indent-sequences: whatever

--- a/README.md
+++ b/README.md
@@ -1,48 +1,68 @@
 ### About
 
-- [Docker](https://docker.com/) is an open source project to pack, ship and run any Linux application in a lighter weight, faster container than a traditional virtual machine.
+- [Docker](https://docker.com/) is an open source project to pack, ship and run
+  any Linux application in a lighter weight, faster container than a traditional
+  virtual machine.
 
-- Docker makes it much easier to deploy [a Discourse forum](https://github.com/discourse/discourse) on your servers and keep it updated. For background, see [Sam's blog post](http://samsaffron.com/archive/2013/11/07/discourse-in-a-docker-container).
+- Docker makes it much easier to deploy [a Discourse forum](https://github.com/discourse/discourse)
+  on your servers and keep it updated. For background, see
+  [Sam's blog post](http://samsaffron.com/archive/2013/11/07/discourse-in-a-docker-container).
 
-- The templates and base image configure Discourse with the Discourse team's recommended optimal defaults.
+- The templates and base image configure Discourse with the Discourse team's
+  recommended optimal defaults.
 
 ### Getting Started
 
-The simplest way to get started is via the **standalone** template, which can be installed in 30 minutes or less. For detailed install instructions, see
+The simplest way to get started is via the **standalone** template, which can
+be installed in 30 minutes or less. For detailed install instructions, see
 
-https://github.com/discourse/discourse/blob/master/docs/INSTALL-cloud.md
+<https://github.com/discourse/discourse/blob/master/docs/INSTALL-cloud.md>
 
 ### Directory Structure
 
 #### `/cids`
 
-Contains container ids for currently running Docker containers. cids are Docker's "equivalent" of pids. Each container will have a unique git like hash.
+Contains container ids for currently running Docker containers. cids are
+Docker's "equivalent" of pids. Each container will have a unique git like hash.
 
 #### `/containers`
 
-This directory is for container definitions for your various Discourse containers. You are in charge of this directory, it ships empty.
+This directory is for container definitions for your various Discourse
+containers. You are in charge of this directory, it ships empty.
 
 #### `/samples`
 
-Sample container definitions you may use to bootstrap your environment. You can copy templates from here into the containers directory.
+Sample container definitions you may use to bootstrap your environment. You can
+copy templates from here into the containers directory.
 
 #### `/shared`
 
-Placeholder spot for shared volumes with various Discourse containers. You may elect to store certain persistent information outside of a container, in our case we keep various logfiles and upload directory outside. This allows you to rebuild containers easily without losing important information. Keeping uploads outside of the container allows you to share them between multiple web instances.
+Placeholder spot for shared volumes with various Discourse containers. You may
+elect to store certain persistent information outside of a container, in our
+case we keep various logfiles and upload directory outside. This allows you to
+rebuild containers easily without losing important information. Keeping uploads
+outside of the container allows you to share them between multiple web
+instances.
 
 #### `/templates`
 
-[pups](https://github.com/samsaffron/pups)-managed templates you may use to bootstrap your environment.
+[pups](https://github.com/samsaffron/pups)-managed templates you may use to
+bootstrap your environment.
 
 #### `/image`
 
-Dockerfiles for Discourse; see [the README](image/README.md) for further details.
+Dockerfiles for Discourse; see [the README](image/README.md) for further
+details.
 
-The Docker repository will always contain the latest built version at: https://hub.docker.com/r/discourse/discourse/, you should not need to build the base image.
+The Docker repository will always contain the latest built version at:
+<https://hub.docker.com/r/discourse/discourse/>, you should not need to build
+the base image.
 
 ### Launcher
 
-The base directory contains a single bash script which is used to manage containers. You can use it to "bootstrap" a new container, enter, start, stop and destroy a container.
+The base directory contains a single bash script which is used to manage
+containers. You can use it to "bootstrap" a new container, enter, start, stop
+and destroy a container.
 
 ```
 Usage: launcher COMMAND CONFIG [--skip-prereqs]
@@ -58,11 +78,14 @@ Commands:
     rebuild:    Rebuild a container (destroy old, bootstrap, start new)
 ```
 
-If the environment variable "SUPERVISED" is set to true, the container won't be detached, allowing a process monitoring tool to manage the restart behaviour of the container.
+If the environment variable "SUPERVISED" is set to true, the container won't be
+detached, allowing a process monitoring tool to manage the restart behaviour of
+the container.
 
 ### Container Configuration
 
-The beginning of the container definition can contain the following "special" sections:
+The beginning of the container definition can contain the following "special"
+sections:
 
 #### templates:
 
@@ -72,7 +95,9 @@ templates:
   - "templates/postgres.template.yml"
 ```
 
-This template is "composed" out of all these child templates, this allows for a very flexible configuration structure. Furthermore you may add specific hooks that extend the templates you reference.
+This template is "composed" out of all these child templates, this allows for a
+very flexible configuration structure. Furthermore you may add specific hooks
+that extend the templates you reference.
 
 #### expose:
 
@@ -82,8 +107,10 @@ expose:
   - "127.0.0.1:20080:80"
 ```
 
-Expose port 22 inside the container on port 2222 on ALL local host interfaces. In order to bind to only one interface, you may specify the host's IP address as `([<host_interface>:[host_port]])|(<host_port>):<container_port>[/udp]` as defined in the [docker port binding documentation](http://docs.docker.com/userguide/dockerlinks/)
-
+Expose port 22 inside the container on port 2222 on ALL local host interfaces.
+In order to bind to only one interface, you may specify the host's IP address
+as `([<host_interface>:[host_port]])|(<host_port>):<container_port>[/udp]` as
+defined in the [docker port binding documentation](http://docs.docker.com/userguide/dockerlinks/)
 
 #### volumes:
 
@@ -92,12 +119,12 @@ volumes:
   - volume:
       host: /var/discourse/shared
       guest: /shared
-
 ```
 
 Expose a directory inside the host to the container.
 
 #### links:
+
 ```
 links:
   - link:
@@ -105,47 +132,70 @@ links:
       alias: postgres
 ```
 
-Links another container to the current container. This will add `--link postgres:postgres`
-to the options when running the container.
+Links another container to the current container. This will add
+`--link postgres:postgres` to the options when running the container.
 
 ### Upgrading Discourse
 
 The Docker setup gives you multiple upgrade options:
 
-1. Use the front end at http://yoursite.com/admin/upgrade to upgrade an already running image.
+1. Use the front end at <http://yoursite.com/admin/upgrade> to upgrade an
+   already running image.
 
 2. Create a new base image manually by running:
-  - `./launcher rebuild my_image`
+
+
+```
+./launcher rebuild my_image
+```
 
 ### Single Container vs. Multiple Container
 
-The samples directory contains a standalone template. This template bundles all of the software required to run Discourse into a single container. The advantage is that it is easy.
+The samples directory contains a standalone template. This template bundles all
+of the software required to run Discourse into a single container. The
+advantage is that it is easy.
 
-The multiple container configuration setup is far more flexible and robust, however it is also more complicated to set up. A multiple container setup allows you to:
+The multiple container configuration setup is far more flexible and robust,
+however it is also more complicated to set up. A multiple container setup
+allows you to:
 
-- Minimize downtime when upgrading to new versions of Discourse. You can bootstrap new web processes while your site is running and only after it is built, switch the new image in.
+- Minimize downtime when upgrading to new versions of Discourse. You can
+  bootstrap new web processes while your site is running and only after it is
+  built, switch the new image in.
 - Scale your forum to multiple servers.
 - Add servers for redundancy.
 - Have some required services (e.g. the database) run on beefier hardware.
 
-If you want a multiple container setup, see the `data.yml` and `web_only.yml` templates in the samples directory. To ease this process, `launcher` will inject an env var called `DISCOURSE_HOST_IP` which will be available inside the image.
+If you want a multiple container setup, see the `data.yml` and `web_only.yml`
+templates in the samples directory. To ease this process, `launcher` will inject
+an env var called `DISCOURSE_HOST_IP` which will be available inside the image.
 
-WARNING: In a multiple container configuration, *make sure* you setup iptables or some other firewall to protect various ports (for postgres/redis).
-On Ubuntu, install the `ufw` or `iptables-persistent` package to manage firewall rules.
+WARNING: In a multiple container configuration, _make sure_ you setup iptables
+or some other firewall to protect various ports (for postgres/redis).
+On Ubuntu, install the `ufw` or `iptables-persistent` package to manage firewall
+rules.
 
 ### Email
 
-For a Discourse instance to function properly Email must be set up. Use the `SMTP_URL` env var to set your SMTP address, see sample templates for an example. The Docker image does not contain postfix, exim or another MTA, it was omitted because it is very tricky to set up correctly.
+For a Discourse instance to function properly Email must be set up. Use the
+`SMTP_URL` env var to set your SMTP address, see sample templates for an
+example. The Docker image does not contain postfix, exim or another MTA, it was
+omitted because it is very tricky to set up correctly.
 
 ### Troubleshooting
 
 View the container logs: `./launcher logs my_container`
 
-Spawn a shell inside your container using `./launcher enter my_container`. This is the most foolproof method if you have host root access.
+Spawn a shell inside your container using `./launcher enter my_container`. This
+is the most foolproof method if you have host root access.
 
-If you see network errors trying to retrieve code from `github.com` or `rubygems.org` try again - sometimes there are temporary interruptions and a retry is all it takes.
+If you see network errors trying to retrieve code from `github.com` or
+`rubygems.org` try again - sometimes there are temporary interruptions and a
+retry is all it takes.
 
-Behind a proxy network with no direct access to the Internet? Add proxy information to the container environment by adding to the existing `env` block in the `container.yml` file:
+Behind a proxy network with no direct access to the Internet? Add proxy
+information to the container environment by adding to the existing `env` block
+in the `container.yml` file:
 
 ```yaml
 env:
@@ -163,7 +213,6 @@ host do not match the IDs in the guest, permissions will mismatch. On clean
 installs you can ensure they are in sync by looking at `/etc/passwd` and
 `/etc/group`, the Discourse account will have UID 1000.
 
-
 ### Advanced topics
 
 - [Setting up SSL with Discourse Docker](https://meta.discourse.org/t/allowing-ssl-for-your-discourse-docker-setup/13847)
@@ -179,7 +228,9 @@ out your changes before committing, using the magic of
 instructions](http://docs.vagrantup.com/v2/installation/index.html), and
 then run:
 
-    vagrant up
+```
+vagrant up
+```
 
 This will spawn a new Ubuntu VM, install Docker, and then await your
 instructions.  You can then SSH into the VM with `vagrant ssh`, become
@@ -187,7 +238,6 @@ instructions.  You can then SSH into the VM with `vagrant ssh`, become
 already available at `/var/discourse`, so you can just `cd /var/discourse`
 and then start running `launcher`.
 
+# License
 
-License
-===
 MIT

--- a/image/README.md
+++ b/image/README.md
@@ -2,50 +2,64 @@
 
 ## Building new images
 
-To build a new set of images, update the `Makefile` with the new version number, and then `make all`.  This will automatically update the header comments in the Dockerfiles and update any `FROM` statements to ensure that the image verions remain in lock-step with each other.  (The downside is that if you only wanted to tweak a "leaf" image, you'll still be touching/updating _all_ of the images.  But reasoning about the images is much easier if they all have the same version.)
+To build a new set of images, update the `Makefile` with the new version number,
+and then `make all`.  This will automatically update the header comments in the
+Dockerfiles and update any `FROM` statements to ensure that the image verions
+remain in lock-step with each other.  (The downside is that if you only wanted
+to tweak a "leaf" image, you'll still be touching/updating _all_ of the images.
+But reasoning about the images is much easier if they all have the same
+version.)
 
-The build process will tag the images with the version number, but not with "latest", nor will it push the images up to Docker Hub.  Both of those steps must be performed manually.
+The build process will tag the images with the version number, but not with
+"latest", nor will it push the images up to Docker Hub.  Both of those steps
+must be performed manually.
 
-> _A note about docker-squash:_ Getting docker-squash configured correctly on OSX takes a bit of doing, so if you want to simply skip the squashing step entirely, just prefix the make command with `SQUASH=NO`, as follows:
+> _A note about docker-squash:_ Getting docker-squash configured correctly on
+> OSX takes a bit of doing, so if you want to simply skip the squashing step
+> entirely, just prefix the make command with `SQUASH=NO`, as follows:
 >
 > ```sh
 > SQUASH=NO make all
 > ```
 
-
-
 ## More about the images
 
-See both `Makefile` and the respective `Dockerfile`s for details on _how_ all of this happens.
-
+See both `Makefile` and the respective `Dockerfile`s for details on _how_ all of
+this happens.
 
 ### base ([discourse/base](https://hub.docker.com/r/discourse/base/))
 
-All of the dependencies for running Discourse.  This includes runit, postgres, nginx, ruby, imagemagick, etc.  It also includes the creation of the "discourse" user and `/var/www` directory.
-
+All of the dependencies for running Discourse.  This includes runit, postgres,
+nginx, ruby, imagemagick, etc.  It also includes the creation of the "discourse"
+user and `/var/www` directory.
 
 ### discourse ([discourse/discourse](https://hub.docker.com/r/discourse/discourse/))
 
-Builds on the base image and adds the current (as of image build time) version of Discourse, cloned from GitHub, and also the bundled gems.
-
+Builds on the base image and adds the current (as of image build time) version
+of Discourse, cloned from GitHub, and also the bundled gems.
 
 ### discourse_dev ([discourse/discourse_dev](https://hub.docker.com/r/discourse/discourse_dev/))
 
-Adds redis and postgres just like the "standalone" template for Discourse in order to have an all-in-one container for development.  Note that you are expected to mount your local discourse source directory to `/src`.  See [the README in GitHub's discourse/bin/docker](https://github.com/discourse/discourse/tree/master/bin/docker/) for utilities that help with this.
+Adds redis and postgres just like the "standalone" template for Discourse in
+order to have an all-in-one container for development.  Note that you are
+expected to mount your local discourse source directory to `/src`.  See
+[the README in GitHub's discourse/bin/docker](https://github.com/discourse/discourse/tree/master/bin/docker/)
+for utilities that help with this.
 
-Note that the discourse user is granted "sudo" permission without asking for a password in the discourse_dev image.  This is to facilitate the command-line Docker tools in discourse proper that run commands as the discourse user.
-
+Note that the discourse user is granted "sudo" permission without asking for a
+password in the discourse_dev image.  This is to facilitate the command-line
+Docker tools in discourse proper that run commands as the discourse user.
 
 ### discourse_test ([discourse/discourse_test](https://hub.docker.com/r/discourse/discourse_test/))
 
-Builds on the discourse image and adds testing tools and a default testing entrypoint.
-
+Builds on the discourse image and adds testing tools and a default testing
+entrypoint.
 
 ### discourse_bench ([discourse/discourse_bench](https://hub.docker.com/r/discourse/discourse_bench/))
 
 Builds on the discourse_test image and adds benchmark testing.
 
-
 ### discourse_fast_switch ([discourse/discourse_fast_switch](https://hub.docker.com/r/discourse/discourse_fast_switch/))
 
-Builds on the discourse image and adds the ability to easily switch versions of Ruby.
+Builds on the discourse image and adds the ability to easily switch versions of
+Ruby.

--- a/image/discourse_fast_switch/create_switch.rb
+++ b/image/discourse_fast_switch/create_switch.rb
@@ -1,19 +1,18 @@
 require 'fileutils'
 
-puts "-"*100,"creating switch","-"*100
+puts '-' * 100, 'creating switch', '-' * 100
 
 Dir.glob('/usr/ruby_20/*/**').each do |file|
   file = file.gsub('/usr/ruby_20/', '/usr/local/')
-  FileUtils.rm(file) if File.exists?(file) && !File.directory?(file)
+  FileUtils.rm(file) if File.exist?(file) && !File.directory?(file)
 end
 
-system("cd /var/www/discourse && git pull")
+system('cd /var/www/discourse && git pull')
 
-['22', '23'].each do |v|
-
+%w(22 23).each do |v|
   bin = "/usr/local/bin/use_#{v}"
 
-File.write(bin, <<RUBY
+  File.write(bin, <<RUBY
 #!/usr/ruby_22/bin/ruby
 
 Dir.glob('/usr/ruby_#{v}/bin/*').each do |file|
@@ -22,7 +21,7 @@ Dir.glob('/usr/ruby_#{v}/bin/*').each do |file|
 end
 
 RUBY
-)
+            )
 
   system("chmod +x #{bin}")
   system("use_#{v} && gem update --system && gem install bundler")


### PR DESCRIPTION
Hello,

I see that this repo doesn't have any mean of CI nor linting. So I try to create one with Travis and [Coala](https://github.com/coala/coala) for for linting. It's a pretty big patch but mainly just editing of whitespace and newlines.

Here are list of rules that i use in this patch

## Markdown

- Set max line length 80
- Exception for line that have URL link
- Enforce `*` for bold and `_` for emphasis. I just adhere the most commonly used pattern previously.

## YAML

- Consistent indentation rules, based on same rules used in <www.yamllint.com>

## Ruby

- Enforce rules based on [RuboCop](https://github.com/bbatsov/rubocop)
- I disable few default rules because i dont have enough understanding in the codebase to make change without breaking things.

## Shell

- Actually i want to lint bash file too, but there are bugs in Coala that prevent excluding a rule that not relevant with this repo code. The rule is enforcing `cd .... || exit`, preventing script failing silently on changing dir.