### PR TITLE
Introduce a discourse/base:slim image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,9 +8,6 @@ on:
 
 jobs:
   base:
-    strategy:
-      matrix:
-        name: ["base", "base_slim"]
     runs-on: [ubuntu-20.04]
     steps:
       - name: enable experimental docker features
@@ -21,15 +18,16 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 1
-      - name: build base image
+      - name: build slim image
         run: |
-          cd image && ruby auto_build.rb ${{ matrix.name }}
+          cd image && ruby auto_build.rb base_slim
+      - name: build release image
+        run: |
+          cd image && ruby auto_build.rb base
       - name: build test_build image
-        if: matrix.name == 'base'
         run: |
           cd image && ruby auto_build.rb discourse_test_build
       - name: run specs
-        if: matrix.name == 'base'
         run: |
           docker run --rm -e RUBY_ONLY=1 -e USE_TURBO=1 -e SKIP_PLUGINS=1 -e SKIP_LINT=1 discourse/discourse_test:build
       - name: Print summary
@@ -42,17 +40,15 @@ jobs:
         run: |
           TAG=`date +%Y%m%d-%H%M`
           docker login --username discoursebuild --password $DOCKERHUB_PASSWORD
-          if [ "${{matrix.name}}" == "base" ]; then
-            docker tag discourse/base:build discourse/base:2.0.$TAG
-            docker tag discourse/base:build discourse/base:release
-            docker push discourse/base:2.0.$TAG
-            docker push discourse/base:release
-          else
-            docker tag discourse/base:build discourse/base:2.0.$TAG-slim
-            docker tag discourse/base:build discourse/base:slim
-            docker push discourse/base:2.0.$TAG-slim
-            docker push discourse/base:slim
-          fi
+          docker tag discourse/base:build discourse/base:2.0.$TAG-slim
+          docker tag discourse/base:build discourse/base:slim
+          docker tag discourse/base:build discourse/base:2.0.$TAG
+          docker tag discourse/base:build discourse/base:release
+
+          docker push discourse/base:2.0.$TAG-slim
+          docker push discourse/base:slim
+          docker push discourse/base:2.0.$TAG
+          docker push discourse/base:release
   test:
     runs-on: [ubuntu-20.04]
     needs: base

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,9 @@ on:
 
 jobs:
   base:
+    strategy:
+      matrix:
+        name: ["base", "base_slim"]
     runs-on: [ubuntu-20.04]
     steps:
       - name: enable experimental docker features
@@ -20,24 +23,36 @@ jobs:
           fetch-depth: 1
       - name: build base image
         run: |
-          cd image && ruby auto_build.rb base
+          cd image && ruby auto_build.rb ${{ matrix.name }}
       - name: build test_build image
+        if: matrix.name == 'base'
         run: |
           cd image && ruby auto_build.rb discourse_test_build
       - name: run specs
+        if: matrix.name == 'base'
         run: |
           docker run --rm -e RUBY_ONLY=1 -e USE_TURBO=1 -e SKIP_PLUGINS=1 -e SKIP_LINT=1 discourse/discourse_test:build
+      - name: Print summary
+        run: |
+          docker images discourse/base
       - name: push to dockerhub
         if: success() && (github.ref == 'refs/heads/main')
         env:
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
         run: |
           TAG=`date +%Y%m%d-%H%M`
-          docker tag discourse/base:build discourse/base:2.0.$TAG
-          docker tag discourse/base:build discourse/base:release
           docker login --username discoursebuild --password $DOCKERHUB_PASSWORD
-          docker push discourse/base:release
-          docker push discourse/base:2.0.$TAG
+          if [ "${{matrix.name}}" == "base" ]; then
+            docker tag discourse/base:build discourse/base:2.0.$TAG
+            docker tag discourse/base:build discourse/base:release
+            docker push discourse/base:2.0.$TAG
+            docker push discourse/base:release
+          else
+            docker tag discourse/base:build discourse/base:2.0.$TAG-slim
+            docker tag discourse/base:build discourse/base:slim
+            docker push discourse/base:2.0.$TAG-slim
+            docker push discourse/base:slim
+          fi
   test:
     runs-on: [ubuntu-20.04]
     needs: base

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,13 @@ jobs:
       - name: run specs
         run: |
           docker run --rm -e RUBY_ONLY=1 -e USE_TURBO=1 -e SKIP_PLUGINS=1 -e SKIP_LINT=1 discourse/discourse_test:build
+      - name: tag images
+        run:
+          TAG=`date +%Y%m%d-%H%M`
+          docker tag discourse/base:build discourse/base:2.0.$TAG-slim
+          docker tag discourse/base:build discourse/base:slim
+          docker tag discourse/base:build discourse/base:2.0.$TAG
+          docker tag discourse/base:build discourse/base:release
       - name: Print summary
         run: |
           docker images discourse/base
@@ -38,13 +45,7 @@ jobs:
         env:
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
         run: |
-          TAG=`date +%Y%m%d-%H%M`
           docker login --username discoursebuild --password $DOCKERHUB_PASSWORD
-          docker tag discourse/base:build discourse/base:2.0.$TAG-slim
-          docker tag discourse/base:build discourse/base:slim
-          docker tag discourse/base:build discourse/base:2.0.$TAG
-          docker tag discourse/base:build discourse/base:release
-
           docker push discourse/base:2.0.$TAG-slim
           docker push discourse/base:slim
           docker push discourse/base:2.0.$TAG

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,7 +104,9 @@ jobs:
         uses: docker/setup-buildx-action@v1
       - name: build base image for aarch64
         run: |
