### PR TITLE
DEV: Fix aarch64 build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,6 +96,11 @@ jobs:
   aarch64:
     runs-on: [ubuntu-20.04]
     needs: base
+    services:
+      registry:
+        image: registry
+        ports:
+          - 5000:5000
     steps:
       - uses: actions/checkout@v2
         with:
@@ -105,11 +110,28 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1
-      - name: build base image for aarch64
+      - name: build slim image
+        working-directory: image/base
         run: |
-          cd image/base
-          docker buildx build . -f slim.Dockerfile --platform linux/arm64 --load --tag discourse/base:aarch64-slim
-          docker buildx build . -f release.Dockerfile --platform linux/arm64 --load --tag discourse/base:aarch64 --build-arg tag=aarch64-slim
+          docker buildx build . --load \
+            -f slim.Dockerfile \
+            --platform linux/arm64 \
+            --tag discourse/base:aarch64-slim
+          docker tag discourse/base:aarch64-slim localhost:5000/discourse/base:aarch64-slim
+          docker push localhost:5000/discourse/base:aarch64-slim 
+      - name: build release image
+        working-directory: image/base
+        run: |
+          docker buildx create --name builder --use --driver-opt network=host
+          docker buildx build . --load \
+            -f release.Dockerfile \
+            --platform linux/arm64 \
+            --network=host \
+            --build-arg from=localhost:5000/discourse/base \
+            --build-arg tag=aarch64-slim \
+            --tag discourse/base:aarch64
+      - name: Print summary
+        run: docker images discourse/base
       - name: push to dockerhub
         if: success() && (github.ref == 'refs/heads/main')
         env:

--- a/image/base/release.Dockerfile
+++ b/image/base/release.Dockerfile
@@ -1,6 +1,7 @@
+ARG from=discourse/base
 ARG tag=build_slim
 
-FROM discourse/base:$tag
+FROM $from:$tag
 
 RUN cd /var/www/discourse &&\
     sudo -u discourse bundle install --deployment --jobs 4 --without test development &&\


### PR DESCRIPTION
buildx can't build `FROM` a local image, so we need to set up a temporary local registry for the intermediate image