### PR TITLE
Allow all to connect in with md5 auth using IPv6

### DIFF
--- a/templates/postgres.10.template.yml
+++ b/templates/postgres.10.template.yml
@@ -118,6 +118,12 @@ run:
       from: /^host.*all.*all.*127.*$/
       to: "host all all 0.0.0.0/0 md5"
 
+  # allow all to connect in with md5 auth (IPv6)
+  - replace:
+      filename: "/etc/postgresql/13/main/pg_hba.conf"
+      from: /^host.*all.*all.*::1\/128.*$/
+      to: "host all all ::/0 md5"
+
   - exec:
       background: true
       # use fast shutdown for pg

--- a/templates/postgres.12.template.yml
+++ b/templates/postgres.12.template.yml
@@ -117,6 +117,12 @@ run:
       from: /^host.*all.*all.*127.*$/
       to: "host all all 0.0.0.0/0 md5"
 
+  # allow all to connect in with md5 auth (IPv6)
+  - replace:
+      filename: "/etc/postgresql/13/main/pg_hba.conf"
+      from: /^host.*all.*all.*::1\/128.*$/
+      to: "host all all ::/0 md5"
+
   - exec:
       background: true
       # use fast shutdown for pg

--- a/templates/postgres.13.template.yml
+++ b/templates/postgres.13.template.yml
@@ -192,6 +192,12 @@ run:
       from: /^host.*all.*all.*137.*$/
       to: "host all all 0.0.0.0/0 md5"
 
+  # allow all to connect in with md5 auth (IPv6)
+  - replace:
+      filename: "/etc/postgresql/13/main/pg_hba.conf"
+      from: /^host.*all.*all.*::1\/128.*$/
+      to: "host all all ::/0 md5"
+
   - exec:
       background: true
       # use fast shutdown for pg

--- a/templates/postgres.9.5.template.yml
+++ b/templates/postgres.9.5.template.yml
@@ -118,6 +118,12 @@ run:
       from: /^host.*all.*all.*127.*$/
       to: "host all all 0.0.0.0/0 md5"
 
+  # allow all to connect in with md5 auth (IPv6)
+  - replace:
+      filename: "/etc/postgresql/13/main/pg_hba.conf"
+      from: /^host.*all.*all.*::1\/128.*$/
+      to: "host all all ::/0 md5"
+
   - exec:
       background: true
       # use fast shutdown for pg

--- a/templates/postgres.template.yml
+++ b/templates/postgres.template.yml
@@ -192,6 +192,12 @@ run:
       from: /^host.*all.*all.*127.*$/
       to: "host all all 0.0.0.0/0 md5"
 
+  # allow all to connect in with md5 auth (IPv6)
+  - replace:
+      filename: "/etc/postgresql/13/main/pg_hba.conf"
+      from: /^host.*all.*all.*::1\/128.*$/
+      to: "host all all ::/0 md5"
+
   - exec:
       background: true
       # use fast shutdown for pg


### PR DESCRIPTION
In a Docker environment configured for IPv6 (`"ipv6": true` in _/etc/docker/daemon.json_) a Discourse web container may not be able to connect to the data container using IPv6. 

This PR fixes it by replacing `::1/128` in _/etc/postgresql/13/main/pg_hba.conf_ by `::/0`. That's a similar approach as already working for IPv4.