### PR TITLE
FIX: disk space check tests /shared

### DIFF
--- a/templates/postgres.template.yml
+++ b/templates/postgres.template.yml
@@ -62,7 +62,7 @@ run:
 
        if [ ! "10" = "$PG_MAJOR_OLD" ]; then
          echo Upgrading PostgreSQL from version ${PG_MAJOR_OLD} to 10
-         free_disk=$(df /var | tail -n 1 | awk '{print $4}')
+         free_disk=$(df /shared | tail -n 1 | awk '{print $4}')
          required=$(($(du -s /shared/postgres_data | awk '{print $1}') * 2))
 
          if [ "$free_disk" -lt "$required" ]; then


### PR DESCRIPTION
If `/shared` is not the same as `/`then the disk space test fails because it's testing the wrong partition.
For example, if `/` is too small you might create a separate partition for postgres so there will be enough room to update.