### PR TITLE
allow re-run of discourse-setup; pull defaults from standalone.yml

### DIFF
--- a/discourse-setup
+++ b/discourse-setup
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ##
 ## Make sure only root can run our script
@@ -153,7 +153,7 @@ scale_ram_and_cpu() {
   fi
   db_shared_buffers=$(( db_shared_buffers < 4096 ? db_shared_buffers : 4096 ))
 
-  sed -i -e "s/^  #db_shared_buffers:.*/  db_shared_buffers: \"${db_shared_buffers}MB\"/w $changelog" $config_file
+  sed -i -e "s/^  #\?db_shared_buffers:.*/  db_shared_buffers: \"${db_shared_buffers}MB\"/w $changelog" $config_file
   if [ -s $changelog ]
   then
     echo "setting db_shared_buffers = ${db_shared_buffers}MB"
@@ -169,7 +169,7 @@ scale_ram_and_cpu() {
   fi
   unicorn_workers=$(( unicorn_workers < 8 ? unicorn_workers : 8 ))
 
-  sed -i -e "s/^  #UNICORN_WORKERS:.*/  UNICORN_WORKERS: ${unicorn_workers}/w $changelog" $config_file
+  sed -i -e "s/^  #\?UNICORN_WORKERS:.*/  UNICORN_WORKERS: ${unicorn_workers}/w $changelog" $config_file
   if [ -s $changelog ]
   then
       echo "setting UNICORN_WORKERS = ${unicorn_workers}"
@@ -203,24 +203,62 @@ check_port() {
     echo "server like Apache or nginx, you will need to bind to a different port"
     echo
     echo "See https://meta.discourse.org/t/17247"
+    echo
+    echo "If you are reconfiguring an already-configured Discourse, use "
+    echo
+    echo "./launcher stop app"
+    echo
+    echo "to stop Discourse before you reconfigure it and try again."
     exit 1
   fi
 }
+
+##
+## read a variable from the config file
+##
+read_config() {
+
+  config_line=`egrep "^  #?$1:" $config_file`
+  read_config_result=`echo $config_line | awk '{print $2}'`
+  read_config_result=`echo $read_config_result | sed "s/^\([\"']\)\(.*\)\1\$/\2/g"`
+}
+
+
 
 ##
 ## prompt user for typical Discourse config file values
 ##
 ask_user_for_config() {
 
+  # NOTE: Defaults now come from standalone.yml
+
   local changelog=/tmp/changelog.$PPID
-  local hostname="discourse.example.com"
-  local developer_emails="me@example.com,you@example.com"
-  local smtp_address="smtp.example.com"
-  local smtp_port="587"
-  local smtp_user_name="postmaster@discourse.example.com"
-  local smtp_password=""
-  local letsencrypt_account_email="me@example.com"
-  local letsencrypt_status="ENTER to skip"
+  read_config "DISCOURSE_SMTP_ADDRESS"
+  local smtp_address=$read_config_result
+  # NOTE: if there are spaces between emails, this breaks, but a human should be paying attention
+  read_config "DISCOURSE_DEVELOPER_EMAILS"
+  local developer_emails=$read_config_result
+  read_config "DISCOURSE_SMTP_PASSWORD"
+  local smtp_password=$read_config_result
+  read_config "DISCOURSE_SMTP_PORT"
+  local smtp_port=$read_config_result
+  read_config "DISCOURSE_SMTP_USER_NAME"
+  local smtp_user_name=$read_config_result
+  if [ "$smtp_password" = "pa$$word" ]
+  then
+      smtp_password = ""
+  fi
+  read_config "LETSENCRYPT_ACCOUNT_EMAIL"
+  local letsencrypt_account_email=$read_config_result
+  if [ $letsencrypt_account_email = "me@example.com" ]
+  then
+      local letsencrypt_status="ENTER to skip"
+  else
+    local letsencrypt_status="Enter 'OFF' to disable."
+  fi
+
+  read_config "DISCOURSE_HOSTNAME"
+  hostname=$read_config_result
 
   local new_value=""
   local config_ok="n"
@@ -241,7 +279,7 @@ ask_user_for_config() {
 
     if [ ! -z $developer_emails ]
     then
-      read -p "Email address for admin account? [$developer_emails]: " new_value
+      read -p "Email address for admin account(s)? [$developer_emails]: " new_value
       if [ ! -z $new_value ]
       then
           developer_emails=$new_value
@@ -303,7 +341,7 @@ ask_user_for_config() {
       if [ ! -z $new_value ]
       then
           letsencrypt_account_email=$new_value
-          if [ "$new_value" == "off" ]
+          if [ "${new_value,,}" = "off" ]
           then
             letsencrypt_status="ENTER to skip"
           else
@@ -356,7 +394,7 @@ ask_user_for_config() {
     update_ok="n"
   fi
 
-  sed -i -e "s/^  #DISCOURSE_SMTP_PORT:.*/  DISCOURSE_SMTP_PORT: $smtp_port/w $changelog" $config_file
+  sed -i -e "s/^  #\?DISCOURSE_SMTP_PORT:.*/  DISCOURSE_SMTP_PORT: $smtp_port/w $changelog" $config_file
   if [ -s $changelog ]
   then
     rm $changelog
@@ -365,7 +403,7 @@ ask_user_for_config() {
     update_ok="n"
   fi
 
-  sed -i -e "s/^  #DISCOURSE_SMTP_USER_NAME:.*/  DISCOURSE_SMTP_USER_NAME: $smtp_user_name/w $changelog" $config_file
+  sed -i -e "s/^  #\?DISCOURSE_SMTP_USER_NAME:.*/  DISCOURSE_SMTP_USER_NAME: $smtp_user_name/w $changelog" $config_file
   if [ -s $changelog ]
   then
     rm $changelog
@@ -374,7 +412,7 @@ ask_user_for_config() {
     update_ok="n"
   fi
 
-  sed -i -e "s/^  #DISCOURSE_SMTP_PASSWORD:.*/  DISCOURSE_SMTP_PASSWORD: \"${smtp_password/\//\\/}\"/w $changelog" $config_file
+  sed -i -e "s/^  #\?DISCOURSE_SMTP_PASSWORD:.*/  DISCOURSE_SMTP_PASSWORD: \"${smtp_password/\//\\/}\"/w $changelog" $config_file
   if [ -s $changelog ]
   then
       rm $changelog
@@ -383,9 +421,33 @@ ask_user_for_config() {
     update_ok="n"
   fi
 
-  if [ "$letsencrypt_status" != "ENTER to skip" ]
+  if [ "$letsencrypt_status" = "ENTER to skip" ]
   then
-      sed -i -e "s/^  #LETSENCRYPT_ACCOUNT_EMAIL:.*/  LETSENCRYPT_ACCOUNT_EMAIL: $letsencrypt_account_email/w $changelog" $config_file
+      echo "Let's Encrypt will not be configured"
+      local src='^  #\?- "templates\/web.ssl.template.yml"'
+      local dst='  #\- "templates\/web.ssl.template.yml"'
+      sed -i -e "s/$src/$dst/w $changelog" $config_file
+      if [ -s $changelog ]
+      then
+	  echo "web.ssl.template.yml disabled"
+      else
+        update_ok="n"
+        echo "web.ssl.template.yml NOT DISABLED--Are you using a non-standard template?"
+      fi
+      local src='^  #\?- "templates\/web.letsencrypt.ssl.template.yml"'
+      local dst='  #- "templates\/web.letsencrypt.ssl.template.yml"'
+
+      sed -i -e "s/$src/$dst/w $changelog" $config_file
+      if [ -s $changelog ]
+      then
+	      echo "letsencrypt.ssl.template.yml disabled"
+      else
+        update_ok="n"
+        echo "web.ssl.template.yml NOT DISABLED--Are you using a non-standard template?"
+      fi
+  else # enable let's encrypt
+    echo "Let's Encrypt will be enabled for $letsencrypt_account_email"
+      sed -i -e "s/^  #\?LETSENCRYPT_ACCOUNT_EMAIL:.*/  LETSENCRYPT_ACCOUNT_EMAIL: $letsencrypt_account_email/w $changelog" $config_file
       if [ -s $changelog ]
       then
         rm $changelog
@@ -393,7 +455,7 @@ ask_user_for_config() {
         echo "LETSENCRYPT_ACCOUNT_EMAIL change failed."
         update_ok="n"
       fi
-      local src='^  #- "templates\/web.ssl.template.yml"'
+      local src='^  #\?- "templates\/web.ssl.template.yml"'
       local dst='  \- "templates\/web.ssl.template.yml"'
       sed -i -e "s/$src/$dst/w $changelog" $config_file
       if [ -s $changelog ]
@@ -403,7 +465,7 @@ ask_user_for_config() {
         update_ok="n"
         echo "web.ssl.template.yml NOT ENABLED--was it on already?"
       fi
-      local src='^  #- "templates\/web.letsencrypt.ssl.template.yml"'
+      local src='^  #\?- "templates\/web.letsencrypt.ssl.template.yml"'
       local dst='  - "templates\/web.letsencrypt.ssl.template.yml"'
 
       sed -i -e "s/$src/$dst/w $changelog" $config_file
@@ -489,10 +551,9 @@ check_ports
 if [ -a $config_file ]
 then
   echo "The configuration file $config_file already exists!"
-  echo ""
-  echo "If you want to delete your old configuration file and start over:"
-  echo "rm $config_file"
-  exit 1
+  echo
+  echo ". . . reconfiguring . . ."
+  echo
 else
   cp $template_path $config_file
 fi
@@ -503,5 +564,7 @@ validate_config
 
 ##
 ## if we reach this point without exiting, OK to proceed
+## rebuild won't fail if there's nothing to rebuild and does the restart
 ##
-./launcher bootstrap $app_name && ./launcher start $app_name
+sleep 5 # Just a chance to ^C in case they were too fast on the draw
+time ./launcher rebuild $app_name

--- a/samples/standalone.yml
+++ b/samples/standalone.yml
@@ -15,7 +15,7 @@ templates:
 ## Uncomment these two lines if you wish to add Lets Encrypt (https)
   #- "templates/web.ssl.template.yml"
   #- "templates/web.letsencrypt.ssl.template.yml"
- 
+
 ## which TCP/IP ports should this container expose?
 ## If you want Discourse to share a port with another webserver like Apache or nginx,
 ## see https://meta.discourse.org/t/17247 for details
@@ -29,10 +29,10 @@ params:
   ## Set db_shared_buffers to a max of 25% of the total memory.
   ## will be set automatically by bootstrap based on detected RAM, or you can override
   #db_shared_buffers: "256MB"
-  
+
   ## can improve sorting performance, but adds memory usage per-connection
   #db_work_mem: "40MB"
-  
+
   ## Which Git revision should this container use? (default: tests-passed)
   #version: tests-passed
 
@@ -46,14 +46,14 @@ env:
 
   ## TODO: The domain name this Discourse instance will respond to
   DISCOURSE_HOSTNAME: 'discourse.example.com'
-  
+
   ## Uncomment if you want the container to be started with the same
   ## hostname (-h option) as specified above (default "$hostname-$config")
   #DOCKER_USE_HOSTNAME: true
 
   ## TODO: List of comma delimited emails that will be made admin and developer
   ## on initial signup example 'user1@example.com,user2@example.com'
-  DISCOURSE_DEVELOPER_EMAILS: 'me@example.com'
+  DISCOURSE_DEVELOPER_EMAILS: 'me@example.com,you@example.com'
 
   ## TODO: The SMTP mail server used to validate new accounts and send notifications
   DISCOURSE_SMTP_ADDRESS: smtp.example.com         # required
@@ -61,7 +61,7 @@ env:
   #DISCOURSE_SMTP_USER_NAME: user@example.com      # required
   #DISCOURSE_SMTP_PASSWORD: pa$$word               # required, WARNING the char '#' in pw can cause problems!
   #DISCOURSE_SMTP_ENABLE_START_TLS: true           # (optional, default true)
-  
+
   ## If you added the Lets Encrypt template, uncomment below to get a free SSL certificate
   #LETSENCRYPT_ACCOUNT_EMAIL: me@example.com
 


### PR DESCRIPTION
This is exactly the same files I pushed last time, but this time, I'm not blamed for the stuff that tests mac memory requirements.

Reminder:  `discourse-setup` now reads `app.yml` to get initial values (the point of this is to allow re-running the script to change something rather than having to delete `app.yml` and start from scratch). The first time, `standalone.yml` is copied to `app.yml`, so defaults for the first run come from `standalone.yml`. That's why I changed DISOURSE_DEVELOPER_EMAILS in `standalone.yml`.

Reminder: I have configured my editor to make white space the way God intended when I save. I made an actual change to `standalone.yml`; this is not a case of gratuitous white space fixing.