### PR TITLE
FEATURE: Add a template to install clamAV

### DIFF
--- a/templates/clamav.template.yml
+++ b/templates/clamav.template.yml
@@ -1,0 +1,20 @@
+run:
+  - exec:
+      cmd:
+        - apt-get update && apt-get install -y clamav clamav-daemon
+        - mkdir -p /shared/freschlam
+        - freshclam
+  - file:
+     path: /etc/service/clamdscan/run
+     chmod: "+x"
+     contents: |
+        #!/bin/sh
+        exec /etc/init.d/clamav-daemon start
+  - file:
+     path: /shared/freshclam/cron.dd.freshclam
+     contents: |
+        0 */12    * * *   root /usr/bin/freshclam
+  - exec:
+      cmd: 
+        - cp /shared/freshclam/cron.dd.freshclam /etc/cron.d/freshclam
+        - rm -rf /shared/freshclam


### PR DESCRIPTION
### What does this template do?

- It installs the `clamav` and `clamav-daemon` libraries.
- Creates a file to start the `clamav-daemon` as a service.
- Defines a cron job to update the virus database every 12 hours.


