### PR TITLE
discourse_test image: include official plugins and their gems

### DIFF
--- a/image/discourse_test/Dockerfile
+++ b/image/discourse_test/Dockerfile
@@ -15,8 +15,7 @@ RUN gem update bundler --force &&\
       chown -R discourse . &&\
       rm -fr .bundle &&\
       sudo -u discourse git pull &&\
-      sudo -u discourse bundle install --standalone --jobs=4 &&\
-      chown -R discourse /var/run/postgresql
+      sudo -u discourse bundle install --standalone --jobs=4
 
 RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add - &&\
     echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list &&\
@@ -26,6 +25,10 @@ RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo ap
     apt-get install -y libgconf-2-4 google-chrome-stable yarn nodejs &&\
     npm install -g eslint babel-eslint &&\
     cd /var/www/discourse && sudo -E -u discourse -H yarn install
+
+RUN cd /var/www/discourse && sudo -E -u discourse -H bundle exec rake plugin:install_all_official &&\
+    sudo -E -u discourse -H bundle exec rake plugin:install_all_gems &&\
+    chown -R discourse /var/run/postgresql
 
 WORKDIR /var/www/discourse
 ENV LANG en_US.UTF-8


### PR DESCRIPTION
To speed up plugin ruby and js test builds, it's useful to have the official plugins and their gems already in the test image. 