### PR TITLE
FIX: Add a blank sshd.template.yml

### DIFF
--- a/templates/sshd.template.yml
+++ b/templates/sshd.template.yml
@@ -1,0 +1,1 @@
+# This file is deprecated; you can remove it from your app.yml


### PR DESCRIPTION
Fixes https://meta.discourse.org/t/cant-rebuild-because-ssh-template-is-removed/150285/10