### PR TITLE
Add support for btrfs storage driver in docker

### DIFF
--- a/launcher
+++ b/launcher
@@ -168,7 +168,7 @@ check_prereqs() {
   fi
 
   # 2. running an approved storage driver?
-  if ! $docker_path info 2> /dev/null | egrep -q 'Storage Driver: (aufs|zfs|overlay2)$'; then
+  if ! $docker_path info 2> /dev/null | egrep -q 'Storage Driver: (btrfs|aufs|zfs|overlay2)$'; then
     echo "Your Docker installation is not using a supported storage driver.  If we were to proceed you may have a broken install."
     echo "overlay2 is the recommended storage driver, although zfs and aufs may work as well."
     echo "Other storage drivers are known to be problematic."


### PR DESCRIPTION
After several months of using btrfs in our forum in production with no issue, I can say that btrfs seems quite stable and I am proposing to add it to the supported storage drivers under docker.

Using btrfs makes it a breeze to take snapshots and revert to a previous state of discourse, and taking backups with minimal forum interrupt time.

Here is a discussion about it in discourse forum:
https://meta.discourse.org/t/unable-to-rebuild-app-not-supported-docker-storage-driver-btrfs/209200/14