### PR TITLE
Fix usage of docker_ip variable with multiple ips

### DIFF
--- a/launcher
+++ b/launcher
@@ -518,7 +518,7 @@ run_start() {
 
      set -x
      $docker_path run $links $attach_on_run $restart_policy "${env[@]}" "${labels[@]}" -h "$hostname" \
-        -e DOCKER_HOST_IP=$docker_ip --name $config -t $ports $volumes $mac_address $docker_args $user_args \
+        -e DOCKER_HOST_IP="$docker_ip" --name $config -t $ports $volumes $mac_address $docker_args $user_args \
         $run_image $boot_command
 
    )
@@ -562,7 +562,7 @@ run_bootstrap() {
   echo $run_command
 
   unset ERR
-  (exec echo "$input" | $docker_path run $user_args $links "${env[@]}" -e DOCKER_HOST_IP=$docker_ip --cidfile $cidbootstrap -i -a stdin -a stdout -a stderr $volumes $image \
+  (exec echo "$input" | $docker_path run $user_args $links "${env[@]}" -e DOCKER_HOST_IP="$docker_ip" --cidfile $cidbootstrap -i -a stdin -a stdout -a stderr $volumes $image \
     /bin/bash -c "$run_command") || ERR=$?
 
   unset FAILED


### PR DESCRIPTION
My setup contains a default Rancher node + agent on the same host. This leads to multiple ips in the docker_ip variable. Fix by adding double quotes around docker_ip variable.

Running `./launcher rebuild ...` fails with the following error message:
```
Unable to find image '10.42.0.1:latest' locally
Pulling repository docker.io/library/10.42.0.1
```

This error message is caused by using **$docker_ip** in run_bootstrap method, but without double quotes the docker cli uses the second ip as image name:
Bash: `... -e DOCKER_HOST_IP=$docker_ip --cidfile ...`
Execution: `... -e DOCKER_HOST_IP=172.17.0.1 10.42.0.1 --cidfile ...`