### PR TITLE
FIX: Don't install devDependencies in production image

### DIFF
--- a/image/base/Dockerfile
+++ b/image/base/Dockerfile
@@ -140,6 +140,6 @@ RUN useradd discourse -s /bin/bash -m -U &&\
     chown -R discourse:discourse /var/www/discourse &&\
     cd /var/www/discourse &&\
     sudo -u discourse bundle install --deployment --jobs 4 --without test development &&\
-    sudo -u discourse yarn install &&\
+    sudo -u discourse yarn install --production &&\
     bundle exec rake maxminddb:get &&\
     find /var/www/discourse/vendor/bundle -name tmp -type d -exec rm -rf {} +


### PR DESCRIPTION
devDependencies includes `lefthook`, which can cause some unexpected side effects during git operations in a production image