### PR TITLE
no longer allow nested templates

### DIFF
--- a/launcher
+++ b/launcher
@@ -276,15 +276,6 @@ find_templates() {
     local arrTemplates=${templates// / }
 
     if [ ! -z "$templates" ]; then
-      for template in "${arrTemplates[@]}"
-      do
-        local nested_templates=$(find_templates $template)
-
-        if [ ! -z "$nested_templates" ]; then
-          templates="$nested_templates $templates"
-        fi
-      done
-
       echo $templates
     else
       echo ""


### PR DESCRIPTION
Drop support for nested templates. Require strict composition of templates from base app.yml files.