### PR TITLE
FEATURE: Added checks to disable the Transparent Hugepages (THP) setting to the doctor

### DIFF
--- a/discourse-doctor
+++ b/discourse-doctor
@@ -335,6 +335,26 @@ initialize_log_file() {
   log -e "OS: $(uname -a)\n\n"
 }
 
+check_transparent_hugepages_config() {
+  log -e "\n==================== TRANSPARENT HUGEPAGES (THP) SETTING TEST ===================="
+  CMD=$(cat /sys/kernel/mm/transparent_hugepage/enabled)
+  if echo $CMD | grep -q "\[never\]"; then
+    log "The Transparent Hugepages (THP) setting is already disabled on your server. Test skipped."
+  else
+    log "The Transparent Hugepages (THP) setting is enabled on your server."
+    log "This can cause memory to bloat."
+    read -p "Would you like me to disable it? (y/n) " var
+    
+    if [ $var = y ] || [ $var = Y ] ; then
+      echo never >/sys/kernel/mm/transparent_hugepage/enabled
+      log "The Transparent Hugepages (THP) setting is now disabled on your server."
+      log "You will see better memory usage and performance."
+    else
+      log "You entered $var. Test skipped."
+    fi
+  fi
+}
+
 ##
 ## END FUNCTION DECLARATION
 ##
@@ -351,4 +371,5 @@ check_if_hostname_resolves_here
 check_disk_and_memory
 check_email
 clean_up_log_file
+check_transparent_hugepages_config
 print_done


### PR DESCRIPTION
- [x] Ensures that `/sys/kernel/mm/transparent_hugepage/enabled` is set to `never` after asking user
~~- [ ] After getting permission to disable THP, ensure that it is disabled at startup in the future~~

@SamSaffron 
This works really well,
~~I just have to add `echo never >/sys/kernel/mm/transparent_hugepage/enabled` to be run at boot.
Adding to `rc.local` or `cron` with bash seems a bit hacky, I'm looking for a better way to do it.~~

---

My implementation isn't the cleanest but I think it works well.
I spent a lot of time trying to use the code below, but it just wouldn't work :disappointed: 
```
if test -f /sys/kernel/mm/transparent_hugepage/enabled; then
   echo never > /sys/kernel/mm/transparent_hugepage/enabled
```

