### PR TITLE
fallocate swapfile instead of dd

### DIFF
--- a/discourse-setup
+++ b/discourse-setup
@@ -139,7 +139,7 @@ check_disk_and_memory() {
       ## derived from https://meta.discourse.org/t/13880
       ##
       install -o root -g root -m 0600 /dev/null /swapfile
-      dd if=/dev/zero of=/swapfile bs=1k count=2048k
+      fallocate -l 2G /swapfile
       mkswap /swapfile
       swapon /swapfile
       echo "/swapfile       swap    swap    auto      0       0" | tee -a /etc/fstab


### PR DESCRIPTION
On the plus side, this will be an order of magnitude or three faster.

On the minus side, this may cause more headache with CentOS because it purportedly doesn't work with xfs -- https://bugzilla.redhat.com/show_bug.cgi?id=1129205 -- which is the Redhat default now.