### PR TITLE
Drop CBC Support & use X25519 Curve

### DIFF
--- a/templates/dropcbccipher.template.yml
+++ b/templates/dropcbccipher.template.yml
@@ -1,0 +1,5 @@
+run:
+  - replace:
+     filename: "/etc/nginx/conf.d/discourse.conf"
+     from: "ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-SHA"
+     to: ""

--- a/templates/uploadsize.template.yml
+++ b/templates/uploadsize.template.yml
@@ -1,0 +1,5 @@
+run:
+  - replace:
+     filename: "/etc/nginx/conf.d/discourse.conf"
+     from: "client_max_body_size 10m"
+     to: "client_max_body_size 100m"

--- a/templates/web.ssl.template.yml
+++ b/templates/web.ssl.template.yml
@@ -19,9 +19,9 @@ run:
      to: |
        listen 443 ssl http2;
        ssl_protocols TLSv1.2;
-       ssl_ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-SHA;
+       ssl_ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384;
        ssl_prefer_server_ciphers on;
-       ssl_ecdh_curve secp384r1:prime256v1;
+       ssl_ecdh_curve X25519:secp384r1:prime256v1;
 
        ssl_certificate /shared/ssl/ssl.crt;
        ssl_certificate_key /shared/ssl/ssl.key;


### PR DESCRIPTION
Drop CBC see: https://blog.qualys.com/technology/2019/04/22/zombie-poodle-and-goldendoodle-vulnerabilities

Use X25519 instead of secp see: https://safecurves.cr.yp.to/