### PR TITLE
Remove git pull

### DIFF
--- a/templates/web.template.yml
+++ b/templates/web.template.yml
@@ -89,7 +89,6 @@ run:
         - git reset --hard
         - git clean -f
         - git remote set-branches --add origin master
-        - git pull
         - git remote set-branches origin $version
         - git fetch --depth 1 origin $version
         - git checkout $version


### PR DESCRIPTION
re-implement this: https://github.com/discourse/discourse_docker/pull/499

The issue that we had to revert for did not affect the removal of the pull command.