### PR TITLE
Reverse the order of nested templates.

### DIFF
--- a/launcher
+++ b/launcher
@@ -280,7 +280,7 @@ find_templates() {
         local nested_templates=$(find_templates $template)
 
         if [ ! -z "$nested_templates" ]; then
-          templates="$templates $nested_templates"
+          templates="$nested_templates $templates"
         fi
       done
 


### PR DESCRIPTION
Reverses the order of nested template declaration.

This way templates that depend nested templates over the same
hook are ensured to run in the proper order.

Ensures consistency of run-order template includes, for both
base yml files, and nested template yml

eg:

base.yml
```
templates:
  - "templates/template1.yml"
hooks:
  after_code:
    - exec: cat "/tmp/file_made_from_template1.yml.txt"
```

template1.yml
```
templates:
  - "templates/template2.yml"
hooks:
  after_code:
    - exec: cat "/tmp/file_made_from_template2.yml"
    - exec: echo "data from template1" > /tmp/file_made_from_template1.yml.txt
```

template2.yml
```
hooks:
  after_code:
    - exec: echo "data from template2" > /tmp/file_made_from_template2.yml.txt
```