### PR TITLE
Adding dev dependencies in the docker image

### DIFF
--- a/image/discourse_dev/Dockerfile
+++ b/image/discourse_dev/Dockerfile
@@ -4,6 +4,10 @@ FROM discourse/base:1.3.9
 
 MAINTAINER Sam Saffron "https://twitter.com/samsaffron"
 
+# Istall some development environment dependencies
+RUN apt-get update && apt-get install -y libsqlite3-dev \
+    && rm -rf /var/lib/apt/lists/*
+
 # Create discourse user and /var/www location for both
 # discourse and dev images.
 RUN useradd discourse -s /bin/bash -m -U &&\


### PR DESCRIPTION
Adding `libsqlite3-dev` dependency for dev image while mailcatcher is added in the Gemfile of the main discourse repo.