### PR TITLE
Drop CBC Cipher Support & ez to use uploadsize change

### DIFF
--- a/templates/dropcbccipher.template.yml
+++ b/templates/dropcbccipher.template.yml
@@ -1,0 +1,5 @@
+run:
+  - replace:
+     filename: "/etc/nginx/conf.d/discourse.conf"
+     from: "ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-SHA"
+     to: ""

--- a/templates/uploadsize.template.yml
+++ b/templates/uploadsize.template.yml
@@ -1,0 +1,5 @@
+run:
+  - replace:
+     filename: "/etc/nginx/conf.d/discourse.conf"
+     from: "client_max_body_size 10m"
+     to: "client_max_body_size 100m"


### PR DESCRIPTION
Hi, 

theese two small templates drop support for CBC cipher
See: https://blog.qualys.com/technology/2019/04/22/zombie-poodle-and-goldendoodle-vulnerabilities

And enable an easy to use change of the nginx upload size.

