### PR TITLE
Create initial redis.socketed.template.yml

### DIFF
--- a/templates/redis.socketed.template.yml
+++ b/templates/redis.socketed.template.yml
@@ -1,0 +1,84 @@
+run:
+  - file:
+      path: /etc/service/redis/run
+      chmod: "+x"
+      contents: |
+        #!/bin/sh
+        exec 2>&1
+        exec thpoff chpst -u redis -U redis /usr/bin/redis-server /etc/redis/redis.conf
+  - file:
+      path: /etc/service/redis/log/run
+      chmod: "+x"
+      contents: |
+        #!/bin/sh
+        mkdir -p /var/log/redis
+        exec svlogd /var/log/redis
+  - file:
+      path: /etc/runit/3.d/10-redis
+      chmod: "+x"
+      contents: |
+        #!/bin/bash
+        sv stop redis
+  - replace:
+      filename: "/etc/redis/redis.conf"
+      from: "port 6379"
+      to: "port 0"
+  - replace:
+      filename: "/etc/redis/redis.conf"
+      from: "# unixsocket /tmp/redis.sock"
+      to: "unixsocket /shared/tmp/redis.sock"
+  - replace:
+      filename: "/etc/redis/redis.conf"
+      from: "# unixsocketperm 700"
+      to: "unixsocketperm 777"
+  - replace:
+      filename: "/etc/redis/redis.conf"
+      from: /^pidfile.*$/
+      to: ""
+
+  - exec:
+      cmd:
+        - install -d -m 0755 -o redis -g redis /shared/redis_data
+
+  - replace:
+      filename: "/etc/redis/redis.conf"
+      from: /^logfile.*$/
+      to: 'logfile ""'
+
+  - replace:
+      filename: "/etc/redis/redis.conf"
+      from: /^bind .*$/
+      to: ""
+
+  - replace:
+      filename: "/etc/redis/redis.conf"
+      from: /^dir .*$/
+      to: "dir /shared/redis_data"
+
+  - replace:
+      filename: "/etc/redis/redis.conf"
+      from: /^protected-mode yes/
+      to: "protected-mode no"
+
+  - exec:
+      cmd: echo redis installed
+      hook: redis
+  - exec: cat /etc/redis/redis.conf | grep logfile
+
+  - exec:
+      background: true
+      cmd: exec chpst -u redis -U redis /usr/bin/redis-server /etc/redis/redis.conf
+
+  - exec: sleep 10
+
+# we can not migrate without redis, launch it if needed
+hooks:
+  before_code:
+    - exec:
+        background: true
+        cmd: exec chpst -u redis -U redis /usr/bin/redis-server /etc/redis/redis.conf
+  after_code:
+    - replace:
+        filename: /etc/service/unicorn/run
+        from: "# redis"
+        to: sv start redis || exit 1


### PR DESCRIPTION
This file adds the required directives to set up Redis in Discourse with a unix domain socket.

See Also:

https://meta.discourse.org/t/discourse-container-with-unixsocket-for-redis/153945/5

Note:  

To implement:

- Change the redis template in the container yml file
- Add one additional line to the same container yml file

 ```
  ## Set the REDIS_URL and use the ```redis.socketed.template.yml``` to use 
  ## a unix domain socket for Redis
  REDIS_URL: unix:///shared/tmp/redis.sock
```

Notes:

1. If concerned about security of the Redis DB on the host, there is no need to expose this unix socket in the shared volume.

2. If you wish to set the permissions of the unix socket to 770 (instead of 777) , change the group of the unix socket to www-data.