### PR TITLE
Changed awk config command to be more cross platform

### DIFF
--- a/discourse-doctor
+++ b/discourse-doctor
@@ -210,7 +210,7 @@ dump_yaml() {
 ##
 read_config() {
   config_line=$(egrep "^  #?$1:" $web_file)
-  read_config_result=$(echo $config_line | awk  --field-separator=":" '{print $2}')
+  read_config_result=$(echo $config_line | awk  -F ":" '{print $2}')
   read_config_result=$(echo $read_config_result | sed "s/^\([\"']\)\(.*\)\1\$/\2/g")
 }
 


### PR DESCRIPTION
in Ubuntu 20.04 LTS, pre installed is mawk 1.3.4 (https://linux.die.net/man/1/mawk) , which is called when you use awk. In this version, "--field-seperator" is not a valid option, leaving discourse-doctor with many errors.
Described in https://meta.discourse.org/t/discourse-doctor-parsing-smtp-credentials-not-working-admin-registration-email-not-working/174461, this commit aims to use -F as the accepted flag for field separation which is unambiguous across GNU AWK and Ubuntu MAWK.