### PR TITLE
Fix install suffix of jemalloc

### DIFF
--- a/image/base/Dockerfile
+++ b/image/base/Dockerfile
@@ -66,7 +66,7 @@ RUN mkdir /jemalloc-stable && cd /jemalloc-stable &&\
 
 RUN mkdir /jemalloc-new && cd /jemalloc-new &&\
       wget https://github.com/jemalloc/jemalloc/releases/download/5.2.0/jemalloc-5.2.0.tar.bz2 &&\
-      tar -xjf jemalloc-5.2.0.tar.bz2 && cd jemalloc-5.2.0 && ./configure --prefix=/usr --with-install-suffix=5.1.0 && make build_lib && make install_lib &&\
+      tar -xjf jemalloc-5.2.0.tar.bz2 && cd jemalloc-5.2.0 && ./configure --prefix=/usr --with-install-suffix=5.2.0 && make build_lib && make install_lib &&\
       cd / && rm -rf /jemalloc-new
 
 RUN echo 'gem: --no-document' >> /usr/local/etc/gemrc &&\


### PR DESCRIPTION
Just a nitpick, I found that the version of jemalloc-new installed (5.2.0) doesn't correspond to the version in the suffix.