### PR TITLE
Revert "Separate themes:update and assets:precompile tasks (#522)"

### DIFF
--- a/templates/web.template.yml
+++ b/templates/web.template.yml
@@ -169,8 +169,7 @@ run:
       cd: $home
       hook: assets_precompile
       cmd:
-        - su discourse -c 'bundle exec rake themes:update'
-        - su discourse -c 'bundle exec rake assets:precompile'
+        - su discourse -c 'bundle exec rake themes:update assets:precompile'
 
   - file:
      path: /usr/local/bin/discourse


### PR DESCRIPTION
This reverts commit 70686cf6ee53432aa9f92880c368e52a589f7196, it broke CI. 