### PR TITLE
Update ImageMagick to 7.0.8-42

### DIFF
--- a/image/base/install-imagemagick
+++ b/image/base/install-imagemagick
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -o errexit
 
-IMAGE_MAGICK_VERSION="7.0.8-41"
+IMAGE_MAGICK_VERSION="7.0.8-42"
 LIBPNG_VERSION="1.6.36"
 
 PREFIX=/usr/local


### PR DESCRIPTION
This version of ImageMagick (7.0.8-41) is not available anymore. Accessing https://imagemagick.org/download/ImageMagick-7.0.8-41.tar.gz will return a 404. So, building a Docker image with that version will return an error as well.