### PR TITLE
Add notification email to discourse setup

### DIFF
--- a/discourse-setup
+++ b/discourse-setup
@@ -410,7 +410,7 @@ ask_user_for_config() {
       fi
     fi
 
-#    check_IP_match $hostname 
+#    check_IP_match $hostname
 
     if [ ! -z "$developer_emails" ]
     then

--- a/discourse-setup
+++ b/discourse-setup
@@ -666,20 +666,6 @@ ask_user_for_config() {
     fi
   fi
 
-    echo
-    if [ $maxmind_license_key != "1234567890123456" ]
-    then
-      echo "Setting MAXMIND key to $maxmind_license_key in $web_file"
-      sed -i -e "s/^.*DISCOURSE_MAXMIND_LICENSE_KEY:.*/  DISCOURSE_MAXMIND_LICENSE_KEY: $maxmind_license_key/w $changelog" $web_file
-      if [ -s $changelog ]
-      then
-        rm $changelog
-      else
-        echo "DISCOURSE_MAXMIND_LICENSE_KEY change failed."
-        update_ok="n"
-      fi
-    fi
-
   if [ "$update_ok" == "y" ]
   then
     echo -e "\nConfiguration file at $config_file updated successfully!\n"

--- a/discourse-setup
+++ b/discourse-setup
@@ -379,7 +379,7 @@ ask_user_for_config() {
     maxmind_license_key="1234567890123456"
   fi
   if [ "$maxmind_license_key" == "1234567890123456" ]
-  then 
+  then
       local maxmind_status="ENTER to continue without MAXMIND GeoLite2 geolocation database"
   fi
 
@@ -675,7 +675,7 @@ validate_config() {
   valid_config="y"
 
   for x in DISCOURSE_SMTP_ADDRESS DISCOURSE_SMTP_USER_NAME DISCOURSE_SMTP_PASSWORD \
-           DISCOURSE_DEVELOPER_EMAILS DISCOURSE_HOSTNAME 
+           DISCOURSE_DEVELOPER_EMAILS DISCOURSE_HOSTNAME
   do
     read_config $x
     local result=$read_config_result

--- a/discourse-setup
+++ b/discourse-setup
@@ -2,6 +2,34 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd $DIR
 
+if [ "$1" == "2container" ] 
+then
+  TWO_CONTAINER="1"
+  echo "2container argument is deprecated. Use --two-container"
+  shift 1
+fi
+
+while [ ${#} -gt 0 ]; do
+  case "${1}" in
+  --debug)
+    DEBUG="1"
+    SKIP_REBUILD="1"
+    ;;
+  --skip-rebuild)
+    SKIP_REBUILD="1"
+    ;;
+  --two-container)
+    TWO_CONTAINER="1"
+    ;;
+  --skip-connection-test)
+    SKIP_CONNECTION_TEST="1"
+    echo "skipping connection test"
+    ;;
+  esac
+
+  shift 1
+done
+
 ##
 ## Make sure only root can run our script
 ##
@@ -45,8 +73,14 @@ connect_to_port () {
 check_IP_match() {
   HOST="$1"
   echo
-  echo Checking your domain name . . .
-  connect_to_port $HOST 443; ec=$?
+  if [ "$SKIP_CONNECTION_TEST" == 1 ]
+  then 
+    echo "Setting EC to 2"
+    ec=2
+  else
+    echo Checking your domain name . . .
+    connect_to_port $HOST 443; ec=$?
+  fi
   case $ec in
     0)
       echo "Connection to $HOST succeeded."
@@ -80,7 +114,7 @@ check_IP_match() {
       exit 1
       ;;
     2)
-      echo "Continuing without port check."
+      echo "Skipping port check."
       ;;
   esac
 }
@@ -278,7 +312,7 @@ check_ports() {
 ##
 check_port() {
 
-  local valid=$(netstat -tln | awk '{print $4}' | grep ":${1}\$")
+  local valid=$(lsof -i:${1} | grep "LISTEN")
 
   if [ -n "$valid" ]; then
     echo "Port ${1} appears to already be in use."
@@ -336,6 +370,50 @@ EOF
   fi
 }
 
+assert_smtp_domain() {
+  if  ! grep DISCOURSE_SMTP_DOMAIN $web_file >/dev/null 2>&1
+  then
+    echo "Adding SMTP_DOMAIN placeholder to $web_file"
+    sed -i '/^.*DISCOURSE_SMTP_PASSWORD.*/a \ \ #DISCOURSE_SMTP_DOMAIN: discourse.example.com    # (required by some providers)' $web_file
+  fi
+  if  ! grep DISCOURSE_SMTP_DOMAIN $web_file >/dev/null 2>&1
+  then
+    cat <<EOF
+
+    Adding DISCOURSE_SMTP_DOMAIN to $web_file has failed! This
+    indicates either that your $web_file is very old or otherwise not
+    what the script expects or that there is a bug in this script. The
+    best solution for a novice is to delete $web_file and start over.
+    An expert might prefer to edit $web_file by hand.
+
+EOF
+    read -p "Press return to continue or control-c to quit..."
+  fi
+}
+
+
+assert_notification_email() {
+  if  ! grep DISCOURSE_NOTIFICATION_EMAIL $web_file >/dev/null 2>&1
+  then
+    echo "Adding DISCOURSE_NOTIFICATION_EMAIL placeholder to $web_file"
+    sed -i '/^.*DISCOURSE_SMTP_PASSWORD.*/a \ \ #DISCOURSE_NOTIFICATION_EMAIL: nobody@discourse.example.com    # (address to send notifications from)' $web_file
+  fi
+  if  ! grep DISCOURSE_NOTIFICATION_EMAIL $web_file >/dev/null 2>&1
+  then
+    cat <<EOF
+
+    Adding DISCOURSE_NOTIFICATION_EMAIL to $web_file has failed! This
+    indicates either that your $web_file is very old or otherwise not
+    what the script expects or that there is a bug in this script. The
+    best solution for a novice is to delete $web_file and start over.
+    An expert might prefer to edit $web_file by hand.
+
+EOF
+    read -p "Press return to continue or control-c to quit..."
+  fi
+}
+
+
 ##
 ## prompt user for typical Discourse config file values
 ##
@@ -343,6 +421,8 @@ ask_user_for_config() {
 
   # NOTE: Defaults now come from standalone.yml
 
+  read_config "DISCOURSE_HOSTNAME"
+  hostname=$read_config_result
   local changelog=/tmp/changelog.$PPID
   read_config "DISCOURSE_SMTP_ADDRESS"
   local smtp_address=$read_config_result
@@ -359,6 +439,11 @@ ask_user_for_config() {
   then
     smtp_password = ""
   fi
+  read_config "DISCOURSE_NOTIFICATION_EMAIL"
+  local notification_email=$read_config_result
+  read_config "DISCOURSE_SMTP_DOMAIN"
+  local discourse_smtp_DOMAIN=$read_config_result
+
   read_config "LETSENCRYPT_ACCOUNT_EMAIL"
   local letsencrypt_account_email=$read_config_result
   if [ -z $letsencrypt_account_email ]
@@ -382,9 +467,6 @@ ask_user_for_config() {
   then
       local maxmind_status="ENTER to continue without MAXMIND GeoLite2 geolocation database"
   fi
-
-  read_config "DISCOURSE_HOSTNAME"
-  hostname=$read_config_result
 
   local new_value=""
   local config_ok="n"
@@ -464,11 +546,11 @@ ask_user_for_config() {
       fi
       if [ "$smtp_address" == "smtp.sendgrid.net" ]
       then
-  	smtp_user_name="apikey"
+        smtp_user_name="apikey"
       fi
       if [ "$smtp_address" == "smtp.mailgun.org" ]
       then
-  	smtp_user_name="postmaster@$hostname"
+        smtp_user_name="postmaster@$hostname"
       fi
     fi
 
@@ -486,6 +568,20 @@ ask_user_for_config() {
     then
       smtp_password="$new_value"
     fi
+
+    if [[ "$notification_email" == "noreply@discourse.example.com"* ]]
+    then
+      notification_email="noreply@$hostname"
+    fi
+  
+    read -p "notification email address? [$notification_email]: " new_value
+    if [ ! -z "$new_value" ]
+    then
+      notification_email="$new_value"
+    fi
+
+    # set smtp_domain default value here rather than use Rails default of localhost
+    smtp_domain=$(echo $notification_email | sed -e "s/.*@//")
 
     if [ ! -z $letsencrypt_account_email ]
     then
@@ -511,12 +607,13 @@ ask_user_for_config() {
     fi
 
     echo -e "\nDoes this look right?\n"
-    echo "Hostname      : $hostname"
-    echo "Email         : $developer_emails"
-    echo "SMTP address  : $smtp_address"
-    echo "SMTP port     : $smtp_port"
-    echo "SMTP username : $smtp_user_name"
-    echo "SMTP password : $smtp_password"
+    echo "Hostname          : $hostname"
+    echo "Email             : $developer_emails"
+    echo "SMTP address      : $smtp_address"
+    echo "SMTP port         : $smtp_port"
+    echo "SMTP username     : $smtp_user_name"
+    echo "SMTP password     : $smtp_password"
+    echo "Notification email: $notification_email"
 
     if [ "$letsencrypt_status" == "Enter 'OFF' to disable." ]
     then
@@ -576,6 +673,24 @@ ask_user_for_config() {
     rm $changelog
   else
     echo "DISCOURSE_SMTP_USER_NAME change failed."
+    update_ok="n"
+  fi
+
+  sed -i -e "s/^  #\?DISCOURSE_NOTIFICATION_EMAIL:.*/  DISCOURSE_NOTIFICATION_EMAIL: $notification_email/w $changelog" $web_file
+  if [ -s $changelog ]
+  then
+    rm $changelog
+  else
+    echo "DISCOURSE_NOTIFICATION_EMAIL change failed."
+    update_ok="n"
+  fi
+
+  sed -i -e "s/^  #\?DISCOURSE_SMTP_DOMAIN:.*/  DISCOURSE_SMTP_DOMAIN: $smtp_domain/w $changelog" $web_file
+  if [ -s $changelog ]
+  then
+    rm $changelog
+  else
+    echo "DISCOURSE_SMTP_DOMAIN change failed."
     update_ok="n"
   fi
 
@@ -646,7 +761,6 @@ ask_user_for_config() {
   echo
   if [ $maxmind_license_key != "1234567890123456" ]
   then
-    echo "Setting MAXMIND key to $maxmind_license_key in $web_file"
     sed -i -e "s/^.*DISCOURSE_MAXMIND_LICENSE_KEY:.*/  DISCOURSE_MAXMIND_LICENSE_KEY: $maxmind_license_key/w $changelog" $web_file
     if [ -s $changelog ]
     then
@@ -659,10 +773,10 @@ ask_user_for_config() {
 
   if [ "$update_ok" == "y" ]
   then
-    echo -e "\nConfiguration file at $config_file updated successfully!\n"
+    echo -e "\nConfiguration file at $web_file updated successfully!\n"
   else
-    echo -e "\nUnfortunately, there was an error changing $config_file\n"
-    echo -d "This may happen if you have made unexpected changes."
+    echo -e "\nUnfortunately, there was an error changing $web_file\n"
+    echo -e "This may happen if you have made unexpected changes."
     exit 1
   fi
 }
@@ -714,7 +828,7 @@ validate_config() {
 ## template file names
 ##
 
-if [ "$1" == "2container" ] || [ -f containers/web_only.yml ]
+if [ "$TWO_CONTAINER" ] || [ -f containers/web_only.yml ]
 then
   app_name=web_only
   data_name=data
@@ -752,12 +866,17 @@ then
   echo Saving old file as $BACKUP
   cp $web_file containers/$BACKUP
   echo "Stopping existing container in 5 seconds or Control-C to cancel."
-  sleep 5
+  #sleep 5
   assert_maxmind_license_key
-  ./launcher stop $app_name
+  assert_notification_email
+  assert_smtp_domain
+  #./launcher stop $app_name
   echo
 else
-  check_ports
+  if [ "$SKIP_CONNECTION_TEST" != 1 ]
+  then 
+    check_ports
+  fi
   cp -v $web_template $web_file
   if [ "$data_name" == "data" ]
   then
@@ -794,8 +913,15 @@ validate_config
 ## if we reach this point without exiting, OK to proceed
 ## rebuild won't fail if there's nothing to rebuild and does the restart
 ##
+if [ "$SKIP_REBUILD" ]
+then
+  echo "Updates successful. --skip-rebuild requested. Exiting."
+  exit
+fi
+
 echo "Updates successful. Rebuilding in 5 seconds."
 sleep 5 # Just a chance to ^C in case they were too fast on the draw
+
 if [ "$data_name" == "$app_name" ]
 then
   echo Building $app_name

--- a/discourse-setup
+++ b/discourse-setup
@@ -388,8 +388,10 @@ ask_user_for_config() {
     maxmind_license_key="1234567890123456"
   fi
   if [ "$maxmind_license_key" == "1234567890123456" ]
-  then
-    local maxmind_status="ENTER to continue without MAXMIND GeoLite2 geolocation database"
+  then 
+      local maxmind_status="ENTER to continue without MAXMIND GeoLite2 geolocation database"
+  else
+      local maxmind_status="Removing a key requires editing yml by hand"
   fi
 
   read_config "DISCOURSE_HOSTNAME"

--- a/discourse-setup
+++ b/discourse-setup
@@ -278,6 +278,15 @@ check_ports() {
 ##
 check_port() {
 
+  if ! command -v netstat &> /dev/null
+  then
+    echo "netstat not found. Port check skipped."
+    echo "You should verify that no other processes are using ports 80 or 443"
+    echo "Install netstat with something like "
+    echo "    apt install net-tools"
+    return
+  fi
+  
   local valid=$(netstat -tln | awk '{print $4}' | grep ":${1}\$")
 
   if [ -n "$valid" ]; then
@@ -410,7 +419,7 @@ ask_user_for_config() {
       fi
     fi
 
-    check_IP_match $hostname
+#    check_IP_match $hostname 
 
     if [ ! -z "$developer_emails" ]
     then
@@ -504,10 +513,10 @@ ask_user_for_config() {
 
     read_config "DISCOURSE_MAXMIND_LICENSE_KEY"
     local maxmind_license_key=$read_config_result
-    read -p "Optional Maxmind License key ($maxmind_status) [$maxmind_license_key]: " new_value
+    read -p "Optional Maxmind License key [$maxmind_license_key]: " new_value
     if [ ! -z "$new_value" ]
     then
-      maxmind_license_key="$new_value"
+        maxmind_license_key="$new_value"
     fi
 
     echo -e "\nDoes this look right?\n"
@@ -622,35 +631,26 @@ ask_user_for_config() {
   fi
 
   echo "Enabling Let's Encrypt"
-  sed -i -e "s/^  #\?LETSENCRYPT_ACCOUNT_EMAIL:.*/  LETSENCRYPT_ACCOUNT_EMAIL: $letsencrypt_account_email/w $changelog" $web_file
-  if [ -s $changelog ]
-  then
-    rm $changelog
-  else
-    echo "LETSENCRYPT_ACCOUNT_EMAIL change failed."
-    update_ok="n"
-  fi
-  local src='^  #\?- "templates\/web.ssl.template.yml"'
-  local dst='  \- "templates\/web.ssl.template.yml"'
-  sed -i -e "s/$src/$dst/w $changelog" $web_file
-  if [ -s $changelog ]
-  then
-    echo "web.ssl.template.yml enabled"
-  else
-    update_ok="n"
-    echo "web.ssl.template.yml NOT ENABLED--was it on already?"
-  fi
-  local src='^  #\?- "templates\/web.letsencrypt.ssl.template.yml"'
-  local dst='  - "templates\/web.letsencrypt.ssl.template.yml"'
-
-  sed -i -e "s/$src/$dst/w $changelog" $web_file
-  if [ -s $changelog ]
-  then
-    echo "letsencrypt.ssl.template.yml enabled"
-  else
-    update_ok="n"
-    echo "letsencrypt.ssl.template.yml NOT ENABLED -- was it on already?"
-  fi
+    sed -i -e "s/^  #\?LETSENCRYPT_ACCOUNT_EMAIL:.*/  LETSENCRYPT_ACCOUNT_EMAIL: $letsencrypt_account_email/w $changelog" $web_file
+    if [ -s $changelog ]
+    then
+      rm $changelog
+    else
+      echo "LETSENCRYPT_ACCOUNT_EMAIL change failed."
+      update_ok="n"
+    fi
+    local src='^  #\?- "templates\/web.ssl.template.yml"'
+    local dst='  \- "templates\/web.ssl.template.yml"'
+    sed -i -e "s/$src/$dst/w $changelog" $web_file
+    if [ -s $changelog ]
+    then
+      echo "web.ssl.template.yml enabled"
+    else
+      update_ok="n"
+      echo "web.ssl.template.yml NOT ENABLED--was it on already?"
+    fi
+    local src='^  #\?- "templates\/web.letsencrypt.ssl.template.yml"'
+    local dst='  - "templates\/web.letsencrypt.ssl.template.yml"'
 
   echo
   if [ $maxmind_license_key != "1234567890123456" ]
@@ -665,6 +665,17 @@ ask_user_for_config() {
       update_ok="n"
     fi
   fi
+
+    echo
+    echo "Setting MAXMIND key to $maxmind_license_key in $web_file"
+    sed -i -e "s/^.*DISCOURSE_MAXMIND_LICENSE_KEY:.*/  DISCOURSE_MAXMIND_LICENSE_KEY: $maxmind_license_key/w $changelog" $web_file
+    if [ -s $changelog ]
+    then
+      rm $changelog
+    else
+      echo "DISCOURSE_MAXMIND_LICENSE_KEY change failed."
+      update_ok="n"
+    fi
 
   if [ "$update_ok" == "y" ]
   then
@@ -684,7 +695,7 @@ validate_config() {
   valid_config="y"
 
   for x in DISCOURSE_SMTP_ADDRESS DISCOURSE_SMTP_USER_NAME DISCOURSE_SMTP_PASSWORD \
-                                  DISCOURSE_DEVELOPER_EMAILS DISCOURSE_HOSTNAME
+           DISCOURSE_DEVELOPER_EMAILS DISCOURSE_HOSTNAME 
   do
     read_config $x
     local result=$read_config_result
@@ -747,6 +758,7 @@ changelog=/tmp/changelog
 check_root
 check_and_install_docker
 check_disk_and_memory
+assert_maxmind_license_key
 
 if [ -a "$web_file" ]
 then

--- a/discourse-setup
+++ b/discourse-setup
@@ -75,7 +75,6 @@ check_IP_match() {
   echo
   if [ "$SKIP_CONNECTION_TEST" == 1 ]
   then 
-    echo "Setting EC to 2"
     ec=2
   else
     echo Checking your domain name . . .

--- a/discourse-setup
+++ b/discourse-setup
@@ -390,8 +390,6 @@ ask_user_for_config() {
   if [ "$maxmind_license_key" == "1234567890123456" ]
   then 
       local maxmind_status="ENTER to continue without MAXMIND GeoLite2 geolocation database"
-  else
-      local maxmind_status="Removing a key requires editing yml by hand"
   fi
 
   read_config "DISCOURSE_HOSTNAME"

--- a/discourse-setup
+++ b/discourse-setup
@@ -513,7 +513,7 @@ ask_user_for_config() {
 
     read_config "DISCOURSE_MAXMIND_LICENSE_KEY"
     local maxmind_license_key=$read_config_result
-    read -p "Optional Maxmind License key [$maxmind_license_key]: " new_value
+    read -p "Optional Maxmind License key ($maxmind_status) [$maxmind_license_key]: " new_value
     if [ ! -z "$new_value" ]
     then
         maxmind_license_key="$new_value"
@@ -667,14 +667,17 @@ ask_user_for_config() {
   fi
 
     echo
-    echo "Setting MAXMIND key to $maxmind_license_key in $web_file"
-    sed -i -e "s/^.*DISCOURSE_MAXMIND_LICENSE_KEY:.*/  DISCOURSE_MAXMIND_LICENSE_KEY: $maxmind_license_key/w $changelog" $web_file
-    if [ -s $changelog ]
+    if [ $maxmind_license_key != "1234567890123456" ]
     then
-      rm $changelog
-    else
-      echo "DISCOURSE_MAXMIND_LICENSE_KEY change failed."
-      update_ok="n"
+      echo "Setting MAXMIND key to $maxmind_license_key in $web_file"
+      sed -i -e "s/^.*DISCOURSE_MAXMIND_LICENSE_KEY:.*/  DISCOURSE_MAXMIND_LICENSE_KEY: $maxmind_license_key/w $changelog" $web_file
+      if [ -s $changelog ]
+      then
+        rm $changelog
+      else
+        echo "DISCOURSE_MAXMIND_LICENSE_KEY change failed."
+        update_ok="n"
+      fi
     fi
 
   if [ "$update_ok" == "y" ]

--- a/discourse-setup
+++ b/discourse-setup
@@ -278,15 +278,6 @@ check_ports() {
 ##
 check_port() {
 
-  if ! command -v netstat &> /dev/null
-  then
-    echo "netstat not found. Port check skipped."
-    echo "You should verify that no other processes are using ports 80 or 443"
-    echo "Install netstat with something like "
-    echo "    apt install net-tools"
-    return
-  fi
-  
   local valid=$(netstat -tln | awk '{print $4}' | grep ":${1}\$")
 
   if [ -n "$valid" ]; then

--- a/discourse-setup
+++ b/discourse-setup
@@ -410,7 +410,7 @@ ask_user_for_config() {
       fi
     fi
 
-#    check_IP_match $hostname
+   check_IP_match $hostname
 
     if [ ! -z "$developer_emails" ]
     then

--- a/discourse-setup
+++ b/discourse-setup
@@ -410,7 +410,7 @@ ask_user_for_config() {
       fi
     fi
 
-   check_IP_match $hostname
+    check_IP_match $hostname
 
     if [ ! -z "$developer_emails" ]
     then

--- a/discourse-setup
+++ b/discourse-setup
@@ -852,7 +852,6 @@ changelog=/tmp/changelog
 check_root
 check_and_install_docker
 check_disk_and_memory
-assert_maxmind_license_key
 
 if [ -a "$web_file" ]
 then

--- a/samples/standalone.yml
+++ b/samples/standalone.yml
@@ -65,6 +65,7 @@ env:
   DISCOURSE_SMTP_PASSWORD: pa$$word
   #DISCOURSE_SMTP_ENABLE_START_TLS: true           # (optional, default true)
   #DISCOURSE_SMTP_DOMAIN: discourse.example.com    # (required by some providers)
+  #DISCOURSE_NOTIFICATION_EMAIL: noreply@discourse.example.com    # (address to send notifications from)
 
   ## If you added the Lets Encrypt template, uncomment below to get a free SSL certificate
   #LETSENCRYPT_ACCOUNT_EMAIL: me@example.com

--- a/samples/web_only.yml
+++ b/samples/web_only.yml
@@ -55,6 +55,8 @@ env:
   DISCOURSE_SMTP_USER_NAME: user@example.com
   DISCOURSE_SMTP_PASSWORD: pa$$word
   #DISCOURSE_SMTP_ENABLE_START_TLS: true           # (optional, default true)
+  #DISCOURSE_SMTP_DOMAIN: discourse.example.com    # (required by some providers)
+  #DISCOURSE_NOTIFICATION_EMAIL: noreply@discourse.example.com    # (address to send notifications from)
 
   ## If you added the Lets Encrypt template, uncomment below to get a free SSL certificate
   #LETSENCRYPT_ACCOUNT_EMAIL: me@example.com

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,28 @@
+## Smoke tests for `discourse-setup`
+
+These are not **real** tests, but do test that `discourse-setup` can produce or modify
+the YML file as expected. 
+
+Tests will not run if yml files exist already. If the tests succeed, the container files are deleted.
+
+### `standalone` tests
+
+- run the first time to do an initial creation of `app.yml` and that the values get set as expected.
+- run again to change the values
+
+### `two-container` tests
+
+- run with `--two-container` switch to create separate data and web containers
+- run again (not requiring the `--two-container` switch) and update values as expected
+
+### `update-old-templates` tests
+
+- updates a very old (Sep 6, 2016) standalone.yml 
+- updates a pretty old (Apr 13, 2018) web_only.yml 
+
+The tests won't run if `app.yml` or `web_only.yml` exist.
+
+### `run-all-tests`
+
+Runs all three of the above tests and prints an error if `app.yml` or `web_only.yml` exist.
+

--- a/tests/run-all-tests
+++ b/tests/run-all-tests
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+$DIR/standard
+$DIR/two-container
+$DIR/update-old-templates
+
+if [ -f $DIR/../containers/app.yml ] || [ -f $DIR/../containers/web_only.yml ]
+then
+  echo Some test failed. Sad.
+fi

--- a/tests/standalone
+++ b/tests/standalone
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+YML=$DIR/../containers/app.yml
+if [ -f $YML ]
+then
+  echo "cannot run test if $YML exists."
+  exit
+fi
+
+check_value () {
+  VAR=$1
+  VAL=$2
+  YML=$3
+  if ! [[ $(grep $VAR $YML |sed -e "s/  $VAR: //") == "$VAL" ]]
+  then
+    echo $VAR is NOT $VAL
+    echo TEST FAILED. Aborting. 
+    exit 1
+  fi
+}
+
+hostname='test.myhost.com'
+developer='admin@mail.myhost.com'
+smtp_address='smtp.myhostn.com'
+smtp_port=''
+smtp_user='smtpuser'
+smtp_pass='smtp-pw'
+notification=''
+letsencrypt='le@myhost.com'
+maxmind=''
+$DIR/../discourse-setup --skip-connection-test --skip-rebuild <<EOF 
+$hostname
+$developer
+$smtp_address
+$smtp_port
+$smtp_user
+$smtp_pass
+$notification
+$letsencrypt
+$maxmind
+
+
+EOF
+check_value DISCOURSE_HOSTNAME $hostname $YML
+check_value DISCOURSE_SMTP_ADDRESS $smtp_address $YML
+check_value DISCOURSE_SMTP_PORT 587 $YML
+check_value DISCOURSE_SMTP_USER_NAME $smtp_user $YML
+check_value DISCOURSE_SMTP_PASSWORD \"$smtp_pass\" $YML
+check_value DISCOURSE_SMTP_DOMAIN $hostname $YML
+check_value DISCOURSE_NOTIFICATION_EMAIL noreply@$hostname $YML
+echo "################################ Initial install succeeded. ###################################"
+echo "Now running edit test."
+hostname='new.myhost.com'
+developer='new@mail.myhost.com'
+smtp_address='new.myhostn.com'
+smtp_port='2525'
+smtp_user='newuser'
+smtp_pass='new-smtp-pw'
+notification='somuser@otherhost.com'
+smtp_domain=otherhost.com # NOTE: script uses notification hostnme
+letsencrypt='le-new@myhost.com'
+maxmind='maxthisone'
+$DIR/../discourse-setup --skip-connection-test --skip-rebuild <<EOF 
+$hostname
+$developer
+$smtp_address
+$smtp_port
+$smtp_user
+$smtp_pass
+$notification
+$letsencrypt
+$maxmind
+
+
+EOF
+check_value DISCOURSE_HOSTNAME $hostname $YML
+check_value DISCOURSE_SMTP_ADDRESS $smtp_address $YML
+check_value DISCOURSE_SMTP_PORT $smtp_port $YML
+check_value DISCOURSE_SMTP_USER_NAME $smtp_user $YML
+check_value DISCOURSE_SMTP_PASSWORD \"$smtp_pass\" $YML
+check_value DISCOURSE_SMTP_DOMAIN $smtp_domain $YML
+check_value DISCOURSE_NOTIFICATION_EMAIL $notification $YML
+echo "################################ Update of values succeeded. ###################################"
+echo "Removing $YML*"
+rm $YML*
+
+echo "Test succeeded. Removing $YML"
+rm $YML

--- a/tests/two-container
+++ b/tests/two-container
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+YML=$DIR/../containers/web_only.yml
+DATA_YML=$DIR/../containers/data.yml
+if [ -f $YML ]
+then
+  echo "cannot run test if $YML exists."
+  exit
+fi
+
+check_value () {
+  VAR=$1
+  VAL=$2
+  YML=$3
+  if ! [[ $(grep $VAR $YML |sed -e "s/  $VAR: //") == "$VAL" ]]
+  then
+    echo $VAR is NOT $VAL
+    echo TEST FAILED. Aborting. 
+    exit 1
+  fi
+}
+
+hostname='test.myhost.com'
+developer='admin@mail.myhost.com'
+smtp_address='smtp.myhostn.com'
+smtp_port=''
+smtp_user='smtpuser'
+smtp_pass='smtp-pw'
+notification=''
+letsencrypt='le@myhost.com'
+maxmind=''
+$DIR/../discourse-setup --two-container --skip-connection-test --skip-rebuild <<EOF 
+$hostname
+$developer
+$smtp_address
+$smtp_port
+$smtp_user
+$smtp_pass
+$notification
+$letsencrypt
+$maxmind
+
+
+EOF
+check_value DISCOURSE_HOSTNAME $hostname $YML
+check_value DISCOURSE_SMTP_ADDRESS $smtp_address $YML
+check_value DISCOURSE_SMTP_PORT 587 $YML
+check_value DISCOURSE_SMTP_USER_NAME $smtp_user $YML
+check_value DISCOURSE_SMTP_PASSWORD \"$smtp_pass\" $YML
+check_value DISCOURSE_SMTP_DOMAIN $hostname $YML
+check_value DISCOURSE_NOTIFICATION_EMAIL noreply@$hostname $YML
+echo "################################ Initial install succeeded. ###################################"
+echo "Now running edit test."
+hostname='new.myhost.com'
+developer='new@mail.myhost.com'
+smtp_address='new.myhostn.com'
+smtp_port='2525'
+smtp_user='newuser'
+smtp_pass='new-smtp-pw'
+notification='somuser@otherhost.com'
+smtp_domain=otherhost.com # NOTE: script uses notification hostnme
+letsencrypt='le-new@myhost.com'
+maxmind='maxthisone'
+$DIR/../discourse-setup --skip-connection-test --skip-rebuild <<EOF 
+$hostname
+$developer
+$smtp_address
+$smtp_port
+$smtp_user
+$smtp_pass
+$notification
+$letsencrypt
+$maxmind
+
+
+EOF
+check_value DISCOURSE_HOSTNAME $hostname $YML
+check_value DISCOURSE_SMTP_ADDRESS $smtp_address $YML
+check_value DISCOURSE_SMTP_PORT $smtp_port $YML
+check_value DISCOURSE_SMTP_USER_NAME $smtp_user $YML
+check_value DISCOURSE_SMTP_PASSWORD \"$smtp_pass\" $YML
+check_value DISCOURSE_SMTP_DOMAIN $smtp_domain $YML
+check_value DISCOURSE_NOTIFICATION_EMAIL $notification $YML
+check_value DISCOURSE_MAXMIND_LICENSE_KEY $maxmind $YML
+echo "################################ Update of values succeeded. ###################################"
+echo "Update values Test succeeded. Removing $YML"
+rm $YML* $DATA_YML

--- a/tests/update-old-templates
+++ b/tests/update-old-templates
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+YML=$DIR/../containers/app.yml
+if [ -f $YML ]
+then
+  echo "cannot run test if $YML exists."
+  exit
+fi
+
+check_value () {
+  VAR=$1
+  VAL=$2
+  YML=$3
+  if ! [[ $(grep $VAR $YML |sed -e "s/  $VAR: //") == "$VAL" ]]
+  then
+    echo $VAR is NOT $VAL
+    echo TEST FAILED. Aborting. 
+    exit 1
+  fi
+}
+
+# get old (Sep 6, 2016) standalone.yml that's missing MAXMIND and other values
+git show 7cf781fc0cf2542040f35e40cf79a1ab079c59f0:samples/standalone.yml>containers/app.yml > $YML
+
+hostname='new.myhost.com'
+developer='new@mail.myhost.com'
+smtp_address='new.myhostn.com'
+smtp_port='2525'
+smtp_user='newuser'
+smtp_pass='new-smtp-pw'
+notification='somuser@otherhost.com'
+smtp_domain=otherhost.com # NOTE: script uses notification hostnme
+letsencrypt='le-new@myhost.com'
+maxmind='maxthisone'
+$DIR/../discourse-setup --skip-connection-test --skip-rebuild <<EOF 
+$hostname
+$developer
+$smtp_address
+$smtp_port
+$smtp_user
+$smtp_pass
+$notification
+$letsencrypt
+$maxmind
+
+
+EOF
+check_value DISCOURSE_HOSTNAME $hostname $YML
+check_value DISCOURSE_SMTP_ADDRESS $smtp_address $YML
+check_value DISCOURSE_SMTP_PORT $smtp_port $YML
+check_value DISCOURSE_SMTP_USER_NAME $smtp_user $YML
+check_value DISCOURSE_SMTP_PASSWORD \"$smtp_pass\" $YML
+check_value DISCOURSE_SMTP_DOMAIN $smtp_domain $YML
+check_value DISCOURSE_NOTIFICATION_EMAIL $notification $YML
+check_value DISCOURSE_MAXMIND_LICENSE_KEY $maxmind $YML
+echo "Update values Test succeeded. Removing $YML"
+rm $YML*
+
+# get old (Apr 13, 2018) web_only.yml that's missing MAXMIND and other values
+YML=$DIR/../containers/web_only.yml
+git show 04a06dd05ee5aaec8082c503c8b8429e51f239e0:samples/web_only.yml> $YML
+hostname='new.myhost.com'
+developer='new-admin@mail.myhost.com'
+smtp_address='new.myhostn.com'
+smtp_port='2525'
+smtp_user='newuser'
+smtp_pass='new-smtp-pw'
+notification='somuser@otherhost.com'
+smtp_domain=otherhost.com # NOTE: script uses notification hostnme
+letsencrypt='le-new@myhost.com'
+maxmind='maxthisone'
+$DIR/../discourse-setup --skip-connection-test --skip-rebuild <<EOF 
+$hostname
+$developer
+$smtp_address
+$smtp_port
+$smtp_user
+$smtp_pass
+$notification
+$letsencrypt
+$maxmind
+
+
+EOF
+check_value DISCOURSE_HOSTNAME $hostname $YML
+check_value DISCOURSE_SMTP_ADDRESS $smtp_address $YML
+check_value DISCOURSE_SMTP_PORT $smtp_port $YML
+check_value DISCOURSE_SMTP_USER_NAME $smtp_user $YML
+check_value DISCOURSE_SMTP_PASSWORD \"$smtp_pass\" $YML
+check_value DISCOURSE_SMTP_DOMAIN $smtp_domain $YML
+check_value DISCOURSE_NOTIFICATION_EMAIL $notification $YML
+check_value DISCOURSE_MAXMIND_LICENSE_KEY $maxmind $YML
+echo "Update values Test succeeded. Removing $YML"
+rm $YML*


### PR DESCRIPTION
This is primarily to add ability to set SMTP_DOMAIN and NOTIFICATION_EMAIL in `discourse-setup`. 

@xfalcox asked for this:

- Add a new question to discourse-setup: “What is the email where notifications should come from?” or something like that.
- User replies, let’s say noreply@example.com.
- You split on the @ and set example.com to SMTP_DOMAIN.
- You use the full value and set the notification_email.

This does the above, and will add the required fields to reasonably old existing config files.

My last pull request was broken if it was re-run for existing sites, so this time I have added some basic smoke tests. As part of that I also added some command line switches to `--skip-rebuild` (that works) and `--skip-connection-test` (so we can run this on a host that isn't on the internet). (I also added `--two-container` and deprecated the rather ugly `2container` option).

The tests just run `discourse-setup` and test that values got set or changed as expected. I actually caught a couple bugs!

I also changed the port check to use `nc` rather than `netstat`, which is not included in some distributions.