### PR TITLE
Fix line break handling in Cloudflare template

### DIFF
--- a/templates/cloudflare.template.yml
+++ b/templates/cloudflare.template.yml
@@ -6,9 +6,10 @@ run:
         #!/bin/bash -e
         # Download list of CloudFlare ips
         wget https://www.cloudflare.com/ips-v4/ -O - > /tmp/cloudflare-ips
+        echo >> /tmp/cloudflare-ips
         wget https://www.cloudflare.com/ips-v6/ -O - >> /tmp/cloudflare-ips
         # Make into nginx commands and escape for inclusion into sed append command
-        CONTENTS=$(</tmp/cloudflare-ips sed 's/^/set_real_ip_from /' | sed 's/$/;/' | tr '\n' '\\' | sed 's/\\/\\n/g')
+        CONTENTS=$(</tmp/cloudflare-ips sed '/^$/d; s/^.*/set_real_ip_from &;/' | tr '\n' '\\' | sed 's/\\/\\n/g')
         
         echo CloudFlare IPs:
         echo $(echo | sed "/^/a $CONTENTS")


### PR DESCRIPTION
Cloudflare's IP list has gone back and forth between including a trailing line break and omitting it.

When a trailing line break was first added in 2015, it resulted in a bug: https://meta.discourse.org/t/issue-with-cloudflare-template/35113

The trailing line break was removed again in 2021: https://meta.discourse.org/t/cloudflare-template-broken-again/200219

This fixes the template so that it will work regardless of extra line breaks.  It will also safely ignore any empty lines that may appear in the files.