### PR TITLE
FIX: md5 auth replace for postgres.13.template.yml

### DIFF
--- a/templates/postgres.13.template.yml
+++ b/templates/postgres.13.template.yml
@@ -189,7 +189,7 @@ run:
   # allow all to connect in with md5 auth
   - replace:
       filename: "/etc/postgresql/13/main/pg_hba.conf"
-      from: /^host.*all.*all.*137.*$/
+      from: /^host.*all.*all.*127.*$/
       to: "host all all 0.0.0.0/0 md5"
 
   # allow all to connect in with md5 auth (IPv6)


### PR DESCRIPTION
There has likely been one `s/12/13/g` too many in this file.
Note: the typo is not present in the default postgres template; only this specific file, which is otherwise identical to the default one.