### PR TITLE
Show how to grab the proper IP address behind a reverse proxy

### DIFF
--- a/templates/web.template.yml
+++ b/templates/web.template.yml
@@ -163,6 +163,16 @@ run:
       from: /client_max_body_size.+$/
       to: client_max_body_size $upload_size ;
 
+#  Uncomment the following section for discourse_docker behind a reverse proxy
+#  - replace:
+#      filename: "/etc/nginx/conf.d/discourse.conf"
+#      from: /listen 80;/
+#      to: |
+#         listen 80;
+#         
+#         set_real_ip_from <reverse-proxy-addr>; # address or CIDR
+#         real_ip_header X-Forwarded-For;
+
   - exec:
       cmd: echo "done configuring web"
       hook: web_config


### PR DESCRIPTION
Tell nginx to trust the ip address as provided by a forwarding reverse proxy.
Use X-Forwarded-For which is set by both Apache and nginx acting as reverse proxy.

This seems to be a common source of confusion, with hundreds of posts in meta.discourse,
including terrible "solutions" - so it might be worthwhile to clearly state the minimal functional solution.