### PR TITLE
FIX: Avoid printing error message from which when checking docker install

### DIFF
--- a/discourse-setup
+++ b/discourse-setup
@@ -123,15 +123,16 @@ check_IP_match() {
 ## Do we have docker?
 ##
 check_and_install_docker () {
-  docker_path=`which docker.io || which docker`
-  if [ -z $docker_path ]; then
-    read  -p "Docker not installed. Enter to install from https://get.docker.com/ or Ctrl+C to exit"
+  if ! which docker.io docker 2>/dev/null ; then
+    echo Failed to find docker.io or docker on your PATH.
+    read -p "Enter to install Docker from https://get.docker.com/ or Ctrl+C to exit"
     curl https://get.docker.com/ | sh
-  fi
-  docker_path=`which docker.io || which docker`
-  if [ -z $docker_path ]; then
-    echo Docker install failed. Quitting.
-    exit
+
+    if ! which docker.io docker 2>/dev/null ; then
+      echo Still failed to find docker.io or docker on your PATH.
+      echo Docker install failed. Quitting.
+      exit
+    fi
   fi
 }
 


### PR DESCRIPTION
Presently, this is the first thing I see on Fedora when running `discourse-setup`:
```
[root@test discourse]# ./discourse-setup 
/usr/bin/which: no docker.io in (/root/.local/bin:/root/bin:/usr/lib64/ccache:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin)
/usr/bin/which: no docker.io in (/root/.local/bin:/root/bin:/usr/lib64/ccache:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin)
```
These two error messages come from `which docker.io`, which will always report an error on a non-Ubuntu machine. (My understanding is that Ubuntu already had an unrelated package called `docker`, so what is the `docker` executable everywhere else is named `docker.io` instead on Ubuntu.)

These messages don't indicate a problem and are confusing for anyone who has never set up Discourse before or is unaware of how Ubuntu packages Docker.

This PR suppresses the error messages, calls `which` once for both executables (which is preferable, as we're checking for existence, not trying to resolve a particular path), improves the other messages indicating Docker is missing, and nests the second check for Docker so that it happens only if a Docker install is attempted (it's silly to check a second time if we found Docker on the first check).