### PR TITLE
Bump node.js to version 8

### DIFF
--- a/image/base/Dockerfile
+++ b/image/base/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get -y upgrade
 RUN curl http://apt.postgresql.org/pub/repos/apt/ACCC4CF8.asc | apt-key add -
 RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -sc)-pgdg main" | \
         tee /etc/apt/sources.list.d/postgres.list
-RUN curl --silent --location https://deb.nodesource.com/setup_6.x | sudo bash -
+RUN curl --silent --location https://deb.nodesource.com/setup_8.x | sudo bash -
 RUN apt-get -y update
 RUN apt-get -y install build-essential git wget \
                        libxslt-dev libcurl4-openssl-dev \


### PR DESCRIPTION
FAO @SamSaffron following discussion here: https://meta.discourse.org/t/chrome-59-headless-support/62060/16?u=david_taylor

I have tested this by upgrading node to version 8, then running 
```
rake assets:precompile
```
in a standard production docker install. It completes without error, and the site appears to work fine.

Is there any further testing that should be done on this?