### PR TITLE
FEATURE: discourse-doctor restart existing container if possible

### DIFF
--- a/discourse-doctor
+++ b/discourse-doctor
@@ -277,12 +277,22 @@ check_docker() {
       log ". . . waiting 30 seconds for container to crank up. . . "
       sleep 30
     else
-      log "$app_name still not running!"
+      log "Failed to rebuild $app_name."
       # check_ip_match checks if curl to $DISCOURSE_HOSTNAME gets to this server
       # It works only if ports 80 and 443 are free
       check_ip_match $DISCOURSE_HOSTNAME
       log "You should probably remove any non-standard plugins and rebuild."
       NO_CONTAINER='y'
+      log "Attempting to restart existing container. . . "
+      ./launcher start $app_name 2>&1 | tee -a $LOG_FILE
+      docker ps| tail -n +2 > /tmp/$UUID-docker.txt
+      if grep $app_name /tmp/$UUID-docker.txt
+      then
+        log "Restarted the container."
+        NO_CONTAINER='n'
+      else
+        log "Failed to restart the container."
+      fi
     fi
   fi
 }

--- a/discourse-doctor
+++ b/discourse-doctor
@@ -270,7 +270,7 @@ check_docker() {
     # too hard to pass STDERR of ./launcher to log()
     ./launcher rebuild $app_name 2>&1 | tee -a $LOG_FILE
     log "==================== END REBUILD LOG ===================="
-    docker ps| tail -n +2 > /tmp/$UUID-docker.txt
+    docker ps | tail -n +2 > /tmp/$UUID-docker.txt
     if grep $app_name /tmp/$UUID-docker.txt
     then
       log -e "\nDiscourse container $app_name is now running."
@@ -285,7 +285,7 @@ check_docker() {
       NO_CONTAINER='y'
       log "Attempting to restart existing container. . . "
       ./launcher start $app_name 2>&1 | tee -a $LOG_FILE
-      docker ps| tail -n +2 > /tmp/$UUID-docker.txt
+      docker ps | tail -n +2 > /tmp/$UUID-docker.txt
       if grep $app_name /tmp/$UUID-docker.txt
       then
         log "Restarted the container."


### PR DESCRIPTION
If `discourse-doctor` finds that the container isn't running, it attempts a rebuild. BUT NOW, if the rebuild fails, it attempts to re-start an existing container. To the uninitiated (who discourse-doctor is designed for) re-starting an existing container is a mystery.