### PR TITLE
DEV: Parse and install bundler version from Gemfile.lock

### DIFF
--- a/templates/web.template.yml
+++ b/templates/web.template.yml
@@ -144,8 +144,8 @@ run:
       cd: $home
       hook: web
       cmd:
-        # ensure we are on latest bundler
-        - gem update bundler
+        # install bundler version to match Gemfile.lock
+        - gem install bundler --conservative -v $(awk '/BUNDLED WITH/ { getline; gsub(/ /,""); print $0 }' Gemfile.lock)
         - find $home ! -user discourse -exec chown discourse {} \+
 
   - exec:


### PR DESCRIPTION
This ensures that changes in Bundler's behavior are only introduced
when we deliberately bump the version in the Gemfile