### PR TITLE
Build Redis from source.

### DIFF
--- a/image/base/Dockerfile
+++ b/image/base/Dockerfile
@@ -38,7 +38,7 @@ RUN sed -i -e 's/start -q anacron/anacron -s/' /etc/cron.d/anacron
 RUN sed -i.bak 's/$ModLoad imklog/#$ModLoad imklog/' /etc/rsyslog.conf
 RUN dpkg-divert --local --rename --add /sbin/initctl
 RUN sh -c "test -f /sbin/initctl || ln -s /bin/true /sbin/initctl"
-RUN apt-get -y install redis-server haproxy openssh-server
+RUN apt-get -y install haproxy openssh-server
 RUN cd / &&\
     apt-get -y install runit monit socat &&\
     mkdir -p /etc/runit/1.d &&\
@@ -76,6 +76,9 @@ RUN gem update --system
 RUN gem install bundler --force &&\
     rm -rf /usr/local/share/ri/2.5.2/system &&\
     cd / && git clone https://github.com/discourse/pups.git
+
+ADD install-redis /tmp/install-redis
+RUN /tmp/install-redis
 
 ADD install-imagemagick /tmp/install-imagemagick
 RUN /tmp/install-imagemagick
@@ -128,7 +131,7 @@ ADD boot /sbin/boot
 ADD cron /etc/service/cron/run
 ADD rsyslog /etc/service/rsyslog/run
 ADD cron.d_anacron /etc/cron.d/anacron
-
+ADD redis /etc/service/redis/run
 
 # Discourse specific bits
 RUN useradd discourse -s /bin/bash -m -U &&\

--- a/image/base/install-redis
+++ b/image/base/install-redis
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -e
+REDIS_VERSION=5.0.3
+REDIS_DOWNLOAD_SHA=e290b4ddf817b26254a74d5d564095b11f9cd20d8f165459efa53eb63cd93e02
+
+cd /tmp
+
+# Prepare Redis source.
+wget http://download.redis.io/releases/redis-$REDIS_VERSION.tar.gz
+echo "$REDIS_DOWNLOAD_SHA redis-$REDIS_VERSION.tar.gz" | sha256sum -c -
+tar zxf redis-$REDIS_VERSION.tar.gz
+cd redis-$REDIS_VERSION
+
+# Building and installing binaries.
+make && make install PREFIX=/usr
+
+# Add `redis` user and group.
+adduser --system --home /var/lib/redis --quiet --group redis || true
+
+# Configure Redis.
+mkdir -p /etc/redis
+mkdir -p /var/lib/redis
+mkdir -p /var/log/redis
+cp /tmp/redis-$REDIS_VERSION/redis.conf /etc/redis
+
+chown -R redis:redis /var/lib/redis
+chmod 750 /var/lib/redis
+
+chown -R redis:redis /var/log/redis
+chmod 750 /var/log/redis
+
+# Clean up.
+cd / && rm -rf /tmp/redis*

--- a/image/base/redis
+++ b/image/base/redis
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+
+RUNDIR=/var/run/redis
+PIDFILE=/var/run/redis/redis-server.pid
+
+mkdir -p $RUNDIR
+touch $PIDFILE
+chown -R redis:redis $RUNDIR
+chmod 755 $RUNDIR
+
+exec chpst -u redis /usr/bin/redis-server /etc/redis/redis.conf


### PR DESCRIPTION
* Official redis package ([redis-server](https://packages.ubuntu.com/xenial/misc/redis-server)) is 3.0.6.
* By building from source we have a better control over the version.
* These changes are upgrading Redis to 5.0.3.