### PR TITLE
Ensure it overrides all locale related variables

### DIFF
--- a/samples/data.yml
+++ b/samples/data.yml
@@ -21,7 +21,9 @@ params:
 
 env:
   # ensure locale exists in container, you may need to install it
+  LC_ALL: en_US.UTF-8
   LANG: en_US.UTF-8
+  LANGUAGE: en_US.UTF-8
 
 volumes:
   - volume:

--- a/samples/mail-receiver.yml
+++ b/samples/mail-receiver.yml
@@ -14,7 +14,9 @@ expose:
   - "25:25"   # SMTP
 
 env:
+  LC_ALL: en_US.UTF-8
   LANG: en_US.UTF-8
+  LANGUAGE: en_US.UTF-8
 
   ## Where e-mail to your forum should be sent.  In general, it's perfectly fine
   ## to use the same domain as the forum itself here.

--- a/samples/redis.yml
+++ b/samples/redis.yml
@@ -2,7 +2,9 @@ templates:
   - "templates/redis.template.yml"
 
 env:
+  LC_ALL: en_US.UTF-8
   LANG: en_US.UTF-8
+  LANGUAGE: en_US.UTF-8
 
 # any extra arguments for Docker?
 # docker_args:

--- a/samples/standalone.yml
+++ b/samples/standalone.yml
@@ -37,7 +37,9 @@ params:
   #version: tests-passed
 
 env:
+  LC_ALL: en_US.UTF-8
   LANG: en_US.UTF-8
+  LANGUAGE: en_US.UTF-8
   # DISCOURSE_DEFAULT_LOCALE: en
 
   ## How many concurrent web requests are supported? Depends on memory and CPU cores.

--- a/samples/web_only.yml
+++ b/samples/web_only.yml
@@ -29,7 +29,9 @@ params:
   #version: tests-passed
 
 env:
+  LC_ALL: en_US.UTF-8
   LANG: en_US.UTF-8
+  LANGUAGE: en_US.UTF-8
   # DISCOURSE_DEFAULT_LOCALE: en
 
   ## How many concurrent web requests are supported? Depends on memory and CPU cores.


### PR DESCRIPTION
`LC_ALL`, `LANG` and `LANGUAGE` are set to `en_US.UTF-8` in the docker image.  The config should override all of them when other locale is needed.  Otherwise it fails to create a DB with the proper locale setting.

I actually failed to upgrade my DB from Postgres 10 to 12 with `launcher rebuild app`:

```console
Building PostgreSQL dictionaries from installed myspell/hunspell packages...
Removing obsolete dictionary files:
Stopping PostgreSQL 10 database server: main.
Stopping PostgreSQL 12 database server: main.
Performing Consistency Checks
-----------------------------
Checking cluster versions                                   ok
Checking database user is the install user                  ok
Checking database connection settings                       ok
Checking for prepared transactions                          ok
Checking for reg* data types in user tables                 ok
Checking for contrib/isn with bigint-passing mismatch       ok
Checking for tables WITH OIDS                               ok
Checking for invalid "sql_identifier" user columns          ok
Creating dump of global objects                             ok
Creating dump of database schemas
  discourse
  postgres
  template1
                                                            ok

lc_collate values for database "postgres" do not match:  old "ja_JP.UTF-8", new "en_US.UTF-8"
Failure, exiting
```

You might want to have the launcher to auto correct the inconsistency of the locale variables.
