### PR TITLE
Use docker system prune

### DIFF
--- a/launcher
+++ b/launcher
@@ -226,7 +226,7 @@ check_prereqs() {
     echo
     if [[ $REPLY =~ ^[Yy]$ ]]
     then
-      docker system prune
+      docker system prune -f
       echo "If the cleanup was successful, you may try again now"
     fi
     exit 1
@@ -468,7 +468,7 @@ fi
       space=$(df /var/lib/docker | awk '{ print $4 }' | grep -v Available)
       echo "Starting Cleanup (bytes free $space)"
 
-      STATE_DIR=./.gc-state scripts/docker-gc
+      docker system prune -f
 
       rm -f shared/standalone/log/var-log/*.txt
 

--- a/scripts/docker-gc
+++ b/scripts/docker-gc
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v /var/lib/docker-gc:/var/lib/docker-gc -v /etc:/etc samsaffron/docker-gc
-


### PR DESCRIPTION
This commit updates the repository to use Docker's built in method of
cleaning up old containers per Sam Saffron's request in #416. 

The cleanup command and 1 instance where `docker system prune` was already used will call `docker system prune -f` (don't prompt the user for a yes/no to trigger the command) as the launcher script will prompt the user for confirmation before running `docker system prune`.

P.S: If you are working for Discourse and have write access to this repo feel free to add the `-a` (remove stopped containers as well as all unused images) option to where I've used `docker system prune`. I want your opinon on this so if you want/need it then feel free to commit that to my fork before merging (I'm fine with that).