### PR TITLE
Update dependencies: nginx, redis, imagemagick

### DIFF
--- a/image/base/install-imagemagick
+++ b/image/base/install-imagemagick
@@ -2,8 +2,8 @@
 set -e
 
 # version check: https://github.com/ImageMagick/ImageMagick/releases
-IMAGE_MAGICK_VERSION="7.0.10-6"
-IMAGE_MAGICK_HASH="37d36f4d736eb16e0dd43c50302e1d01d1bb1125165333df8273508a22f8a64d"
+IMAGE_MAGICK_VERSION="7.0.10-24"
+IMAGE_MAGICK_HASH="c555b4724127f9993500c9a7bab148e6075a7397957516b9e0dd9faa02d5c98e"
 
 # version check: https://libpng.sourceforge.io/index.html
 LIBPNG_VERSION="1.6.37"

--- a/image/base/install-nginx
+++ b/image/base/install-nginx
@@ -2,8 +2,8 @@
 set -e
 
 # version check: https://nginx.org/en/download.html
-VERSION=1.17.9
-HASH="7dd65d405c753c41b7fdab9415cfb4bdbaf093ec6d9f7432072d52cb7bcbb689"
+VERSION=1.18.0
+HASH="4c373e7ab5bf91d34a4f11a0c9496561061ba5eee6020db272a17a7228d35f99"
 
 apt install -y autoconf
 

--- a/image/base/install-redis
+++ b/image/base/install-redis
@@ -2,8 +2,8 @@
 set -e
 
 # version check: https://redis.io/
-REDIS_VERSION=5.0.5
-REDIS_HASH="2139009799d21d8ff94fc40b7f36ac46699b9e1254086299f8d3b223ca54a375"
+REDIS_VERSION=5.0.9
+REDIS_HASH="53d0ae164cd33536c3d4b720ae9a128ea6166ebf04ff1add3b85f1242090cb85"
 
 cd /tmp
 # Prepare Redis source.


### PR DESCRIPTION
- Bump Redis from 5.0.5 to 5.0.9
- Bump Nginx from 1.17.9 to 1.18.0
- Bump ImageMagick from 7.0.10-6 to 7.0.10-24