### PR TITLE
Bump base image used with launcher

### DIFF
--- a/launcher
+++ b/launcher
@@ -91,7 +91,7 @@ git_rec_version='1.8.0'
 config_file=containers/"$config".yml
 cidbootstrap=cids/"$config"_bootstrap.cid
 local_discourse=local_discourse
-image="discourse/base:2.0.20211019-0324"
+image="discourse/base:2.0.20211118-0105"
 docker_path=`which docker.io 2> /dev/null || which docker`
 git_path=`which git`
 


### PR DESCRIPTION
This change includes the oxipng binary.

See: 244c9cb110df44eb9d846a24b5572471a2687071
