### PR TITLE
postgres.10.template: purge postgres-13 rather than 12.

### DIFF
--- a/templates/postgres.10.template.yml
+++ b/templates/postgres.10.template.yml
@@ -17,7 +17,7 @@ hooks:
        to: sv start postgres || exit 1
 
 run:
-  - exec: DEBIAN_FRONTEND=noninteractive apt-get purge -y postgresql-12 postgresql-client-12 postgresql-contrib-12
+  - exec: DEBIAN_FRONTEND=noninteractive apt-get purge -y postgresql-13 postgresql-client-13 postgresql-contrib-13
   - exec: apt-get update && apt-get install -y postgresql-10 postgresql-client-10 postgresql-contrib-10
   - exec: mkdir -p /shared/postgres_run
   - exec: chown postgres:postgres /shared/postgres_run


### PR DESCRIPTION
This purge command was missed and caused issues with the database
starting up correctly in some cases. Postgres-12 is no longer in the
base image so this wouldn't be doing anything.