### PR TITLE
There's no Docker image tag for 1.3.10 (yet?)

### DIFF
--- a/launcher
+++ b/launcher
@@ -64,7 +64,7 @@ git_rec_version='1.8.0'
 config_file=containers/"$config".yml
 cidbootstrap=cids/"$config"_bootstrap.cid
 local_discourse=local_discourse
-image=discourse/discourse:1.3.10
+image=discourse/discourse:1.3.9
 docker_path=`which docker.io || which docker`
 git_path=`which git`
 


### PR DESCRIPTION
FIX: `./launcher rebuild app` fails with `docker: Tag 1.3.10 not found in repository docker.io/discourse/discourse`