### PR TITLE
rubygems still use .org

### DIFF
--- a/templates/web.china.template.yml
+++ b/templates/web.china.template.yml
@@ -2,9 +2,9 @@ hooks:
   before_web:
     - exec:
        cmd:
-         - gem sources --add https://gems.ruby-china.com/ --remove https://rubygems.com/
+         - gem sources --add https://gems.ruby-china.com/ --remove https://rubygems.org/
 
   before_bundle_exec:
     - exec:
        cmd:
-         - su discourse -c 'bundle config mirror.https://rubygems.com https://gems.ruby-china.com/'
+         - su discourse -c 'bundle config mirror.https://rubygems.org https://gems.ruby-china.com/'


### PR DESCRIPTION
`ruby-china` mirror changed to `.com` due to ICP Filing complications.
The original `rubygems` source still uses `.org`, though

My bad, sorry I missed this in https://github.com/discourse/discourse_docker/pull/406. /cc @scavin @SamSaffron 