### PR TITLE
.gitignore show some love for emacs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 shared/*
 *.swp
+*~
+\#*\#
 containers/*
 cids/*
 bin/*


### PR DESCRIPTION
Add `*~` and `#*#` to .gitignore for emacs temp/lock files