### PR TITLE
FIX: remove pull for Discourse core

### DIFF
--- a/templates/web.template.yml
+++ b/templates/web.template.yml
@@ -89,7 +89,6 @@ run:
         - git reset --hard
         - git clean -f
         - git remote set-branches --add origin master
-        - git pull
         - git remote set-branches origin $version
         - git fetch --depth 1 origin $version
         - git checkout $version


### PR DESCRIPTION
We are already shallow-fetching a few lines below. A pull with a shallow
clone can be dangerous if Discourse is using a different repository
or version, as that potentially results in more data being pulled or a
dirty merge with a different upstream.

Remove the pull and rely only on the fetch and checkout.