### PR TITLE
Update web.ssl.template.yml - drop cbc & use X25519 curve

### DIFF
--- a/templates/web.ssl.template.yml
+++ b/templates/web.ssl.template.yml
@@ -19,9 +19,9 @@ run:
      to: |
        listen 443 ssl http2;
        ssl_protocols TLSv1.2;
-       ssl_ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-SHA;
+       ssl_ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384;
        ssl_prefer_server_ciphers on;
-       ssl_ecdh_curve secp384r1:prime256v1;
+       ssl_ecdh_curve X25519:secp384r1:prime256v1;
 
        ssl_certificate /shared/ssl/ssl.crt;
        ssl_certificate_key /shared/ssl/ssl.key;


### PR DESCRIPTION
X25519 see: https://safecurves.cr.yp.to/
drop cbc see: https://blog.qualys.com/technology/2019/04/22/zombie-poodle-and-goldendoodle-vulnerabilities