### PR TITLE
Add google chrome and NPM modules to discourse_test image

### DIFF
--- a/image/discourse_test/Dockerfile
+++ b/image/discourse_test/Dockerfile
@@ -15,6 +15,13 @@ RUN gem update bundler &&\
 
 RUN npm install -g eslint babel-eslint
 
+RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add - &&\
+    echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list &&\
+    apt-get update &&\
+    apt-get install -y google-chrome-stable
+
+RUN sudo -E -u discourse -H npm install chrome-launcher chrome-remote-interface
+
 WORKDIR /var/www/discourse
 ENV LANG en_US.UTF-8
 ENTRYPOINT sudo -E -u discourse -H ruby script/docker_test.rb


### PR DESCRIPTION
To allow qunit tests to be run using headless chrome. See https://meta.discourse.org/t/chrome-59-headless-support/62060/5?u=david_taylor