### PR TITLE
FIX: mysql-dep template--un-freeze the Gemfile

### DIFF
--- a/templates/import/mysql-dep.template.yml
+++ b/templates/import/mysql-dep.template.yml
@@ -10,4 +10,5 @@ hooks:
         cmd:
           - echo "gem 'mysql2'" >> Gemfile
           - apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y libmariadb-dev
+          - su discourse -c 'bundle config unset deployment'
           - su discourse -c 'bundle install --no-deployment --path vendor/bundle --jobs 4 --without test development'


### PR DESCRIPTION
I suspect that the others of the import templates need this as well.