### PR TITLE
Revert git command changes

### DIFF
--- a/templates/web.template.yml
+++ b/templates/web.template.yml
@@ -90,7 +90,7 @@ run:
         - git remote set-branches origin $version
         - git fetch --depth 1 origin $version
         - git checkout $version
-        - git reset --hard origin/$version
+        - git reset --hard origin $version
         - git clean -f
         - mkdir -p tmp
         - chown discourse:www-data tmp

--- a/templates/web.template.yml
+++ b/templates/web.template.yml
@@ -86,12 +86,12 @@ run:
       cd: $home
       hook: code
       cmd:
+        - git reset --hard
+        - git clean -f
         - git remote set-branches --add origin master
         - git remote set-branches origin $version
         - git fetch --depth 1 origin $version
         - git checkout $version
-        - git reset --hard origin $version
-        - git clean -f
         - mkdir -p tmp
         - chown discourse:www-data tmp
         - mkdir -p tmp/pids

--- a/templates/web.template.yml
+++ b/templates/web.template.yml
@@ -89,6 +89,7 @@ run:
         - git reset --hard
         - git clean -f
         - git remote set-branches --add origin master
+        - git pull
         - git remote set-branches origin $version
         - git fetch --depth 1 origin $version
         - git checkout $version


### PR DESCRIPTION
Reverts some commits which caused build to fail when commit hash was unknown

- Revert "FIX: reset takes the full slash path (#501)"
- Revert "FIX: Run reset and clean after checkout (#500)"
- Revert "FIX: remove pull for Discourse core (#499)"

We will revisit later
