### PR TITLE
Change check for linux memory

### DIFF
--- a/discourse-setup
+++ b/discourse-setup
@@ -114,7 +114,8 @@ check_osx_memory() {
 ## Linux available memory
 ##
 check_linux_memory() {
-  echo `free -g --si | awk ' /Mem:/  {print $2} '`
+  ## use MB and round up...some VMs come in around 995MB and that's darn near "close enough"
+  echo `free -m --si | awk ' /Mem:/ {printf "%.0f", $2/1000}'`
 }
 
 ##

--- a/discourse-setup
+++ b/discourse-setup
@@ -114,8 +114,15 @@ check_osx_memory() {
 ## Linux available memory
 ##
 check_linux_memory() {
-  ## use MB and round up...some VMs come in around 995MB and that's darn near "close enough"
-  echo `free -m --si | awk ' /Mem:/ {printf "%.0f", $2/1000}'`
+  ## some VMs report just under 1GB of RAM, so
+  ## make an exception and allow those with more
+  ## than 989MB
+  mem=`free -m --si | awk ' /Mem:/ {print $2}'`
+  if [ "$mem" -ge 990 -a "$mem" -lt 1000 ]; then
+    echo 1
+  else
+    echo `free -g --si | awk ' /Mem:/  {print $2} '`
+  fi
 }
 
 ##


### PR DESCRIPTION
Some VMs clock in at *just under* 1GB, so checking for 1GB of RAM will miss these.  Instead, check for MB, divide by 1000 and round up.