### PR TITLE
Support maxmind

### DIFF
--- a/discourse-setup
+++ b/discourse-setup
@@ -381,6 +381,8 @@ ask_user_for_config() {
   if [ "$maxmind_license_key" == "1234567890123456" ]
   then 
       local maxmind_status="ENTER to continue without MAXMIND GeoLite2 geolocation database"
+  else
+      local maxmind_status="Removing a key requires editing yml by hand"
   fi
 
   read_config "DISCOURSE_HOSTNAME"

--- a/discourse-setup
+++ b/discourse-setup
@@ -279,15 +279,6 @@ check_ports() {
 ##
 check_port() {
 
-  if ! command -v netstat &> /dev/null
-  then
-    echo "netstat not found. Port check skipped."
-    echo "You should verify that no other processes are using ports 80 or 443"
-    echo "Install netstat with something like "
-    echo "    apt install net-tools"
-    return
-  fi
-  
   local valid=$(netstat -tln | awk '{print $4}' | grep ":${1}\$")
 
   if [ -n "$valid" ]; then

--- a/discourse-setup
+++ b/discourse-setup
@@ -321,7 +321,7 @@ assert_maxmind_license_key() {
   if  ! grep DISCOURSE_MAXMIND_LICENSE_KEY $web_file
   then
     echo "Adding MAXMIND placeholder to $web_file"
-    sed -i -e 's/LETSENCRYPT_ACCOUNT_EMAIL/a\ \ #DISCOURSE_MAXMIND_LICENSE_KEY: 1234567890123456' $web_file 
+    sed -i -e 's/LETSENCRYPT_ACCOUNT_EMAIL/a\ \ #DISCOURSE_MAXMIND_LICENSE_KEY: 1234567890123456' $web_file
   fi
 }
 
@@ -368,7 +368,7 @@ ask_user_for_config() {
       maxmind_license_key="1234567890123456"
   fi
   if [ "$maxmind_license_key" == "1234567890123456" ]
-  then 
+  then
       local maxmind_status="ENTER to continue without MAXMIND GeoLite2 geolocation database"
   fi
 
@@ -673,7 +673,7 @@ validate_config() {
   valid_config="y"
 
   for x in DISCOURSE_SMTP_ADDRESS DISCOURSE_SMTP_USER_NAME DISCOURSE_SMTP_PASSWORD \
-           DISCOURSE_DEVELOPER_EMAILS DISCOURSE_HOSTNAME 
+           DISCOURSE_DEVELOPER_EMAILS DISCOURSE_HOSTNAME
   do
     read_config $x
     local result=$read_config_result

--- a/discourse-setup
+++ b/discourse-setup
@@ -399,7 +399,7 @@ ask_user_for_config() {
       fi
     fi
 
-#    check_IP_match $hostname 
+#    check_IP_match $hostname
 
     if [ ! -z "$developer_emails" ]
     then

--- a/discourse-setup
+++ b/discourse-setup
@@ -381,8 +381,6 @@ ask_user_for_config() {
   if [ "$maxmind_license_key" == "1234567890123456" ]
   then 
       local maxmind_status="ENTER to continue without MAXMIND GeoLite2 geolocation database"
-  else
-      local maxmind_status="Removing a key requires editing yml by hand"
   fi
 
   read_config "DISCOURSE_HOSTNAME"

--- a/discourse-setup
+++ b/discourse-setup
@@ -399,7 +399,7 @@ ask_user_for_config() {
       fi
     fi
 
-#    check_IP_match $hostname
+   check_IP_match $hostname
 
     if [ ! -z "$developer_emails" ]
     then

--- a/discourse-setup
+++ b/discourse-setup
@@ -381,10 +381,7 @@ ask_user_for_config() {
   if [ "$maxmind_license_key" == "1234567890123456" ]
   then 
       local maxmind_status="ENTER to continue without MAXMIND GeoLite2 geolocation database"
-  else
-      local maxmind_status="Enter 'NONE' to disable."
   fi
-
 
   read_config "DISCOURSE_HOSTNAME"
   hostname=$read_config_result
@@ -493,7 +490,7 @@ ask_user_for_config() {
 
     read_config "DISCOURSE_MAXMIND_LICENSE_KEY"
     local maxmind_license_key=$read_config_result
-    read -p "Optional Maxmind License key [$maxmind_license_key]: " new_value
+    read -p "Optional Maxmind License key ($maxmind_status) [$maxmind_license_key]: " new_value
     if [ ! -z "$new_value" ]
     then
         maxmind_license_key="$new_value"
@@ -512,7 +509,12 @@ ask_user_for_config() {
       echo "Let's Encrypt : $letsencrypt_account_email"
     fi
 
-    echo "Maxmind license: $maxmind_license_key"
+    if [ "$maxmind_license_key" != "1234567890123456" ]
+    then
+      echo "Maxmind license: $maxmind_license_key"
+    else
+	    echo "Maxmind license: (unset)"
+    fi
 
     echo ""
     read -p "ENTER to continue, 'n' to try again, Ctrl+C to exit: " config_ok
@@ -637,14 +639,17 @@ ask_user_for_config() {
     fi
 
     echo
-    echo "Setting MAXMIND key to $maxmind_license_key in $web_file"
-    sed -i -e "s/^.*DISCOURSE_MAXMIND_LICENSE_KEY:.*/  DISCOURSE_MAXMIND_LICENSE_KEY: $maxmind_license_key/w $changelog" $web_file
-    if [ -s $changelog ]
+    if [ $maxmind_license_key != "1234567890123456" ]
     then
-      rm $changelog
-    else
-      echo "DISCOURSE_MAXMIND_LICENSE_KEY change failed."
-      update_ok="n"
+      echo "Setting MAXMIND key to $maxmind_license_key in $web_file"
+      sed -i -e "s/^.*DISCOURSE_MAXMIND_LICENSE_KEY:.*/  DISCOURSE_MAXMIND_LICENSE_KEY: $maxmind_license_key/w $changelog" $web_file
+      if [ -s $changelog ]
+      then
+        rm $changelog
+      else
+        echo "DISCOURSE_MAXMIND_LICENSE_KEY change failed."
+        update_ok="n"
+      fi
     fi
 
   if [ "$update_ok" == "y" ]

--- a/discourse-setup
+++ b/discourse-setup
@@ -326,13 +326,11 @@ read_default() {
 }
 
 assert_maxmind_license_key() {
-  echo "Assert maxmind license key for $web_file"
+  echo "Checking if $web_file has MAXMIND placeholder."
   if  ! grep DISCOURSE_MAXMIND_LICENSE_KEY $web_file
   then
-    echo "Adding DISCOURSE_MAXMIND_LICENSE_KEY to $web_file"
+    echo "Adding MAXMIND placeholder to $web_file"
     sed -i -e 's/LETSENCRYPT_ACCOUNT_EMAIL/a\ \ #DISCOURSE_MAXMIND_LICENSE_KEY: 1234567890123456' $web_file 
-  else
-    echo "Have maxmind already"
   fi
 }
 

--- a/discourse-setup
+++ b/discourse-setup
@@ -279,6 +279,15 @@ check_ports() {
 ##
 check_port() {
 
+  if ! command -v netstat &> /dev/null
+  then
+    echo "netstat not found. Port check skipped."
+    echo "You should verify that no other processes are using ports 80 or 443"
+    echo "Install netstat with something like "
+    echo "    apt install net-tools"
+    return
+  fi
+  
   local valid=$(netstat -tln | awk '{print $4}' | grep ":${1}\$")
 
   if [ -n "$valid" ]; then
@@ -314,6 +323,17 @@ read_default() {
   config_line=`egrep "^  #?$1:" samples/standalone.yml`
   read_default_result=`echo $config_line | awk  -F":" '{print $2}'`
   read_default_result=`echo $read_config_result | sed "s/^\([\"']\)\(.*\)\1\$/\2/g"`
+}
+
+assert_maxmind_license_key() {
+  echo "Assert maxmind license key for $web_file"
+  if  ! grep DISCOURSE_MAXMIND_LICENSE_KEY $web_file
+  then
+    echo "Adding DISCOURSE_MAXMIND_LICENSE_KEY to $web_file"
+    sed -i -e 's/LETSENCRYPT_ACCOUNT_EMAIL/a\ \ #DISCOURSE_MAXMIND_LICENSE_KEY: 1234567890123456' $web_file 
+  else
+    echo "Have maxmind already"
+  fi
 }
 
 ##
@@ -352,6 +372,20 @@ ask_user_for_config() {
     local letsencrypt_status="Enter 'OFF' to disable."
   fi
 
+  read_config "DISCOURSE_MAXMIND_LICENSE_KEY"
+  local maxmind_license_key=$read_config_result
+  if [ -z $maxmind_license_key ]
+  then
+      maxmind_license_key="1234567890123456"
+  fi
+  if [ "$maxmind_license_key" == "1234567890123456" ]
+  then 
+      local maxmind_status="ENTER to continue without MAXMIND GeoLite2 geolocation database"
+  else
+      local maxmind_status="Enter 'NONE' to disable."
+  fi
+
+
   read_config "DISCOURSE_HOSTNAME"
   hostname=$read_config_result
 
@@ -379,7 +413,7 @@ ask_user_for_config() {
       fi
     fi
 
-    check_IP_match $hostname
+#    check_IP_match $hostname 
 
     if [ ! -z "$developer_emails" ]
     then
@@ -457,6 +491,14 @@ ask_user_for_config() {
       fi
     fi
 
+    read_config "DISCOURSE_MAXMIND_LICENSE_KEY"
+    local maxmind_license_key=$read_config_result
+    read -p "Optional Maxmind License key [$maxmind_license_key]: " new_value
+    if [ ! -z "$new_value" ]
+    then
+        maxmind_license_key="$new_value"
+    fi
+
     echo -e "\nDoes this look right?\n"
     echo "Hostname      : $hostname"
     echo "Email         : $developer_emails"
@@ -470,6 +512,7 @@ ask_user_for_config() {
       echo "Let's Encrypt : $letsencrypt_account_email"
     fi
 
+    echo "Maxmind license: $maxmind_license_key"
 
     echo ""
     read -p "ENTER to continue, 'n' to try again, Ctrl+C to exit: " config_ok
@@ -576,7 +619,7 @@ ask_user_for_config() {
     sed -i -e "s/$src/$dst/w $changelog" $web_file
     if [ -s $changelog ]
     then
-  echo "web.ssl.template.yml enabled"
+      echo "web.ssl.template.yml enabled"
     else
       update_ok="n"
       echo "web.ssl.template.yml NOT ENABLED--was it on already?"
@@ -591,6 +634,17 @@ ask_user_for_config() {
     else
       update_ok="n"
       echo "letsencrypt.ssl.template.yml NOT ENABLED -- was it on already?"
+    fi
+
+    echo
+    echo "Setting MAXMIND key to $maxmind_license_key in $web_file"
+    sed -i -e "s/^.*DISCOURSE_MAXMIND_LICENSE_KEY:.*/  DISCOURSE_MAXMIND_LICENSE_KEY: $maxmind_license_key/w $changelog" $web_file
+    if [ -s $changelog ]
+    then
+      rm $changelog
+    else
+      echo "DISCOURSE_MAXMIND_LICENSE_KEY change failed."
+      update_ok="n"
     fi
 
   if [ "$update_ok" == "y" ]
@@ -611,7 +665,7 @@ validate_config() {
   valid_config="y"
 
   for x in DISCOURSE_SMTP_ADDRESS DISCOURSE_SMTP_USER_NAME DISCOURSE_SMTP_PASSWORD \
-           DISCOURSE_DEVELOPER_EMAILS DISCOURSE_HOSTNAME
+           DISCOURSE_DEVELOPER_EMAILS DISCOURSE_HOSTNAME 
   do
     read_config $x
     local result=$read_config_result
@@ -674,6 +728,7 @@ fi
 check_root
 check_and_install_docker
 check_disk_and_memory
+assert_maxmind_license_key
 
 if [ -a "$web_file" ]
 then

--- a/discourse-setup
+++ b/discourse-setup
@@ -399,7 +399,7 @@ ask_user_for_config() {
       fi
     fi
 
-   check_IP_match $hostname
+    check_IP_match $hostname
 
     if [ ! -z "$developer_emails" ]
     then


### PR DESCRIPTION
Long-awaited discourse-setup support for maxmind keys.

If they have an old template with no default value, one gets added, though not with the helpful link to discussion that the new template has.

Oh. Darn. This also includes code to skip  check_port() if there's no netstat. I intend to replace that test that uses netstat with lsof instead, which I think it more universally included (it's installed in AWS Ubuntu which does not include netstat, anyway).

Also still to do is remove the broken disk space check since launcher does it anyway.