### PR TITLE
DEV: Clean yarn cache after yarn install

### DIFF
--- a/image/base/Dockerfile
+++ b/image/base/Dockerfile
@@ -141,5 +141,6 @@ RUN useradd discourse -s /bin/bash -m -U &&\
     cd /var/www/discourse &&\
     sudo -u discourse bundle install --deployment --jobs 4 --without test development &&\
     sudo -u discourse yarn install --production &&\
+    sudo -u discourse yarn cache clean &&\
     bundle exec rake maxminddb:get &&\
     find /var/www/discourse/vendor/bundle -name tmp -type d -exec rm -rf {} +

--- a/templates/web.template.yml
+++ b/templates/web.template.yml
@@ -157,7 +157,7 @@ run:
   - exec:
       cd: $home
       cmd:
-        - "[ ! -d 'node_modules' ] || su discourse -c 'yarn install --production'"
+        - "[ ! -d 'node_modules' ] || su discourse -c 'yarn install --production && yarn cache clean'"
 
   - exec:
       cd: $home


### PR DESCRIPTION
The cache is not required to run the application. This should make the docker image much smaller.

We may want to re-evaluate this decision when switching to yarn v2, which has a very different caching system.