### PR TITLE
discourse/base: remove vim package

### DIFF
--- a/image/base/Dockerfile
+++ b/image/base/Dockerfile
@@ -40,7 +40,7 @@ RUN apt -y install build-essential rsync \
                        postgresql-${PG_MAJOR} postgresql-client-${PG_MAJOR} \
                        postgresql-contrib-${PG_MAJOR} libpq-dev libreadline-dev \
                        anacron wget \
-                       psmisc vim whois brotli libunwind-dev \
+                       psmisc whois brotli libunwind-dev \
                        libtcmalloc-minimal4 cmake \
                        pngcrush pngquant
 RUN sed -i -e 's/start -q anacron/anacron -s/' /etc/cron.d/anacron


### PR DESCRIPTION
A buffer overflow vulnerability (CVE-2021-3973) has been discovered in
vim. As of the moment, this remains unpatched in Debian. Admittedly the
likelihood of encountering this exploit in the wild within the Discourse
base image is pretty low, but given this image is intended to run
non-interactively vim is not strictly required as a part of the image.
In any case, the package can be added at runtime for debugging purposes.

See https://security-tracker.debian.org/tracker/CVE-2021-3973.