### PR TITLE
Discourse setup reconfig

### DIFF
--- a/discourse-setup
+++ b/discourse-setup
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ##
 ## Make sure only root can run our script
@@ -27,13 +27,40 @@ check_and_install_docker () {
   fi
 }
 
+##
+## What are we running on
+##
+check_OS() {
+  echo `uname -s`
+}
+
+##
+## OS X available memory
+##
+check_osx_memory() {
+  echo `top -l 1 | awk '/PhysMem:/ {print $2}' | sed s/G//`
+}
+
+##
+## Linux available memory
+##
+check_linux_memory() {
+  echo `free -g --si | awk ' /Mem:/  {print $2} '`
+}
 
 ##
 ## Do we have enough memory and disk space for Discourse?
 ##
 check_disk_and_memory() {
 
-  avail_mem=`free -g --si | awk ' /Mem:/  {print $2} '`
+  os_type=$(check_OS)
+  avail_mem=0
+  if [ $os_type == "Darwin" ]; then
+    avail_mem=$(check_osx_memory)
+  else
+    avail_mem=$(check_linux_memory)
+  fi
+
   if [ "$avail_mem" -lt 1 ]; then
     echo "WARNING: Discourse requires 1GB RAM to run. This system does not appear"
     echo "to have sufficient memory."
@@ -43,11 +70,11 @@ check_disk_and_memory() {
     exit 1
   fi
 
-  if [ "$avail_mem" -lt 2 ]; then
+  if [ "$avail_mem" -le 2 ]; then
     total_swap=`free -g --si | awk ' /Swap:/  {print $2} '`
     if [ "$total_swap" -lt 2 ]; then
-      echo "WARNING: Discourse requires at least 2GB of swap when running with less "
-      echo "than 2GB of RAM. This system does not appear to have sufficient swap space."
+      echo "WARNING: Discourse requires at least 2GB of swap when running with 2GB of RAM"
+      echo "or less. This system does not appear to have sufficient swap space."
       echo
       echo "Without sufficient swap space, your site may not work properly, and future"
       echo "upgrades of Discourse may not complete successfully."
@@ -100,8 +127,16 @@ scale_ram_and_cpu() {
 
   local changelog=/tmp/changelog.$PPID
   # grab info about total system ram and physical (NOT LOGICAL!) CPU cores
-  avail_gb="$(LANG=C free -g --si | grep '^Mem:' | awk '{print $2}')"
-  avail_cores=`cat /proc/cpuinfo | grep "cpu cores" | uniq | awk '{print $4}'`
+  avail_gb=0
+  avail_cores=0
+  os_type=$(check_OS)
+  if [ $os_type == "Darwin" ]; then
+    avail_gb=$(check_osx_memory)
+    avail_cores=`sysctl hw.ncpu | awk '/hw.ncpu:/ {print $2}'`
+  else
+    avail_gb=$(check_linux_memory)
+    avail_cores=$((`awk '/cpu cores/ {print $4;exit}' /proc/cpuinfo`*`sort /proc/cpuinfo | uniq | grep -c "physical id"`))
+  fi
   echo "Found ${avail_gb}GB of memory and $avail_cores physical CPU cores"
 
   # db_shared_buffers: 128MB for 1GB, 256MB for 2GB, or 256MB * GB, max 4096MB
@@ -168,24 +203,61 @@ check_port() {
     echo "server like Apache or nginx, you will need to bind to a different port"
     echo
     echo "See https://meta.discourse.org/t/17247"
+    echo
+    echo "If you are reconfiguring an already-configured Discourse, use "
+    echo
+    echo "./launcher stop app"
+    echo
+    echo "to stop Discourse before you reconfigure it and try again."
     exit 1
   fi
 }
+
+##
+## read a variable from the config file
+##
+read_config() {
+
+  config_line=`egrep "^  #?$1:" $config_file`
+  read_config_result=`echo $config_line | awk '{print $2}'`
+  read_config_result=`echo $read_config_result | sed "s/^\([\"']\)\(.*\)\1\$/\2/g"`
+}
+
+
 
 ##
 ## prompt user for typical Discourse config file values
 ##
 ask_user_for_config() {
 
+  # NOTE: Defaults now come from standalone.yml
+
   local changelog=/tmp/changelog.$PPID
-  local hostname="discourse.example.com"
-  local developer_emails="me@example.com,you@example.com"
-  local smtp_address="smtp.example.com"
-  local smtp_port="587"
-  local smtp_user_name="postmaster@discourse.example.com"
-  local smtp_password=""
-  local letsencrypt_account_email="me@example.com"
-  local letsencrypt_status="ENTER to skip"
+  read_config "DISCOURSE_SMTP_ADDRESS"
+  local smtp_address=$read_config_result
+  read_config "DISCOURSE_DEVELOPER_EMAILS"
+  local developer_emails=$read_config_result
+  read_config "DISCOURSE_SMTP_PASSWORD"
+  local smtp_password=$read_config_result
+  read_config "DISCOURSE_SMTP_PORT"
+  local smtp_port=$read_config_result
+  read_config "DISCOURSE_SMTP_USER_NAME"
+  local smtp_user_name=$read_config_result
+  if [ "$smtp_password" = "pa$$word" ]
+  then
+      smtp_password = ""
+  fi
+  read_config "LETSENCRYPT_ACCOUNT_EMAIL"
+  local letsencrypt_account_email=$read_config_result
+  if [ $letsencrypt_account_email = "me@example.com" ]
+  then
+      local letsencrypt_status="ENTER to skip"
+  else
+    local letsencrypt_status="Enter 'OFF' to disable."
+  fi
+
+  read_config "DISCOURSE_HOSTNAME"
+  hostname=$read_config_result
 
   local new_value=""
   local config_ok="n"
@@ -206,7 +278,7 @@ ask_user_for_config() {
 
     if [ ! -z $developer_emails ]
     then
-      read -p "Email address for admin account? [$developer_emails]: " new_value
+      read -p "Email address for admin account(s)? [$developer_emails]: " new_value
       if [ ! -z $new_value ]
       then
           developer_emails=$new_value
@@ -268,7 +340,7 @@ ask_user_for_config() {
       if [ ! -z $new_value ]
       then
           letsencrypt_account_email=$new_value
-          if [ "$new_value" == "off" ]
+          if [ "${new_value,,}" = "off" ]
           then
             letsencrypt_status="ENTER to skip"
           else
@@ -321,7 +393,7 @@ ask_user_for_config() {
     update_ok="n"
   fi
 
-  sed -i -e "s/^  #DISCOURSE_SMTP_PORT:.*/  DISCOURSE_SMTP_PORT: $smtp_port/w $changelog" $config_file
+  sed -i -e "s/^  #\?DISCOURSE_SMTP_PORT:.*/  DISCOURSE_SMTP_PORT: $smtp_port/w $changelog" $config_file
   if [ -s $changelog ]
   then
     rm $changelog
@@ -330,7 +402,7 @@ ask_user_for_config() {
     update_ok="n"
   fi
 
-  sed -i -e "s/^  #DISCOURSE_SMTP_USER_NAME:.*/  DISCOURSE_SMTP_USER_NAME: $smtp_user_name/w $changelog" $config_file
+  sed -i -e "s/^  #\?DISCOURSE_SMTP_USER_NAME:.*/  DISCOURSE_SMTP_USER_NAME: $smtp_user_name/w $changelog" $config_file
   if [ -s $changelog ]
   then
     rm $changelog
@@ -339,7 +411,7 @@ ask_user_for_config() {
     update_ok="n"
   fi
 
-  sed -i -e "s/^  #DISCOURSE_SMTP_PASSWORD:.*/  DISCOURSE_SMTP_PASSWORD: \"${smtp_password/\//\\/}\"/w $changelog" $config_file
+  sed -i -e "s/^  #\?DISCOURSE_SMTP_PASSWORD:.*/  DISCOURSE_SMTP_PASSWORD: \"${smtp_password/\//\\/}\"/w $changelog" $config_file
   if [ -s $changelog ]
   then
       rm $changelog
@@ -348,9 +420,33 @@ ask_user_for_config() {
     update_ok="n"
   fi
 
-  if [ "$letsencrypt_status" != "ENTER to skip" ]
+  if [ "$letsencrypt_status" = "ENTER to skip" ]
   then
-      sed -i -e "s/^  #LETSENCRYPT_ACCOUNT_EMAIL:.*/  LETSENCRYPT_ACCOUNT_EMAIL: $letsencrypt_account_email/w $changelog" $config_file
+      echo "Let's Encrypt will not be configured"
+      local src='^  #\?- "templates\/web.ssl.template.yml"'
+      local dst='  #\- "templates\/web.ssl.template.yml"'
+      sed -i -e "s/$src/$dst/w $changelog" $config_file
+      if [ -s $changelog ]
+      then
+	  echo "web.ssl.template.yml disabled"
+      else
+        update_ok="n"
+        echo "web.ssl.template.yml NOT DISABLED--Are you using a non-standard template?"
+      fi
+      local src='^  #\?- "templates\/web.letsencrypt.ssl.template.yml"'
+      local dst='  #- "templates\/web.letsencrypt.ssl.template.yml"'
+
+      sed -i -e "s/$src/$dst/w $changelog" $config_file
+      if [ -s $changelog ]
+      then
+	      echo "letsencrypt.ssl.template.yml disabled"
+      else
+        update_ok="n"
+        echo "web.ssl.template.yml NOT DISABLED--Are you using a non-standard template?"
+      fi
+  else # enable let's encrypt
+    echo "Let's Encrypt will be enabled for $letsencrypt_account_email"
+      sed -i -e "s/^  #\?LETSENCRYPT_ACCOUNT_EMAIL:.*/  LETSENCRYPT_ACCOUNT_EMAIL: $letsencrypt_account_email/w $changelog" $config_file
       if [ -s $changelog ]
       then
         rm $changelog
@@ -358,7 +454,7 @@ ask_user_for_config() {
         echo "LETSENCRYPT_ACCOUNT_EMAIL change failed."
         update_ok="n"
       fi
-      local src='^  #- "templates\/web.ssl.template.yml"'
+      local src='^  #\?- "templates\/web.ssl.template.yml"'
       local dst='  \- "templates\/web.ssl.template.yml"'
       sed -i -e "s/$src/$dst/w $changelog" $config_file
       if [ -s $changelog ]
@@ -368,7 +464,7 @@ ask_user_for_config() {
         update_ok="n"
         echo "web.ssl.template.yml NOT ENABLED--was it on already?"
       fi
-      local src='^  #- "templates\/web.letsencrypt.ssl.template.yml"'
+      local src='^  #\?- "templates\/web.letsencrypt.ssl.template.yml"'
       local dst='  - "templates\/web.letsencrypt.ssl.template.yml"'
 
       sed -i -e "s/$src/$dst/w $changelog" $config_file
@@ -454,10 +550,9 @@ check_ports
 if [ -a $config_file ]
 then
   echo "The configuration file $config_file already exists!"
-  echo ""
-  echo "If you want to delete your old configuration file and start over:"
-  echo "rm $config_file"
-  exit 1
+  echo
+  echo ". . . reconfiguring . . ."
+  echo
 else
   cp $template_path $config_file
 fi
@@ -468,5 +563,7 @@ validate_config
 
 ##
 ## if we reach this point without exiting, OK to proceed
+## rebuild won't fail if there's nothing to rebuild and does the restart
 ##
-./launcher bootstrap $app_name && ./launcher start $app_name
+sleep 5 # In case they were too fast on the draw
+time ./launcher rebuild $app_name

--- a/samples/standalone.yml
+++ b/samples/standalone.yml
@@ -15,7 +15,7 @@ templates:
 ## Uncomment these two lines if you wish to add Lets Encrypt (https)
   #- "templates/web.ssl.template.yml"
   #- "templates/web.letsencrypt.ssl.template.yml"
- 
+
 ## which TCP/IP ports should this container expose?
 ## If you want Discourse to share a port with another webserver like Apache or nginx,
 ## see https://meta.discourse.org/t/17247 for details
@@ -29,10 +29,10 @@ params:
   ## Set db_shared_buffers to a max of 25% of the total memory.
   ## will be set automatically by bootstrap based on detected RAM, or you can override
   #db_shared_buffers: "256MB"
-  
+
   ## can improve sorting performance, but adds memory usage per-connection
   #db_work_mem: "40MB"
-  
+
   ## Which Git revision should this container use? (default: tests-passed)
   #version: tests-passed
 
@@ -46,14 +46,14 @@ env:
 
   ## TODO: The domain name this Discourse instance will respond to
   DISCOURSE_HOSTNAME: 'discourse.example.com'
-  
+
   ## Uncomment if you want the container to be started with the same
   ## hostname (-h option) as specified above (default "$hostname-$config")
   #DOCKER_USE_HOSTNAME: true
 
   ## TODO: List of comma delimited emails that will be made admin and developer
   ## on initial signup example 'user1@example.com,user2@example.com'
-  DISCOURSE_DEVELOPER_EMAILS: 'me@example.com'
+  DISCOURSE_DEVELOPER_EMAILS: 'me@example.com,you@example.com'
 
   ## TODO: The SMTP mail server used to validate new accounts and send notifications
   DISCOURSE_SMTP_ADDRESS: smtp.example.com         # required
@@ -61,7 +61,7 @@ env:
   #DISCOURSE_SMTP_USER_NAME: user@example.com      # required
   #DISCOURSE_SMTP_PASSWORD: pa$$word               # required, WARNING the char '#' in pw can cause problems!
   #DISCOURSE_SMTP_ENABLE_START_TLS: true           # (optional, default true)
-  
+
   ## If you added the Lets Encrypt template, uncomment below to get a free SSL certificate
   #LETSENCRYPT_ACCOUNT_EMAIL: me@example.com
 


### PR DESCRIPTION
This PR allows people to re-run `./discourse-setup`. This is useful to:

- Turn on Let's Encrypt after initial testing (and DNS config) **tested**
- Turn off Let's Encrypt (but why?) **tested** (see note below)
- adjust `db_shared_buffers` and `UNICORN_WORKERS if droplet is resized  **tested**
- Change Email config **tested**
- Works with my install script unchanged

### Notes

- For some reason, this PR shows changes having to do with MacOS memory checking. I didn't do that and don't understand why it's showing up here; when I look at the current version that stuff is there. Apparently I still don't understand git.
- If Let's Encrypt is disabled, the templates are commented out, but `LETSENCRYPT_ACCOUNT_EMAIL` is left configured. This means that if the script is subsequently re-run, it'll default to re-enabling Let's Encrypt. I suppose I could change this, but it seems like an edge case.
- Defaults now come from `standalone.yml` rather than this script. Future changes to `standalone.yml` could break this script (but that's always been the case).
- I added a second email to `DISCOURSE_DEVELOPER_EMAILS`; before you had to look at the comments to see how to include two addresses (and the default in this script included two addresses).
- If there is a space between email addresses in `DISCOURSE_DEVELOPER_EMAILS` they are read incorrectly by `read_config()`. It's inconvenient, but a real live human will be seeing what's there, so this seems acceptable.
- I changed the first line to `#!/usr/bin/env bash`, which should let this script run on macs. Not sure why whoever wrote the mac memory code didn't do this.
- I changed the final `./launcher bootstrap $app_name` to `time ./launcher rebuild $app_name`. Rebuild works fine when there's no image to delete. I like seeing how long things take. I'll take out the `time` if it's deemed annoying.
- I added a `sleep 5` between when changes are made and when the rebuild starts to give people a chance to ^c before it starts. Seems minimally annoying, and it can be impossible to kill `bundle` with a ^C. I'll remove this if it's deemed troublesome.
- Old script refused to run if port 80 or 443 was occupied. Now there is also a message to `./launcher stop app` and then re-run.
- When I ran this on forum.literatecomputing.com I noticed that it fixed memory settings that I'd apparently not set correctly when I set it up by hand.
- None of the error checking code (`validate_config`) was changed, so it should be pretty safe.
- I think that I checked all the cases if a given variable is commented out (as most are in `standalone.yml`) or not (as when re-running the script).