### PR TITLE
SECURITY: Add HSTS directives includeSubDomains and preload.

### DIFF
--- a/templates/web.letsencrypt.ssl.template.yml
+++ b/templates/web.letsencrypt.ssl.template.yml
@@ -89,4 +89,4 @@ hooks:
        filename: "/etc/nginx/conf.d/discourse.conf"
        from: /add_header.+/
        to: |
-         add_header Strict-Transport-Security 'max-age=63072000';
+         add_header Strict-Transport-Security 'max-age=63072000; includeSubDomains; preload';

--- a/templates/web.ssl.template.yml
+++ b/templates/web.ssl.template.yml
@@ -32,7 +32,7 @@ run:
 
        gzip on;
 
-       add_header Strict-Transport-Security 'max-age=31536000'; # remember the certificate for a year and automatically connect to HTTPS for this domain
+       add_header Strict-Transport-Security 'max-age=31536000; includeSubDomains; preload'; # remember the certificate for a year and automatically connect to HTTPS for this domain
 
        if ($http_host != $$ENV_DISCOURSE_HOSTNAME) {
           rewrite (.*) https://$$ENV_DISCOURSE_HOSTNAME$1 permanent;
@@ -42,4 +42,4 @@ run:
      from: /add_header Referrer-Policy 'no-referrer-when-downgrade';/m
      to: |
        add_header Referrer-Policy 'no-referrer-when-downgrade';
-       add_header Strict-Transport-Security 'max-age=31536000'; # remember the certificate for a year and automatically connect to HTTPS for this domain
+


### PR DESCRIPTION
To better comply with the HSTS directive, improve SSL security and add the possibility of all Disocurse sites with HTTPS to be registered in the Chrome HSTS preload list.

Also remove what I think is a unneeded ````add_header```` in ````templates/web.ssl.template.yml````