### PR TITLE
Bootstrap should respect 'run_image' key from config (if present)

### DIFF
--- a/launcher
+++ b/launcher
@@ -567,6 +567,7 @@ run_bootstrap() {
 
   set_volumes
   set_links
+  set_run_image
 
   rm -f $cidbootstrap
 
@@ -594,8 +595,9 @@ run_bootstrap() {
 
   if [[ $FAILED = "TRUE" ]]; then
     if [[ ! -z "$DEBUG" ]]; then
-      $docker_path commit `cat $cidbootstrap` $local_discourse/$config-debug || echo 'FAILED TO COMMIT'
-      echo "** DEBUG ** Maintaining image for diagnostics $local_discourse/$config-debug"
+      debug_run_image="$run_image-debug"
+      $docker_path commit `cat $cidbootstrap` "$debug_run_image" || echo 'FAILED TO COMMIT'
+      echo "** DEBUG ** Maintaining image for diagnostics '$debug_run_image'"
     fi
 
     $docker_path rm `cat $cidbootstrap`
@@ -606,7 +608,7 @@ run_bootstrap() {
 
   sleep 5
 
-  $docker_path commit `cat $cidbootstrap` $local_discourse/$config || echo 'FAILED TO COMMIT'
+  $docker_path commit `cat $cidbootstrap` "$run_image" || echo 'FAILED TO COMMIT'
   $docker_path rm `cat $cidbootstrap` && rm $cidbootstrap
 }
 


### PR DESCRIPTION
I needed more fine-grained control over image name produced by launcher's bootstrap/rebuild tasks. I noted support for optional `run_image` config key. I believe this key should also affect bootstrap to produce image with the same name, rather than default hard-coded `local_discourse/<config>`.

Alternatives:

1) Or alternatively you could maybe consider adding a separate `build_image` config key. And I would make sure it matches my `run_image`.

2) Or to make it super flexible. Optional `image_name` should be introduced which should be used everywhere and can be optionally overridden by `run_image` or `build_image` for specific tasks (and for backwards config compatibility).