-          cd image/base && docker buildx build . --platform linux/arm64 --load --tag discourse/base:aarch64
+          cd image/base
+          docker buildx build . -f slim.Dockerfile --platform linux/arm64 --load --tag discourse/base:aarch64-slim
+          docker buildx build . -f release.Dockerfile --platform linux/arm64 --load --tag discourse/base:aarch64 --build-arg tag=aarch64-slim
       - name: push to dockerhub
         if: success() && (github.ref == 'refs/heads/main')
         env:

--- a/image/auto_build.rb
+++ b/image/auto_build.rb
@@ -5,6 +5,7 @@ require 'optparse'
 
 images = {
   base: { name: 'base', tag: "discourse/base:build", squash: true },
+  base_slim: { name: 'base', tag: "discourse/base:build_slim", squash: true, extra_args: ' --target base-slim ' },
   discourse_test_build: { name: 'discourse_test', tag: "discourse/discourse_test:build", squash: false},
   discourse_test_public: { name: 'discourse_test', tag: "discourse/discourse_test:release", squash: true, extra_args: ' --build-arg tag=release '},
   discourse_dev: { name: 'discourse_dev', tag: "discourse/discourse_dev:build", squash: false },

--- a/image/auto_build.rb
+++ b/image/auto_build.rb
@@ -4,8 +4,8 @@ require 'pty'
 require 'optparse'
 
 images = {
-  base: { name: 'base', tag: "discourse/base:build", squash: true },
-  base_slim: { name: 'base', tag: "discourse/base:build_slim", squash: true, extra_args: ' --target base-slim ' },
+  base_slim: { name: 'base', tag: "discourse/base:build_slim", squash: true, extra_args: '-f slim.Dockerfile' },
+  base: { name: 'base', tag: "discourse/base:build", extra_args: '-f release.Dockerfile' },
   discourse_test_build: { name: 'discourse_test', tag: "discourse/discourse_test:build", squash: false},
   discourse_test_public: { name: 'discourse_test', tag: "discourse/discourse_test:release", squash: true, extra_args: ' --build-arg tag=release '},
   discourse_dev: { name: 'discourse_dev', tag: "discourse/discourse_dev:build", squash: false },

--- a/image/base/Dockerfile
+++ b/image/base/Dockerfile
@@ -1,6 +1,6 @@
 # NAME:     discourse/base
 # VERSION:  release
-FROM debian:bullseye-slim
+FROM debian:bullseye-slim AS base-slim
 
 ENV PG_MAJOR 13
 ENV RUBY_ALLOCATOR /usr/lib/libjemalloc.so.1
@@ -144,8 +144,11 @@ RUN useradd discourse -s /bin/bash -m -U &&\
     git clone --depth 1 https://github.com/discourse/discourse.git &&\
     cd discourse &&\
     git remote set-branches --add origin tests-passed &&\
-    chown -R discourse:discourse /var/www/discourse &&\
-    cd /var/www/discourse &&\
+    chown -R discourse:discourse /var/www/discourse
+
+FROM base-slim AS base
+
+RUN cd /var/www/discourse &&\
     sudo -u discourse bundle install --deployment --jobs 4 --without test development &&\
     sudo -u discourse yarn install --production &&\
     sudo -u discourse yarn cache clean &&\

--- a/image/base/release.Dockerfile
+++ b/image/base/release.Dockerfile
@@ -1,0 +1,10 @@
+ARG tag=build_slim
+
+FROM discourse/base:$tag
+
+RUN cd /var/www/discourse &&\
+    sudo -u discourse bundle install --deployment --jobs 4 --without test development &&\
+    sudo -u discourse yarn install --production &&\
+    sudo -u discourse yarn cache clean &&\
+    bundle exec rake maxminddb:get &&\
+    find /var/www/discourse/vendor/bundle -name tmp -type d -exec rm -rf {} +

--- a/image/base/slim.Dockerfile
+++ b/image/base/slim.Dockerfile
@@ -1,6 +1,6 @@
 # NAME:     discourse/base
 # VERSION:  release
-FROM debian:bullseye-slim AS base-slim
+FROM debian:bullseye-slim
 
 ENV PG_MAJOR 13
 ENV RUBY_ALLOCATOR /usr/lib/libjemalloc.so.1
@@ -145,12 +145,3 @@ RUN useradd discourse -s /bin/bash -m -U &&\
     cd discourse &&\
     git remote set-branches --add origin tests-passed &&\
     chown -R discourse:discourse /var/www/discourse
-
-FROM base-slim AS base
-
-RUN cd /var/www/discourse &&\
-    sudo -u discourse bundle install --deployment --jobs 4 --without test development &&\
-    sudo -u discourse yarn install --production &&\
-    sudo -u discourse yarn cache clean &&\
-    bundle exec rake maxminddb:get &&\
-    find /var/www/discourse/vendor/bundle -name tmp -type d -exec rm -rf {} +


### PR DESCRIPTION
The base-slim image doesn't run `yarn install` or `bundle install`, so it is much more lightweight. This is intended for use by systems which do their own dependency caching (e.g. GitHub Actions)

The image will be released under the `:slim` tag, and also `:v2.0.{timestamp}-slim`