### PR TITLE
DEV: Raise an error when env variable is a YAML hash

### DIFF
--- a/launcher
+++ b/launcher
@@ -358,6 +358,7 @@ set_template_info() {
         p e
        end
     end
+    env.each{|k,v| puts "*ERROR." if v.is_a?(Hash)}
     puts env.map{|k,v| "-e\n#{k}=#{v}" }.join("\n")
 RUBY
 


### PR DESCRIPTION
This is never intended, and almost always causes unintended behavior