### PR TITLE
For resumed installation fix config file backup.

### DIFF
--- a/discourse-setup
+++ b/discourse-setup
@@ -629,7 +629,7 @@ then
   DATE=`date +"%Y-%m-%d-%H%M%S"`
   BACKUP=$app_name.yml.$DATE.bak
   echo Saving old file as $BACKUP
-  cp $config_file containers/$BACKUP
+  cp $web_file containers/$BACKUP
   echo "Stopping existing container in 5 seconds or Control-C to cancel."
   sleep 5
   ./launcher stop app


### PR DESCRIPTION
When installation is aborted and later "resumed" (setup
script called a second (third, ...) ) time, following error will
show
"""
The configuration file containers/app.yml already exists!

. . . reconfiguring . . .

Saving old file as app.yml.2018-01-14-232141.bak
cp: missing destination file operand after
'containers/app.yml.2018-01-14-232141.bak'
Try 'cp --help' for more information.
"""
I believe this is due to using the wrong variable ($config_file vs
$web_file), which is fixed with this commit.