### PR TITLE
FIX discourse-setup--better sanity checking

### DIFF
--- a/discourse-setup
+++ b/discourse-setup
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $DIR
 
 ##
 ## Make sure only root can run our script
@@ -88,7 +90,7 @@ check_OS() {
 ## OS X available memory
 ##
 check_osx_memory() {
-  echo `top -l 1 | awk '/PhysMem:/ {print $2}' | sed s/G//`
+  echo `free -m | awk '/Mem:/ {print $2}'`
 }
 
 ##
@@ -274,7 +276,7 @@ check_port() {
 ##
 read_config() {
   config_line=`egrep "^  #?$1:" $web_file`
-  read_config_result=`echo $config_line | awk '{print $2}'`
+  read_config_result=`echo $config_line | awk  --field-separator=":" '{print $2}'`
   read_config_result=`echo $read_config_result | sed "s/^\([\"']\)\(.*\)\1\$/\2/g"`
 }
 
@@ -330,56 +332,66 @@ ask_user_for_config() {
     if [ ! -z $hostname ]
     then
       read -p "Hostname for your Discourse? [$hostname]: " new_value
-      if [ ! -z $new_value ]
+      if [ ! -z "$new_value" ]
       then
-          hostname=$new_value
+          hostname="$new_value"
+      fi
+      if [[ $hostname =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]
+      then
+        echo
+        echo "Discourse requires a DNS hostname. IP addresses are unsupported and will not work."
+        echo
+        hostname="discourse.example.com"
       fi
     fi
 
     if [ ! -z $developer_emails ]
     then
       read -p "Email address for admin account(s)? [$developer_emails]: " new_value
-      if [ ! -z $new_value ]
+      if [ ! -z "$new_value" ]
       then
-          developer_emails=$new_value
+          developer_emails="$new_value"
       fi
     fi
 
     if [ ! -z $smtp_address ]
     then
       read -p "SMTP server address? [$smtp_address]: " new_value
-      if [ ! -z $new_value ]
+      if [ ! -z "$new_value" ]
       then
-        smtp_address=$new_value
+        smtp_address="$new_value"
       fi
     fi
 
     if [ ! -z $smtp_port ]
     then
       read -p "SMTP port? [$smtp_port]: " new_value
-      if [ ! -z $new_value ]
+      if [ ! -z "$new_value" ]
       then
-        smtp_port=$new_value
+        smtp_port="$new_value"
       fi
     fi
 
     ##
-    ## automatically set correct user name based on common mail providers
+    ## automatically set correct user name based on common mail providers unless it's been set
     ##
-    if [ "$smtp_address" == "smtp.sparkpostmail.com" ]
+    if [ "$smtp_user_name" == "user@example.com" ]
     then
-    	smtp_user_name="SMTP_Injection"
-    fi
-    if [ "$smtp_address" == "smtp.sendgrid.net" ]
-    then
-	    smtp_user_name="apikey"
-    fi
-    if [ "$smtp_address" == "smtp.mailgun.org" ]
-    then
-	    smtp_user_name="postmaster@$hostname"
+      if [ "$smtp_address" == "smtp.sparkpostmail.com" ]
+      then
+      	smtp_user_name="SMTP_Injection"
+      fi
+      if [ "$smtp_address" == "smtp.sendgrid.net" ]
+      then
+  	    smtp_user_name="apikey"
+      fi
+      if [ "$smtp_address" == "smtp.mailgun.org" ]
+      then
+  	    smtp_user_name="postmaster@$hostname"
+      fi
     fi
 
-    if [ ! -z $smtp_user_name ]
+    if [ ! -z "$smtp_user_name" ]
     then
       read -p "SMTP user name? [$smtp_user_name]: " new_value
       if [ ! -z "$new_value" ]
@@ -389,17 +401,17 @@ ask_user_for_config() {
     fi
 
     read -p "SMTP password? [$smtp_password]: " new_value
-    if [ ! -z $new_value ]
+    if [ ! -z "$new_value" ]
     then
-        smtp_password=$new_value
+        smtp_password="$new_value"
     fi
 
     if [ ! -z $letsencrypt_account_email ]
     then
       read -p "Let's Encrypt account email? ($letsencrypt_status) [$letsencrypt_account_email]: " new_value
-      if [ ! -z $new_value ]
+      if [ ! -z "$new_value" ]
       then
-          letsencrypt_account_email=$new_value
+          letsencrypt_account_email="$new_value"
           if [ "${new_value,,}" = "off" ]
           then
             letsencrypt_status="ENTER to skip"
@@ -477,15 +489,47 @@ ask_user_for_config() {
     update_ok="n"
   fi
 
-  sed -i -e "s/^  #\?DISCOURSE_SMTP_PASSWORD:.*/  DISCOURSE_SMTP_PASSWORD: \"${smtp_password/\//\\/}\"/w $changelog" $web_file
-  if [ -s $changelog ]
+  if [[ "$smtp_password" == *"\""* ]]
   then
-      rm $changelog
-  else
-    echo "DISCOURSE_SMTP_PASSWORD change failed."
+    SLASH="BROKEN"
+    echo "========================================"
+    echo "WARNING!!!"
+    echo "Your password contains a quote (\")"
+    echo "Your SMTP Password will not be set. You will need to edit app.yml to enter it."
+    echo "========================================"
     update_ok="n"
+  else
+    SLASH="|"
+    if [[ "$smtp_password" == *"$SLASH"* ]]
+    then SLASH="+"
+      if [[ "$smtp_password" == *"$SLASH"* ]]
+      then
+        SLASH="Q"
+        if [[ "$smtp_password" == *"$SLASH"* ]]
+	then
+	  SLASH="BROKEN"
+          echo "========================================"
+          echo "WARNING!!!"
+          echo "Your password contains all available delimiters (+, |, and Q). "
+          echo "Your SMTP Password will not be set. You will need to edit app.yml to enter it."
+          echo "========================================"
+          update_ok="n"
+         fi
+       fi
+    fi
   fi
+  if [[ "$SLASH" != "BROKEN" ]]
+  then
+    sed -i -e "s${SLASH}^  #\?DISCOURSE_SMTP_PASSWORD:.*${SLASH}  DISCOURSE_SMTP_PASSWORD: \"${smtp_password}\"${SLASH}w $changelog" $web_file
 
+    if [ -s $changelog ]
+    then
+      rm $changelog
+    else
+      echo "DISCOURSE_SMTP_PASSWORD change failed."
+      update_ok="n"
+    fi
+  fi
   if [ "$letsencrypt_status" = "ENTER to skip" ]
   then
       local src='^  #\?- "templates\/web.ssl.template.yml"'
@@ -629,7 +673,7 @@ then
   DATE=`date +"%Y-%m-%d-%H%M%S"`
   BACKUP=$app_name.yml.$DATE.bak
   echo Saving old file as $BACKUP
-  cp $config_file containers/$BACKUP
+  cp $web_file containers/$BACKUP
   echo "Stopping existing container in 5 seconds or Control-C to cancel."
   sleep 5
   ./launcher stop app
@@ -640,7 +684,7 @@ else
   if [ "$data_name" == "data" ]
   then
       echo "--------------------------------------------------"
-      echo "This multisite setup is currently unsupported. Use at your own risk!"
+      echo "This two container setup is currently unsupported. Use at your own risk!"
       echo "--------------------------------------------------"
       DISCOURSE_DB_PASSWORD=`date +%s | sha256sum | base64 | head -c 20`
 

--- a/samples/standalone.yml
+++ b/samples/standalone.yml
@@ -45,6 +45,7 @@ env:
   #UNICORN_WORKERS: 3
 
   ## TODO: The domain name this Discourse instance will respond to
+  ## Required. Discourse will not work with a bare IP number.
   DISCOURSE_HOSTNAME: 'discourse.example.com'
 
   ## Uncomment if you want the container to be started with the same
@@ -56,10 +57,12 @@ env:
   DISCOURSE_DEVELOPER_EMAILS: 'me@example.com,you@example.com'
 
   ## TODO: The SMTP mail server used to validate new accounts and send notifications
-  DISCOURSE_SMTP_ADDRESS: smtp.example.com         # required
-  #DISCOURSE_SMTP_PORT: 587                        # (optional, default 587)
-  #DISCOURSE_SMTP_USER_NAME: user@example.com      # required
-  #DISCOURSE_SMTP_PASSWORD: pa$$word               # required, WARNING the char '#' in pw can cause problems!
+  # SMTP ADDRESS, username, and password are required
+  # WARNING the char '#' in SMTP password can cause problems!
+  DISCOURSE_SMTP_ADDRESS: smtp.example.com
+  #DISCOURSE_SMTP_PORT: 587
+  DISCOURSE_SMTP_USER_NAME: user@example.com
+  DISCOURSE_SMTP_PASSWORD: pa$$word
   #DISCOURSE_SMTP_ENABLE_START_TLS: true           # (optional, default true)
 
   ## If you added the Lets Encrypt template, uncomment below to get a free SSL certificate


### PR DESCRIPTION
Sorry to put all this in one PR, but I'm still a bit inept at git and I'm afraid if I did it as several they'd all conflict.

### don't guess default smtp password if they gave it already

It's only clever to guess that mailgun usually wants a particular format of username if you don't erase someone's actual username that doesn't match the format.

https://meta.discourse.org/t/smtp-user-name-does-not-save/73398/5

### allow spaces in SMTP password 

This required some changes to how the values were read from `app.yml`, and I couldn't figure out how to deal with comments in those lines (e.g., what if the password contained a `#`), so I made a few changes to `standalone.yml`. I didn't like doing that, but it seemed like the best solution.

### check if delimiter is used in password, if so try others

Tries to use `|`, `+`, or `Q` as a `sed` delimiter to deal with password with funky chars.

### fix broken cp of old config

Oops. I broke that on my last commit.

### make discourse-setup cd to /var/discourse

`discourse-setup` wouldn't work if you ran it from a different directory. If you're smart enough to enter a full path to run a script, you should be able to figure out how to `cd` to the directory when the script won't work when you start it from elsewhere, but one guy wasn't. I can't find the post in meta now.

### warn if they use IP address

If they enter an IP for hostname script resets to discourse.example.com and refuses to build.

Added a note in `standalone.yml` since I was mucking with it anyway.

### update mac memory check

Not tested, I don't have a mac, but it looks like it might. 

https://meta.discourse.org/t/macos-install-discourse-setup-bad-script/84256/7?u=pfaffman

