### PR TITLE
Update web.ratelimited.template.yml

### DIFF
--- a/templates/web.ratelimited.template.yml
+++ b/templates/web.ratelimited.template.yml
@@ -3,6 +3,7 @@ params:
   burst_per_second: 12
   reqs_per_minute: 200
   burst_per_minute: 100
+  conn_per_ip: 20
 
 run:
   - replace:
@@ -12,11 +13,14 @@ run:
        limit_req_zone $binary_remote_addr zone=flood:10m rate=$reqs_per_secondr/s;
        limit_req_zone $binary_remote_addr zone=bot:10m rate=$reqs_per_minuter/m;
        limit_req_status 429;
+       limit_conn_zone $binary_remote_addr zone=connperip:10m;
+       limit_conn_status 429;
        server {
   - replace:
      filename: "/etc/nginx/conf.d/discourse.conf"
      from: "/location @discourse {/"
      to: |
        location @discourse {
+         limit_conn connperip $conn_per_ip;
          limit_req zone=flood burst=$burst_per_second nodelay;
          limit_req zone=bot burst=$burst_per_minute nodelay;


### PR DESCRIPTION
Limit maximum connections per IP to combat HTTP/S Flood.
Normal browser doesn't allow more than 10 connections though :).