### PR TITLE
Remove Svgo, update ImageMagick, Redis, Libheif

### DIFF
--- a/image/base/Dockerfile
+++ b/image/base/Dockerfile
@@ -54,8 +54,7 @@ RUN cd / &&\
     locale-gen en_US &&\
     apt install -y nodejs &&\
     npm install -g terser &&\
-    npm install -g uglify-js &&\
-    npm install -g svgo
+    npm install -g uglify-js
 
 ADD install-nginx /tmp/install-nginx
 RUN /tmp/install-nginx

--- a/image/base/install-imagemagick
+++ b/image/base/install-imagemagick
@@ -2,15 +2,15 @@
 set -e
 
 # version check: https://github.com/ImageMagick/ImageMagick/releases
-IMAGE_MAGICK_VERSION="7.0.10-58"
-IMAGE_MAGICK_HASH="0daabb64602164940fbf95cbd6f16709903eef5d3eee7bd329da878f17605df5"
+IMAGE_MAGICK_VERSION="7.0.11-6"
+IMAGE_MAGICK_HASH="8adc1605784653b078572b825e8cd1d3d54f8a1b4ba86b32ca253c038f7e4c37"
 
 # version check: https://github.com/strukturag/libheif/releases
-LIBHEIF_VERSION="1.10.0"
-LIBHEIF_HASH="317a44bf157ba297638ab5a258040ef6ec4895d620cd58f52195f3f89c9eea28"
+LIBHEIF_VERSION="1.11.0"
+LIBHEIF_HASH="993c3320e179b8fdce983e3a7e96615af3830077be6b0ab28bfa25579df08d26"
 
 # version check: https://aomedia.googlesource.com/aom
-LIB_AOM_VERSION="2.0.1"
+LIB_AOM_VERSION="3.0.0"
 
 # We use debian, but GitHub CI is stuck on Ubuntu Bionic, so this must be compatible with both
 LIBJPEGTURBO=$(cat /etc/issue | grep -qi Debian && echo 'libjpeg62-turbo libjpeg62-turbo-dev' || echo 'libjpeg-turbo8 libjpeg-turbo8-dev')

--- a/image/base/install-redis
+++ b/image/base/install-redis
@@ -2,8 +2,8 @@
 set -e
 
 # version check: https://redis.io/
-REDIS_VERSION=6.0.10
-REDIS_HASH="79bbb894f9dceb33ca699ee3ca4a4e1228be7fb5547aeb2f99d921e86c1285bd"
+REDIS_VERSION=6.2.1
+REDIS_HASH="cd222505012cce20b25682fca931ec93bd21ae92cb4abfe742cf7b76aa907520"
 
 cd /tmp
 # Prepare Redis source.


### PR DESCRIPTION
As far as I can see, we don't use Svgo anywhere. 