### PR TITLE
Don't use fully qualified path for bash in host

### DIFF
--- a/launcher
+++ b/launcher
@@ -788,7 +788,7 @@ case "$command" in
           do
             args[$j]=${BASH_ARGV[$i]}
           done
-          exec /bin/bash $0 "${args[@]}" # $@ is empty, because of shift at the beginning. Use BASH_ARGV instead.
+          exec bash $0 "${args[@]}" # $@ is empty, because of shift at the beginning. Use BASH_ARGV instead.
 
         elif [ $REMOTE = $BASE ]; then
           echo "Your version of Launcher is ahead of origin"


### PR DESCRIPTION
My main reason for that is NixOS not having bash at /bin/bash. Besides, shebang line already uses `/usr/bin/env` to find bash location, thus this also makes script re-execing more consistent 😄