### PR TITLE
merge docker_args with user_args for launcher file

### DIFF
--- a/launcher
+++ b/launcher
@@ -626,7 +626,7 @@ run_start() {
 
      set -x
      $docker_path run --shm-size=512m $links $attach_on_run $restart_policy "${env[@]}" "${labels[@]}" -h "$hostname" \
-        -e DOCKER_HOST_IP="$docker_ip" --name $config -t $ports $volumes $mac_address $user_args \
+        -e DOCKER_HOST_IP="$docker_ip" --name $config -t "${ports[@]}" $volumes $mac_address $user_args \
         $run_image $boot_command
 
    )

--- a/launcher
+++ b/launcher
@@ -450,6 +450,8 @@ RUBY
       echo "YAML syntax error. Please check your containers/*.yml config files."
       exit 1
     fi
+
+   merge_user_args
 }
 
 if [ -z $docker_path ]; then
@@ -554,6 +556,15 @@ set_boot_command() {
   fi
 }
 
+merge_user_args() {
+  docker_args=`cat $config_file | $docker_path run $user_args --rm -i -a stdout -a stdin $image ruby -e \
+          "require 'yaml'; puts YAML.load(STDIN.readlines.join)['docker_args']"`
+
+  if [[ $docker_args ]]; then
+    user_args="$user_args $docker_args"
+  fi 
+}
+
 run_start() {
 
    existing=`$docker_path ps | awk '{ print $1, $(NF) }' | grep " $config$" | awk '{ print $1 }'`
@@ -576,9 +587,6 @@ run_start() {
    fi
 
    host_run
-
-   docker_args=`cat $config_file | $docker_path run $user_args --rm -i -a stdout -a stdin $image ruby -e \
-          "require 'yaml'; puts YAML.load(STDIN.readlines.join)['docker_args']"`
 
    set_template_info
    set_volumes
@@ -618,7 +626,7 @@ run_start() {
 
      set -x
      $docker_path run --shm-size=512m $links $attach_on_run $restart_policy "${env[@]}" "${labels[@]}" -h "$hostname" \
-        -e DOCKER_HOST_IP="$docker_ip" --name $config -t "${ports[@]}" $volumes $mac_address $docker_args $user_args \
+        -e DOCKER_HOST_IP="$docker_ip" --name $config -t $ports $volumes $mac_address $user_args \
         $run_image $boot_command
 
    )


### PR DESCRIPTION
see https://meta.discourse.org/t/starting-discourse-on-a-specific-docker-network/49401/4

I took a best guess and added a merging function call to the end of set_template_info because it looked like that was called at the start of a function whenever something config-file-related was used.