### PR TITLE
fix old awk, better error check, fix data.yml for 2container

### DIFF
--- a/discourse-setup
+++ b/discourse-setup
@@ -276,11 +276,15 @@ check_port() {
 ##
 read_config() {
   config_line=`egrep "^  #?$1:" $web_file`
-  read_config_result=`echo $config_line | awk  --field-separator=":" '{print $2}'`
+  read_config_result=`echo $config_line | awk  -F":" '{print $2}'`
   read_config_result=`echo $read_config_result | sed "s/^\([\"']\)\(.*\)\1\$/\2/g"`
 }
 
-
+read_default() {
+  config_line=`egrep "^  #?$1:" samples/standalone.yml`
+  read_default_result=`echo $config_line | awk  -F":" '{print $2}'`
+  read_default_result=`echo $read_config_result | sed "s/^\([\"']\)\(.*\)\1\$/\2/g"`
+}
 
 ##
 ## prompt user for typical Discourse config file values
@@ -329,7 +333,7 @@ ask_user_for_config() {
 
   while [[ "$config_ok" == "n" ]]
   do
-    if [ ! -z $hostname ]
+    if [ ! -z "$hostname" ]
     then
       read -p "Hostname for your Discourse? [$hostname]: " new_value
       if [ ! -z "$new_value" ]
@@ -345,7 +349,7 @@ ask_user_for_config() {
       fi
     fi
 
-    if [ ! -z $developer_emails ]
+    if [ ! -z "$developer_emails" ]
     then
       read -p "Email address for admin account(s)? [$developer_emails]: " new_value
       if [ ! -z "$new_value" ]
@@ -354,7 +358,7 @@ ask_user_for_config() {
       fi
     fi
 
-    if [ ! -z $smtp_address ]
+    if [ ! -z "$smtp_address" ]
     then
       read -p "SMTP server address? [$smtp_address]: " new_value
       if [ ! -z "$new_value" ]
@@ -363,7 +367,7 @@ ask_user_for_config() {
       fi
     fi
 
-    if [ ! -z $smtp_port ]
+    if [ ! -z "$smtp_port" ]
     then
       read -p "SMTP port? [$smtp_port]: " new_value
       if [ ! -z "$new_value" ]
@@ -602,21 +606,22 @@ validate_config() {
   for x in DISCOURSE_SMTP_ADDRESS DISCOURSE_SMTP_USER_NAME DISCOURSE_SMTP_PASSWORD \
            DISCOURSE_DEVELOPER_EMAILS DISCOURSE_HOSTNAME
   do
-    config_line=`grep "^  $x:" $web_file`
-    local result=$?
-    local default="example.com"
+    read_config $x
+    local result=$read_config_result
+    read_default $x
+    local default=$read_default_result
 
-    if (( result == 0 ))
+    if [ ! -z "$result" ]
     then
       if [[ "$config_line" = *"$default"* ]]
       then
-        echo "$x left at incorrect default of example.com"
+        echo "$x left at incorrect default of $default"
         valid_config="n"
       fi
       config_val=`echo $config_line | awk '{print $2}'`
       if [ -z $config_val ]
       then
-        echo "$x was left blank"
+        echo "$x was not configured"
         valid_config="n"
       fi
     else

--- a/samples/web_only.yml
+++ b/samples/web_only.yml
@@ -48,10 +48,12 @@ env:
   DISCOURSE_DEVELOPER_EMAILS: 'me@example.com,you@example.com'
 
   ## TODO: The SMTP mail server used to validate new accounts and send notifications
-  DISCOURSE_SMTP_ADDRESS: smtp.example.com         # required
-  #DISCOURSE_SMTP_PORT: 587                        # (optional, default 587)
-  #DISCOURSE_SMTP_USER_NAME: user@example.com      # required
-  #DISCOURSE_SMTP_PASSWORD: pa$$word               # required, WARNING the char '#' in pw can cause problems!
+  # SMTP ADDRESS, username, and password are required
+  # WARNING the char '#' in SMTP password can cause problems!
+  DISCOURSE_SMTP_ADDRESS: smtp.example.com
+  #DISCOURSE_SMTP_PORT: 587
+  DISCOURSE_SMTP_USER_NAME: user@example.com
+  DISCOURSE_SMTP_PASSWORD: pa$$word
   #DISCOURSE_SMTP_ENABLE_START_TLS: true           # (optional, default true)
 
   ## If you added the Lets Encrypt template, uncomment below to get a free SSL certificate


### PR DESCRIPTION
Someone found a way to install a non-GNU awk that doesn't support extended command line arguments (`-F` good `--field-separator` bad).

While I was here, I fixed `templates/web_only.yml` to match format in `standalone.yml` and improved you-have-to-change-from-default checking.