### PR TITLE
discourse_test: re-use bundled gems from the base file

### DIFF
--- a/image/discourse_test/Dockerfile
+++ b/image/discourse_test/Dockerfile
@@ -13,9 +13,10 @@ RUN sudo -E -u discourse -H git config --global user.email "you@example.com" &&\
 RUN gem update bundler --force &&\
       cd /var/www/discourse &&\
       chown -R discourse . &&\
-      rm -fr .bundle &&\
+      bundle config unset deployment &&\
+      bundle config unset without &&\
       sudo -u discourse git pull &&\
-      sudo -u discourse bundle install --standalone --jobs=4
+      sudo -u discourse bundle install --jobs=4
 
 RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add - &&\
     echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list &&\


### PR DESCRIPTION
By doing `rm -rf .bundle` and `bundle install --standalone`, we were setting up bundle to install gems in `./bundle`. The base file installs gems in `./vendor/bundle`. That means that the test image was ending up with two complete copies of our dependencies.

This commit removes the `--standalone` command, and allows the `./vendor/bundle` artifacts to be re-used in the test image.