### PR TITLE
FEATURE: Add easy mechanism for skipping post-deployment migrations

### DIFF
--- a/launcher
+++ b/launcher
@@ -20,6 +20,7 @@ usage () {
   echo "    --docker-args              Extra arguments to pass when running docker"
   echo "    --skip-mac-address         Don't assign a mac address"
   echo "    --run-image                Override the image used for running the container"
+  echo "    --skip-post-migrations     Apply the SKIP_POST_DEPLOYMENT_MIGRATIONS=1 environment variable"
   exit 1
 }
 
@@ -51,6 +52,9 @@ while [ ${#} -gt 0 ]; do
     ;;
   --skip-mac-address)
     SKIP_MAC_ADDRESS="1"
+    ;;
+  --skip-post-migrations)
+    LAUNCHER_SKIP_POST_MIGRATIONS="1"
     ;;
   --docker-args)
     user_args_argv="$2"
@@ -383,6 +387,10 @@ RUBY
       echo "${env[@]}"
       echo "YAML syntax error. Please check your containers/*.yml config files."
       exit 1
+    fi
+
+    if [ "$LAUNCHER_SKIP_POST_MIGRATIONS" -eq 1 ]; then
+      env+=("-e" "SKIP_POST_DEPLOYMENT_MIGRATIONS=1")
     fi
 
     # labels


### PR DESCRIPTION
This will help self-hosters avoid longer downtime when a large post-deployment migration is pending.

Usage:

```
./launcher rebuild app --skip-post-migrations
./launcher enter app
SKIP_POST_DEPLOYMENT_MIGRATIONS=0 rake db:migrate
exit
./launcher restart app
```

(Note: the 'restart' clears the temporarily-set environment variable, so future web upgrades will correctly apply post-deployment migrations.)

https://meta.discourse.org/t/2-6-0b2-upgrade-very-slow/161604/19?u=riking