### PR TITLE
Update HTTPS configuration

### DIFF
--- a/templates/web.ssl.template.yml
+++ b/templates/web.ssl.template.yml
@@ -3,7 +3,6 @@ run:
      cmd:
        # Generate strong Diffie-Hellman parameters
        - "mkdir -p /shared/ssl/"
-       - "[ -e /shared/ssl/dhparams.pem ] || openssl dhparam -out /shared/ssl/dhparams.pem 2048"
   - replace:
      filename: "/etc/nginx/conf.d/discourse.conf"
      from: /server.+{/
@@ -20,19 +19,15 @@ run:
      to: |
        listen 443 ssl http2;
        ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-       # courtesy of https://wiki.mozilla.org/Security/Server_Side_TLS#Recommended_configurations
-       ssl_ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA;
+       ssl_ciphers EECDH+AESGCM:EECDH+AES;
        ssl_prefer_server_ciphers on;
 
        ssl_certificate /shared/ssl/ssl.crt;
        ssl_certificate_key /shared/ssl/ssl.key;
-       ssl_dhparam /shared/ssl/dhparams.pem;
 
        ssl_session_tickets off;
        ssl_session_timeout 1d;
        ssl_session_cache shared:SSL:1m;
-
-       add_header Strict-Transport-Security 'max-age=31536000'; # remember the certificate for a year and automatically connect to HTTPS for this domain
 
        gzip on;
 

--- a/templates/web.ssl.template.yml
+++ b/templates/web.ssl.template.yml
@@ -21,6 +21,7 @@ run:
        ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
        ssl_ciphers EECDH+AESGCM:EECDH+AES;
        ssl_prefer_server_ciphers on;
+       ssl_ecdh_curve secp384r1;
 
        ssl_certificate /shared/ssl/ssl.crt;
        ssl_certificate_key /shared/ssl/ssl.key;

--- a/templates/web.ssl.template.yml
+++ b/templates/web.ssl.template.yml
@@ -19,7 +19,7 @@ run:
      to: |
        listen 443 ssl http2;
        ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-       ssl_ciphers EECDH+AESGCM:EECDH+AES;
+       ssl_ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-SHA;
        ssl_prefer_server_ciphers on;
        ssl_ecdh_curve secp384r1;
 

--- a/templates/web.ssl.template.yml
+++ b/templates/web.ssl.template.yml
@@ -32,6 +32,8 @@ run:
 
        gzip on;
 
+       add_header Strict-Transport-Security 'max-age=31536000'; # remember the certificate for a year and automatically connect to HTTPS for this domain
+
        if ($http_host != $$ENV_DISCOURSE_HOSTNAME) {
           rewrite (.*) https://$$ENV_DISCOURSE_HOSTNAME$1 permanent;
        }


### PR DESCRIPTION
We should disable DH and use AES CBC/GCM + ECDH ciphers only. It's fast and secure, and widely compatible (cf https://tls.imirhil.fr/suite).
Also, HSTS should not be enabled by default, I think HSTS should be activated manually while knowing what are its consequences.