### PR TITLE
Use rm -rf in remove-old-socket

### DIFF
--- a/templates/web.socketed.template.yml
+++ b/templates/web.socketed.template.yml
@@ -10,7 +10,7 @@ run:
      chmod: "+x"
      contents: |
         #!/bin/bash
-        rm -f /shared/nginx.http*.sock
+        rm -rf /shared/nginx.http*.sock
   - replace:
      filename: "/etc/nginx/conf.d/discourse.conf"
      from: /listen 80;/


### PR DESCRIPTION
In some cases, the leftover socket is actually a directory.