### PR TITLE
PERF: Remove unneeded recursive `chown`

### DIFF
--- a/templates/web.template.yml
+++ b/templates/web.template.yml
@@ -27,7 +27,6 @@ run:
   - exec: /usr/local/bin/ruby -e 'if ENV["DISCOURSE_SMTP_ADDRESS"] == "smtp.example.com"; puts "Aborting! Mail is not configured!"; exit 1; end'
   - exec: /usr/local/bin/ruby -e 'if ENV["DISCOURSE_HOSTNAME"] == "discourse.example.com"; puts "Aborting! Domain is not configured!"; exit 1; end'
   - exec: /usr/local/bin/ruby -e 'if (ENV["DISCOURSE_CDN_URL"] || "")[0..1] == "//"; puts "Aborting! CDN must have a protocol specified. Once fixed you should rebake your posts now to correct all posts."; exit 1; end'
-  - exec: chown -R discourse /home/discourse
   # TODO: move to base image (anacron can not be fired up using rc.d)
   - exec: rm -f /etc/cron.d/anacron
   - file:


### PR DESCRIPTION
This command can take a very long time (> 2 minutes on a CDCK build machine) now that the directory contains the `yarn` cache. However, there are no files in `/home/discourse` that are owned by a different user, so the command does absolutely nothing. This can be demonstrated by using the `-c` flag (which prints any changes made):

```
docker run --rm -it discourse/base:2.0.20210826-1706 /bin/bash -c "time chown -cR discourse /home/discourse"
```

This has an empty output for the latest base image. Therefore this line can be safely removed