### PR TITLE
Some HTTPS improvements to achieve A+ on Qualsys SSL Labs

### DIFF
--- a/templates/web.letsencrypt.ssl.template.yml
+++ b/templates/web.letsencrypt.ssl.template.yml
@@ -88,5 +88,4 @@ hooks:
        filename: "/etc/nginx/conf.d/discourse.conf"
        from: /add_header.+/
        to: |
-         # remember the certificate for 80 days and automatically connect to HTTPS for this domain
-         add_header Strict-Transport-Security 'max-age=6912000';
+         add_header Strict-Transport-Security 'max-age=63072000';

--- a/templates/web.ssl.template.yml
+++ b/templates/web.ssl.template.yml
@@ -3,7 +3,7 @@ run:
      cmd:
        # Generate strong Diffie-Hellman parameters
        - "mkdir -p /shared/ssl/"
-       - "[ -e /shared/ssl/dhparams.pem ] || openssl dhparam -out /shared/ssl/dhparams.pem 2048"
+       - "[ -e /shared/ssl/dhparams.pem ] || openssl dhparam -out /shared/ssl/dhparams.pem 4096"
   - replace:
      filename: "/etc/nginx/conf.d/discourse.conf"
      from: /server.+{/


### PR DESCRIPTION
[Make an A+ on Qualsys SSL Labs](https://www.ssllabs.com/ssltest/analyze.html?d=discourse.oconnor.ninja&s=104.236.222.245) -- It's always bugged me...figured it can't hurt to make a PR. 

- Make HSTS max-age longer for A+ on qualsys SSL labs
- dhparams 4096 bits vs 2048

