### PR TITLE
Add Terser to base image

### DIFF
--- a/image/base/Dockerfile
+++ b/image/base/Dockerfile
@@ -53,6 +53,7 @@ RUN cd / &&\
     rm -f /etc/apt/apt.conf.d/40proxy &&\
     locale-gen en_US &&\
     apt install -y nodejs &&\
+    npm install -g terser &&\
     npm install -g uglify-js &&\
     npm install -g svgo
 


### PR DESCRIPTION
Terser is a replacement for uglify-js. 

This PR adds the dependency, next I will add a PR in core to use Terser if available, and then in a few weeks we can switch to Terser permanently and remove uglify-js from the base image. 