### PR TITLE
Remove unneeded "restricted" Ubuntu repository

### DIFF
--- a/image/base/Dockerfile
+++ b/image/base/Dockerfile
@@ -12,9 +12,9 @@ RUN echo 2.0.`date +%Y%m%d` > /VERSION
 
 RUN apt-get update && apt-get install -y lsb-release sudo curl
 RUN echo "debconf debconf/frontend select Teletype" | debconf-set-selections
-RUN echo "deb http://archive.ubuntu.com/ubuntu $(lsb_release -sc) main restricted universe" > /etc/apt/sources.list
-RUN echo "deb http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-updates main restricted universe" >> /etc/apt/sources.list
-RUN echo "deb http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-security main restricted universe" >> /etc/apt/sources.list
+RUN echo "deb http://archive.ubuntu.com/ubuntu $(lsb_release -sc) main universe" > /etc/apt/sources.list
+RUN echo "deb http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-updates main universe" >> /etc/apt/sources.list
+RUN echo "deb http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-security main universe" >> /etc/apt/sources.list
 RUN apt-get update && apt-get -y install fping
 RUN sh -c "fping proxy && echo 'Acquire { Retries \"0\"; HTTP { Proxy \"http://proxy:3128\";}; };' > /etc/apt/apt.conf.d/40proxy && apt-get update || true"
 RUN apt-get -y install software-properties-common


### PR DESCRIPTION
This change removes the `restricted` Ubuntu repository from the base image, because it could install non-free software. It is unneeded, as no non-free software is installed by the base Docker file.

The Docker image successfully compiled without any errors from `apt`. Note that I tried also tried to remove the `universe` repo, but it is currently needed for the `fping` package, so this commit leaves that untouched.

I ran the automated tests for this change, but they timed out early, possibly due to slow private key generation steps.

[Discussion on meta.discourse.org](https://meta.discourse.org/t/docker-image-includes-unneeded-ubuntu-restricted-non-free-repo/88931?u=sudoman)