### PR TITLE
FIX: Use the return code from which correctly

### DIFF
--- a/discourse-setup
+++ b/discourse-setup
@@ -122,14 +122,22 @@ check_IP_match() {
 ##
 ## Do we have docker?
 ##
-check_and_install_docker () {
-  if ! which docker.io docker 2>/dev/null ; then
-    echo Failed to find docker.io or docker on your PATH.
+
+check_docker() {
+  (which docker || which docker.io) 2>/dev/null
+  echo $?
+}
+
+check_and_install_docker() {
+  found_docker=$(check_docker)
+  if [ "$found_docker" -ne 0 ]; then
+    echo Failed to find docker or docker.io on your PATH.
     read -p "Enter to install Docker from https://get.docker.com/ or Ctrl+C to exit"
     curl https://get.docker.com/ | sh
 
-    if ! which docker.io docker 2>/dev/null ; then
-      echo Still failed to find docker.io or docker on your PATH.
+    found_docker=$(check_docker)
+    if [ "$found_docker" -ne 0 ]; then
+      echo Still failed to find docker or docker.io on your PATH.
       echo Docker install failed. Quitting.
       exit
     fi


### PR DESCRIPTION
The return code of which is the number of arguments which failed... but what we actually want is 0 when at least one of the docker exectutables is found and nonzero when none are found.