### PR TITLE
FIX: See that force_https is set for lets encrypt

### DIFF
--- a/templates/web.letsencrypt.ssl.template.yml
+++ b/templates/web.letsencrypt.ssl.template.yml
@@ -1,5 +1,6 @@
 env:
   LETSENCRYPT_DIR: "/shared/letsencrypt"
+  DISCOURSE_FORCE_HTTPS: true
 
 hooks:
   after_ssl:


### PR DESCRIPTION
Recent changes to let's encrypt having to do with the surprisingly tragic root certificate update are causing sites not to have `force_https` set. 

This set force_https.

There remain some issues with let's encrypt requesting certs when it shouldn't but this fixes the worst of the problem with little effort.