### PR TITLE
FIX: `yarn install` in web.template.yml

### DIFF
--- a/templates/web.template.yml
+++ b/templates/web.template.yml
@@ -157,6 +157,11 @@ run:
   - exec:
       cd: $home
       cmd:
+        - "[ ! -d 'node_modules' ] || su discourse -c 'yarn install --production'"
+
+  - exec:
+      cd: $home
+      cmd:
         - su discourse -c 'bundle exec rake plugin:pull_compatible_all'
       raise_on_fail: false
 


### PR DESCRIPTION
This is required in case dependency versions have changed between the base image, and the current version of Discourse. `yarn install` will only be run when `node_modules` exists, so this change will only affect builds using recent versions of the base image.