### PR TITLE
Fixup: use latest image discourse/base:release

### DIFF
--- a/launcher
+++ b/launcher
@@ -88,7 +88,7 @@ git_rec_version='1.8.0'
 config_file=containers/"$config".yml
 cidbootstrap=cids/"$config"_bootstrap.cid
 local_discourse=local_discourse
-image="discourse/base:2.0.20190625-0946"
+image="discourse/base:release"
 docker_path=`which docker.io 2> /dev/null || which docker`
 git_path=`which git`
 


### PR DESCRIPTION
Instead of using an old outdate image this script should use the latest.
