### PR TITLE
FIX: prevent exit if themes:update errors out

### DIFF
--- a/templates/web.template.yml
+++ b/templates/web.template.yml
@@ -165,11 +165,18 @@ run:
       hook: db_migrate
       cmd:
         - su discourse -c 'bundle exec rake db:migrate'
+
+  - exec:
+      cd: $home
+      cmd:
+        - su discourse -c 'bundle exec rake themes:update'
+      raise_on_fail: false
+
   - exec:
       cd: $home
       hook: assets_precompile
       cmd:
-        - su discourse -c 'bundle exec rake themes:update assets:precompile'
+        - su discourse -c 'bundle exec rake assets:precompile'
 
   - file:
      path: /usr/local/bin/discourse


### PR DESCRIPTION
Make themes:update task a best-effort - If a theme becomes unavailable to update (eg, repository deleted, moved, or pubkey deleted), we *probably* don't want to fail the build for this alone.