### PR TITLE
Expose SMTP_DOMAIN Global Setting in sample file

### DIFF
--- a/samples/standalone.yml
+++ b/samples/standalone.yml
@@ -64,6 +64,7 @@ env:
   DISCOURSE_SMTP_USER_NAME: user@example.com
   DISCOURSE_SMTP_PASSWORD: pa$$word
   #DISCOURSE_SMTP_ENABLE_START_TLS: true           # (optional, default true)
+  #DISCOURSE_SMTP_DOMAIN: discourse.example.com    # (required by some providers)
 
   ## If you added the Lets Encrypt template, uncomment below to get a free SSL certificate
   #LETSENCRYPT_ACCOUNT_EMAIL: me@example.com


### PR DESCRIPTION
This is useful when using some SMTP providers, like Google Apps

https://meta.discourse.org/t/discourse-smtp-sends-ehlo-localhost-instead-of-domain-breaking-google-smtp-relay/176755/6?u=falco