### PR TITLE
Set docker_min_version to 17.03.0

### DIFF
--- a/launcher
+++ b/launcher
@@ -56,7 +56,7 @@ fi
 
 cd "$(dirname "$0")"
 
-docker_min_version='17.06.2'
+docker_min_version='17.03.0'
 docker_rec_version='17.06.2'
 git_min_version='1.8.0'
 git_rec_version='1.8.0'


### PR DESCRIPTION
At the time of writing this, Amazon Linux AMI images come with docker
17.03. If we set it higher, then discourse instances running on those
images could not get *easily* updated.

Further motivation at https://github.com/discourse/discourse_docker/commit/ddf8c54cdde0e448526f4fa0e9f7272695db8271#commitcomment-24976766