### PR TITLE
Repo key should be downloaded securely

### DIFF
--- a/image/base/Dockerfile
+++ b/image/base/Dockerfile
@@ -20,7 +20,7 @@ RUN sh -c "fping proxy && echo 'Acquire { Retries \"0\"; HTTP { Proxy \"http://p
 RUN apt-get -y install software-properties-common
 RUN apt-mark hold initscripts
 RUN apt-get -y upgrade
-RUN curl http://apt.postgresql.org/pub/repos/apt/ACCC4CF8.asc | apt-key add -
+RUN curl https://apt.postgresql.org/pub/repos/apt/ACCC4CF8.asc | apt-key add -
 RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -sc)-pgdg main" | \
         tee /etc/apt/sources.list.d/postgres.list
 RUN curl --silent --location https://deb.nodesource.com/setup_10.x | sudo bash -


### PR DESCRIPTION
PostgreSQL repository public key should be downloaded using a secure connection, otherwise anyone performing MITM attack can do bad things.