### PR TITLE
FEATURE: launcher suggests discourse-doctor on fail

### DIFF
--- a/launcher
+++ b/launcher
@@ -458,6 +458,7 @@ run_stop() {
        )
      else
        echo "$config was not started !"
+       echo "./discourse-doctor may help diagnose the problem."
        exit 1
   fi
 }
@@ -618,7 +619,8 @@ run_bootstrap() {
 
     $docker_path rm `cat $cidbootstrap`
     rm $cidbootstrap
-    echo "** FAILED TO BOOTSTRAP ** please scroll up and look for earlier error messages, there may be more than one"
+    echo "** FAILED TO BOOTSTRAP ** please scroll up and look for earlier error messages, there may be more than one."
+    echo "./discourse-doctor may help diagnose the problem."
     exit 1
   fi
 


### PR DESCRIPTION
If launcher fails to bootstrap or to start the container, it suggests 

    ./discourse-doctor may help diagnose the problem.

Probably one for @SamSaffron  to have a look at. Adding two `echo`s seems safe, but I'd really hate to break `./launcher`. 