### PR TITLE
FIX: Improve Let's Encrypt email address input

### DIFF
--- a/discourse-setup
+++ b/discourse-setup
@@ -412,7 +412,7 @@ ask_user_for_config() {
 
     if [ ! -z $letsencrypt_account_email ]
     then
-      read -p "Let's Encrypt account email? ($letsencrypt_status) [$letsencrypt_account_email]: " new_value
+      read -p "Optional email address for setting up Let's Encrypt? ($letsencrypt_status) [$letsencrypt_account_email]: " new_value
       if [ ! -z "$new_value" ]
       then
           letsencrypt_account_email="$new_value"


### PR DESCRIPTION
Users unfamiliar with Let's Encrypt might think they need a Let's Encrypt account to continue with `discourse-setup`. Example: https://meta.discourse.org/t/setting-up-lets-encrypt/40709/355?u=rishabhn

### This is what the new text looks like:
![le](https://user-images.githubusercontent.com/5862206/43364469-597d0d98-9338-11e8-9a6a-80e9aeed156c.png)
