### PR TITLE
Bump acme.sh to 2.8.0

### DIFF
--- a/templates/web.letsencrypt.ssl.template.yml
+++ b/templates/web.letsencrypt.ssl.template.yml
@@ -10,7 +10,7 @@ hooks:
 
     - exec:
        cmd:
-         - cd /root && git clone https://github.com/Neilpang/acme.sh.git && cd /root/acme.sh && git reset --hard ac0970abbad9390f9ab5e99f7f4043502d40eafa
+         - cd /root && git clone https://github.com/Neilpang/acme.sh.git && cd /root/acme.sh && git reset --hard f62a4a0c0ccf6cd73b5746dd8b8790ce3c512833
          - touch /var/spool/cron/crontabs/root
          - install -d -m 0755 -g root -o root $LETSENCRYPT_DIR
          - cd /root/acme.sh && LE_WORKING_DIR="${LETSENCRYPT_DIR}" ./acme.sh --install --log "${LETSENCRYPT_DIR}/acme.sh.log"


### PR DESCRIPTION
Bump the acme.sh script (Let's Encrypt) version for more API options, ACME v2 wildcard certs and bug fixes