### PR TITLE
FIX: import mysql-dep template, use maria (no mysql available)

### DIFF
--- a/templates/import/mysql-dep.template.yml
+++ b/templates/import/mysql-dep.template.yml
@@ -9,5 +9,5 @@ hooks:
         cd: $home
         cmd:
           - echo "gem 'mysql2'" >> Gemfile
-          - apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y libmysqlclient-dev
+          - apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y libmariadb-dev
           - su discourse -c 'bundle install --no-deployment --path vendor/bundle --jobs 4 --without test development'


### PR DESCRIPTION
Debian seems not to support mysql anymore. I guess it's not Free enough. A quick search doesn't find an announcement, but `apt install libmysqlclient-dev` suggests using maria.

Arguably this template should be renamed, but that might be more confusing.