### PR TITLE
Correct bash path

### DIFF
--- a/launcher
+++ b/launcher
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 usage () {
   echo "Usage: launcher COMMAND CONFIG [--skip-prereqs] [--docker-args STRING]"


### PR DESCRIPTION
We were using an absolute path, rather than the default path for the environment.