### PR TITLE
Configure the nginx resolver to eliminate name resolution on startup

### DIFF
--- a/templates/web.template.yml
+++ b/templates/web.template.yml
@@ -56,6 +56,15 @@ run:
         [ ! -z "$COMPRESS_BROTLI" ] && sed -i "s/. brotli/  brotli/" /etc/nginx/conf.d/discourse.conf || sed -i "s/. brotli/# brotli/" /etc/nginx/conf.d/discourse.conf
 
   - file:
+     path: /etc/runit/1.d/configure-nginx-resolver
+     chmod: "+x"
+     contents: |
+        #!/bin/bash
+        nameservers=`egrep '^\s*nameserver\s+' /etc/resolv.conf | sed -e 's/^\s*nameserver\s*//g'`
+        nameservers_one_line=`echo $nameservers`
+        echo "resolver $nameservers_one_line;" > /etc/nginx/conf.d/000-resolver.conf
+
+  - file:
      path: /etc/service/unicorn/run
      chmod: "+x"
      contents: |


### PR DESCRIPTION
This is desirable for two reasons:

1. As reported in a [bug topic](https://meta.discourse.org/t/restarting-container-when-internet-is-down-causes-discourse-to-fail/42615/4), if nginx resolves Internet hostnames on startup, then the container won't run if the host is disconnected from the Internet at startup.

2. If the IP address of the avatars.discourse.org hostname ever changes, then nginx will end p using an old IP address until the administrator restarts the container, unless we use dynamic resolution.

This commit adds a simple script to extract the nameserver IP addresses from `/etc/resolv.conf` and write them to an nginx configuration file. The configuration change for Discourse itself will be in a separate PR in the main Discourse repository.