### PR TITLE
FIX: Remove expired LE root cert from our local validation

### DIFF
--- a/templates/web.letsencrypt.ssl.template.yml
+++ b/templates/web.letsencrypt.ssl.template.yml
@@ -63,7 +63,7 @@ hooks:
         }
 
         cert_exists() {
-          [[ "$(cd $$ENV_LETSENCRYPT_DIR/$$ENV_DISCOURSE_HOSTNAME$1 && openssl verify -CAfile ca.cer fullchain.cer | grep "OK")" ]]
+          [[ "$(cd $$ENV_LETSENCRYPT_DIR/$$ENV_DISCOURSE_HOSTNAME$1 && openssl verify -CAfile <(openssl x509 -in ca.cer) fullchain.cer | grep "OK")" ]]
         }
 
         ########################################################


### PR DESCRIPTION
The old root was getting openssl confused, resulting in a new
certificate on every rebuild that could easily trigger existing let's
encrypt rate-limits.


Fixes https://meta.discourse.org/t/test-for-valid-cert-to-enable-force-https-is-broken-leaving-it-off-when-it-should-be-on/205547?u=falco