### PR TITLE
Make merge_user_args idempotent

### DIFF
--- a/launcher
+++ b/launcher
@@ -25,7 +25,13 @@ usage () {
 
 command=$1
 config=$2
+
+# user_args_argv is assigned once when the argument vector is parsed.
+user_args_argv=""
+# user_args is mutable:  its value may change when templates are parsed.
+# Superset of user_args_argv.
 user_args=""
+
 user_run_image=""
 
 if [[ $command == "run" ]]; then
@@ -44,7 +50,8 @@ while [ ${#} -gt 0 ]; do
     SKIP_MAC_ADDRESS="1"
     ;;
   --docker-args)
-    user_args="$2"
+    user_args_argv="$2"
+    user_args="$user_args_argv"
     shift
     ;;
   --run-image)
@@ -546,7 +553,7 @@ merge_user_args() {
           "require 'yaml'; puts YAML.load(STDIN.readlines.join)['docker_args']"`
 
   if [[ -n "$docker_args" ]]; then
-    user_args="$user_args $docker_args"
+    user_args="$user_args_argv $docker_args"
   fi
 }
 


### PR DESCRIPTION
The `merge_user_args` function may be called more than once within a single `launcher` process.  e.g.: on `launcher rebuild ...`:

```
[main] -> rebuild -> run_bootstrap -> set_template_info -> merge_user_args
[main] -> rebuild -> run_start     -> set_template_info -> merge_user_args
```

If the user had included a `docker_args` map key in their container YAML, the `user_args` global would be incorrectly populated with duplicate docker CLI flags.

https://meta.discourse.org/t/-/123696

Fixes a regression introduced in https://meta.discourse.org/t/-/49401/9