### PR TITLE
FIX: Use `bundle config` instead of deprecated flags

### DIFF
--- a/image/base/release.Dockerfile
+++ b/image/base/release.Dockerfile
@@ -4,7 +4,10 @@ ARG tag=build_slim
 FROM $from:$tag
 
 RUN cd /var/www/discourse &&\
-    sudo -u discourse bundle install --deployment --jobs 4 --without test development &&\
+    sudo -u discourse bundle config --local deployment true &&\
+    sudo -u discourse bundle config --local path ./vendor/bundle &&\
+    sudo -u discourse bundle config --local without test development &&\
+    sudo -u discourse bundle install --jobs 4 &&\
     sudo -u discourse yarn install --production &&\
     sudo -u discourse yarn cache clean &&\
     bundle exec rake maxminddb:get &&\


### PR DESCRIPTION
Bundler 2.3.0 started re-installing and re-invoking itself based on the `BUNDLED WITH` declaration in the Gemfile.lock. The second run of bundler doesn't receive the flags from the initial invocation.

These flags were deprecated some time ago. The recommended solution is to use `bundle config`, which persists the config to the filesystem for future invocations to load.