### PR TITLE
Added environment variable for mail-receiver's smtp_should_reject support.

### DIFF
--- a/samples/mail-receiver.yml
+++ b/samples/mail-receiver.yml
@@ -26,6 +26,12 @@ env:
   ## the URL needs to have the subfolder included!
   DISCOURSE_MAIL_ENDPOINT: 'http://discourse.example.com/admin/email/handle_mail'
 
+  ## The URL of the smtp_should_reject endpoint of your Discourse forum.
+  ## This is your forum's base URL, with `/admin/email/smtp_should_reject.json`
+  ## appended.  Be careful if you're running a subfolder setup -- in that case,
+  ## the URL needs to have the subfolder included!
+  DISCOURSE_SMTP_SHOULD_REJECT_ENDPOINT: 'http://discourse.example.com/admin/email/smtp_should_reject.json'
+
   ## The master API key of your Discourse forum.  You can get this from
   ## the "API" tab of your admin panel.
   DISCOURSE_API_KEY: abcdefghijklmnop

--- a/samples/mail-receiver.yml
+++ b/samples/mail-receiver.yml
@@ -20,17 +20,10 @@ env:
   ## to use the same domain as the forum itself here.
   MAIL_DOMAIN: discourse.example.com
 
-  ## The URL of the mail processing endpoint of your Discourse forum.
-  ## This is simply your forum's base URL, with `/admin/email/handle_mail`
-  ## appended.  Be careful if you're running a subfolder setup -- in that case,
-  ## the URL needs to have the subfolder included!
-  DISCOURSE_MAIL_ENDPOINT: 'http://discourse.example.com/admin/email/handle_mail'
-
-  ## The URL of the smtp_should_reject endpoint of your Discourse forum.
-  ## This is your forum's base URL, with `/admin/email/smtp_should_reject.json`
-  ## appended.  Be careful if you're running a subfolder setup -- in that case,
-  ## the URL needs to have the subfolder included!
-  DISCOURSE_SMTP_SHOULD_REJECT_ENDPOINT: 'http://discourse.example.com/admin/email/smtp_should_reject.json'
+  ## Your forum's base URL.  Be careful if you're running a subfolder
+  ## setup -- in that case, the URL needs to have the subfolder included!
+  ## (that is, "http://example.com/forum" instead of "http://example.com")
+  DISCOURSE_BASE_URL: 'http://discourse.example.com'
 
   ## The master API key of your Discourse forum.  You can get this from
   ## the "API" tab of your admin panel.


### PR DESCRIPTION
These are the changes needed to the main Discourse container to fight backscatter. This isn't tested because I have no idea what I'm doing. :)

The discussion that led to this is here: https://meta.discourse.org/t/reducing-backscatter-in-email-interface/59974

There is also a PR for discourse/mail-receiver that relies on this PR: https://github.com/discourse/mail-receiver/pull/2

And the new API that mail-receiver will expect to call is on this PR: https://github.com/discourse/discourse/pull/4793