### PR TITLE
FIX: Run reset and clean after checkout

### DIFF
--- a/templates/web.template.yml
+++ b/templates/web.template.yml
@@ -86,12 +86,12 @@ run:
       cd: $home
       hook: code
       cmd:
-        - git reset --hard
-        - git clean -f
         - git remote set-branches --add origin master
         - git remote set-branches origin $version
         - git fetch --depth 1 origin $version
         - git checkout $version
+        - git reset --hard origin $version
+        - git clean -f
         - mkdir -p tmp
         - chown discourse:www-data tmp
         - mkdir -p tmp/pids


### PR DESCRIPTION
shallow fetching and resetting may result in a dirty working tree.
Ensure we have a clean working tree by running the reset and clean after the
fetch.

Previously, we needed the clean and reset before the PULL, to ensure a clean
pull, but since we are using fetch + checkout (which does not result in a
merge if dirty) we might end up with a dirty repo after the checkout, such
as if a clone remote has a different master branch than core.