### PR TITLE
Adding sed statement to disable imklog in rsyslog

### DIFF
--- a/image/base/Dockerfile
+++ b/image/base/Dockerfile
@@ -42,6 +42,7 @@ RUN apt -y install build-essential rsync \
                        libtcmalloc-minimal4 cmake
 RUN sed -i -e 's/start -q anacron/anacron -s/' /etc/cron.d/anacron
 RUN sed -i.bak 's/$ModLoad imklog/#$ModLoad imklog/' /etc/rsyslog.conf
+RUN sed -i.bak 's/module(load="imklog")/#module(load="imklog")/' /etc/rsyslog.conf
 RUN dpkg-divert --local --rename --add /sbin/initctl
 RUN sh -c "test -f /sbin/initctl || ln -s /bin/true /sbin/initctl"
 RUN cd / &&\


### PR DESCRIPTION
It appears the rsyslog version in `debian:buster-slim` has the `imklog` module syntax as follows

```
module(load="imklog")   # provides kernel logging support
```

This PR comments the `imklog` portion out, I'm leaving the previous method of commenting out the line to make sure it doesn't break anything. However happy to remove it if its deemed necessary