### PR TITLE
FEATURE: Add validation to admin email prompt in discourse-setup

### DIFF
--- a/discourse-setup
+++ b/discourse-setup
@@ -383,11 +383,25 @@ ask_user_for_config() {
 
     if [ ! -z "$developer_emails" ]
     then
-      read -p "Email address for admin account(s)? [$developer_emails]: " new_value
-      if [ ! -z "$new_value" ]
-      then
-          developer_emails="$new_value"
-      fi
+      local email_valid="n"
+      until [ "$email_valid" == "y" ]
+      do
+        read -p "Email address for admin account(s)? [$developer_emails]: " new_value
+        if [ ! -z "$new_value" ]
+        then
+          if [[ ${#new_value} -ge 7 && $new_value == *@* ]]
+          then
+            developer_emails="$new_value"
+            email_valid="y"
+          else
+            echo
+            echo "[Error] Invalid email address"
+            echo
+          fi
+        else
+          email_valid="y"
+        fi
+      done
     fi
 
     if [ ! -z "$smtp_address" ]


### PR DESCRIPTION
Prior to this change, a user was able to enter any value when prompted for an admin email when running `discourse-setup`. A functional admin email is critical for the initial setup of Discourse.

This new validation checks that the input is **7 or more characters** and **includes an `@` character**. Pressing the enter key without adding any text will continue to use the current value defined in the `app.yml` file (this value is in brackets when prompted). Obviously, this is not total gold-plating, but it should reduce some potential friction.

Sample output:

```
Hostname for your Discourse? [discourse.example.com]: <REDACTED>

Checking your domain name . . .
Connection to <REDACTED> succeeded.
Email address for admin account(s)? [me@example.com,you@example.com]: abc

[Error] Invalid email address

Email address for admin account(s)? [me@example.com,you@example.com]: abcdefg

[Error] Invalid email address

Email address for admin account(s)? [me@example.com,you@example.com]: abc@

[Error] Invalid email address

Email address for admin account(s)? [me@example.com,you@example.com]: abc@def.com
SMTP server address? [smtp.example.com]: smtp.sendgrid.net
SMTP port? [587]: 
SMTP user name? [apikey]: 
SMTP password? [pa$$word]: <REDACTED>
Optional email address for Let's Encrypt warnings? (ENTER to skip) [me@example.com]: 

Does this look right?

Hostname      : <REDACTED>
Email         : abc@def.com
SMTP address  : smtp.sendgrid.net
SMTP port     : 587
SMTP username : apikey
SMTP password : <REDACTED>

ENTER to continue, 'n' to try again, Ctrl+C to exit: 

```

Where the email is used in the initial Discourse setup UI:

<img width="400" alt="email" src="https://user-images.githubusercontent.com/22733864/104080293-03013d80-51dc-11eb-8745-7d6b7c5a1f68.png">


Admittedly, bash is not my strongest area, so let me know if there are any improvements that can be made to the code.  It works and is somewhat readable, but I imagine there may be room for improvement.