### PR TITLE
DEV: Add oxipng binary to base image

### DIFF
--- a/image/base/Dockerfile
+++ b/image/base/Dockerfile
@@ -63,6 +63,12 @@ RUN /tmp/install-nginx
 
 RUN apt -y install advancecomp jhead jpegoptim libjpeg-turbo-progs optipng
 
+RUN mkdir /oxipng-install && cd /oxipng-install &&\
+      wget https://github.com/shssoichiro/oxipng/releases/download/v5.0.0/oxipng-5.0.0-x86_64-unknown-linux-musl.tar.gz &&\
+      tar -xzf oxipng-5.0.0-x86_64-unknown-linux-musl.tar.gz && cd oxipng-5.0.0-x86_64-unknown-linux-musl &&\
+      cp oxipng /usr/local/bin &&\
+      cd / && rm -rf /oxipng-install
+
 RUN mkdir /jemalloc-stable && cd /jemalloc-stable &&\
       wget https://github.com/jemalloc/jemalloc/releases/download/3.6.0/jemalloc-3.6.0.tar.bz2 &&\
       tar -xjf jemalloc-3.6.0.tar.bz2 && cd jemalloc-3.6.0 && ./configure --prefix=/usr && make && make install &&\


### PR DESCRIPTION
image_optim, a ruby library we use, now has support for oxipng:

 https://github.com/toy/image_optim/pull/190#issuecomment-920433324

So I'm adding the oxipng binary to the base image so that we can
start using it. There currently isn't an apt package for it.