### PR TITLE
Use latest docker garbage collector

### DIFF
--- a/scripts/docker-gc
+++ b/scripts/docker-gc
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v /var/lib/docker-gc:/var/lib/docker-gc -v /etc:/etc samsaffron/docker-gc
+docker run --rm --privileged -v /var/run/docker.sock:/var/run/docker.sock -v /etc:/etc:ro spotify/docker-gc
 


### PR DESCRIPTION
This patch configures discourse_docker to use the latest docker_gc version as the version we use was last updated 3 years ago and (in my opinion) a bit slow compared with this version.