### PR TITLE
[base image] Specify full docker.io URL

### DIFF
--- a/image/base/Dockerfile
+++ b/image/base/Dockerfile
@@ -1,6 +1,6 @@
 # NAME:     discourse/base
 # VERSION:  release
-FROM debian:buster-slim
+FROM docker.io/library/debian:buster-slim
 
 ENV PG_MAJOR 13
 ENV RUBY_ALLOCATOR /usr/lib/libjemalloc.so.1


### PR DESCRIPTION
It is a good practice to be explicit on which source the images are fetched from