### PR TITLE
FIX: discourse-doctor plugin check too loose

### DIFF
--- a/discourse-doctor
+++ b/discourse-doctor
@@ -185,7 +185,7 @@ get_discourse_config() {
 
 check_plugins() {
   log -e "\n\n==================== PLUGINS ===================="
-  log -e "$(grep git containers/$app_name.yml)"
+  log -e "$(grep 'git clone' containers/$app_name.yml)"
   grep git containers/$app_name.yml > /tmp/$PPID.grep
 
   if grep -cv "github.com/discourse" /tmp/$PPID.grep > /dev/null


### PR DESCRIPTION
The non-official plugin check was looking only for `git`, which would match other things in the yml file (e.g., a digital ocean S3 bucket name).

`grep` for `'git clone'` should solve that problem.

Though I did test this edit on a running sitee, I made these edit in the web interface by hand rather than pushing a commit where I tested it. Please look twice to make sure that I didn't do something silly when making the edit here.