### PR TITLE
Make launcher work with french locale (among others)

### DIFF
--- a/launcher
+++ b/launcher
@@ -45,11 +45,11 @@ while [ ${#} -gt 0 ]; do
 done
 
 # Docker doesn't like uppercase characters, spaces or special characters, catch it now before we build everything out and then find out
-re='[A-Z/ !@#$%^&*()+~`=]'
+re='[[:upper:]/ !@#$%^&*()+~`=]'
 if [[ $config =~ $re ]];
   then
     echo
-    echo "ERROR: Config name must not contain upper case characters, spaces or special characters. Correct config name and rerun $0."
+    echo "ERROR: Config name '$config' must not contain upper case characters, spaces or special characters. Correct config name and rerun $0."
     echo
     exit 1
 fi


### PR DESCRIPTION
On several locales others than C, A-Z might match more than A to Z, due
to different collation order.

See https://unix.stackexchange.com/questions/227070/why-does-a-z-match-lowercase-letters-in-bash
for explanation.