### PR TITLE
added github.china template to use github mirror to bypass firewall in China

### DIFF
--- a/templates/github.china.template.yml
+++ b/templates/github.china.template.yml
@@ -1,0 +1,6 @@
+hooks:
+  before_code:
+    - exec:
+       cmd:
+         - git config --global url."https://hub.fastgit.org/".insteadOf "https://github.com/"
+


### PR DESCRIPTION
In China, Github is sometimes blocked by firewall, added a new template to use GitHub mirror hub.fastgit.org to bypass it.