### PR TITLE
Separate themes:update and assets:precompile tasks

### DIFF
--- a/templates/web.template.yml
+++ b/templates/web.template.yml
@@ -169,7 +169,8 @@ run:
       cd: $home
       hook: assets_precompile
       cmd:
-        - su discourse -c 'bundle exec rake themes:update assets:precompile'
+        - su discourse -c 'bundle exec rake themes:update'
+        - su discourse -c 'bundle exec rake assets:precompile'
 
   - file:
      path: /usr/local/bin/discourse


### PR DESCRIPTION
Running these separately means the output is cleaner and there is less chance of theme/component updates happening while assets are getting precompiled. 