### PR TITLE
Fix Vagrantfile to run discourse successfully

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ image/docker-squash.tar.gz
 image/discourse_dev/postgres.template.yml
 image/discourse_dev/redis.template.yml
 .gc-state/*
+.vagrant/

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ then run:
 This will spawn a new Ubuntu VM, install Docker, and then await your
 instructions.  You can then SSH into the VM with `vagrant ssh`, become
 `root` with `sudo -i`, and then you're right to go.  Your live git repo is
-already available at `/var/discourse`, so you can just `cd /var/discourse`
+already available at `/vagrant`, so you can just `cd /vagrant`
 and then start running `launcher`.
 
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -27,8 +27,6 @@ Vagrant.configure(2) do |config|
       apt-get update
       apt-get install -y ruby postgresql redis-server
       wget -qO- https://get.docker.com/ | sh
-
-      ln -s /vagrant /var/discourse
     EOF
   end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,7 +7,13 @@ Vagrant.configure(2) do |config|
   config.vm.define :dockerhost do |config|
     config.vm.box = "ubuntu/xenial64"
     config.vm.network "private_network", ip: ENV["DISCOURSE_DOCKER_HOST_IP"] || "192.168.33.11"
-    config.disksize.size = '50GB'  # requires vagrant-disksize plugin
+
+    if Vagrant.has_plugin?("vagrant-disksize")
+      config.disksize.size = ENV["DISCOURSE_DOCKER_HOST_DISKSIZE"] || "50GB"
+    else
+      raise "The vagrant-disksize plugin required to expand the vm disk size. " +
+            "Run 'vagrant plugin install vagrant-disksize'."
+    end
 
     if ENV["http_proxy"]
       config.vm.provision "shell", inline: <<-EOF

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,6 +6,7 @@ Vagrant.configure(2) do |config|
 
   config.vm.define :dockerhost do |config|
     config.vm.box = "ubuntu/xenial64"
+    config.vm.network "private_network", ip: ENV["DISCOURSE_DOCKER_HOST_IP"] || "192.168.33.11"
     config.disksize.size = '50GB'  # requires vagrant-disksize plugin
 
     if ENV["http_proxy"]

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -32,7 +32,6 @@ Vagrant.configure(2) do |config|
       echo "Apt::Install-Recommends 'false';" >/etc/apt/apt.conf.d/02no-recommends
       echo "Acquire::Languages { 'none' };" >/etc/apt/apt.conf.d/05no-languages
       apt-get update
-      apt-get install -y ruby postgresql redis-server
       wget -qO- https://get.docker.com/ | sh
     EOF
   end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,8 +5,8 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.define :dockerhost do |config|
-    config.vm.box = "trusty64"
-    config.vm.box_url = "http://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
+    config.vm.box = "ubuntu/xenial64"
+    config.disksize.size = '50GB'  # requires vagrant-disksize plugin
 
     if ENV["http_proxy"]
       config.vm.provision "shell", inline: <<-EOF
@@ -25,8 +25,7 @@ Vagrant.configure(2) do |config|
       echo "Apt::Install-Recommends 'false';" >/etc/apt/apt.conf.d/02no-recommends
       echo "Acquire::Languages { 'none' };" >/etc/apt/apt.conf.d/05no-languages
       apt-get update
-      apt-get -y remove --purge puppet juju
-      apt-get -y autoremove --purge
+      apt-get install -y ruby postgresql redis-server
       wget -qO- https://get.docker.com/ | sh
 
       ln -s /vagrant /var/discourse


### PR DESCRIPTION
Fixed below:

1. Update box image from trusty64 to xenial64. (Xenial is suggested [here](https://github.com/discourse/discourse/blob/master/docs/INSTALL-cloud.md))
2. Install requirements on vagrant's shell provisioning.
3. Now won't create symlink from /vagrant to /var/discourse. Vagrant's synced_folder locks the files owner and makes the discourse installation fail.

Now vagrant-disksize is required to run `vagrant up` to expand disksize of vm.