### PR TITLE
FIX: pg_basebackup parameter in take-database-backup

### DIFF
--- a/templates/postgres.10.template.yml
+++ b/templates/postgres.10.template.yml
@@ -155,7 +155,7 @@ run:
         #!/bin/bash
         ID=db-$(date +%F_%T)
         FILENAME=/shared/postgres_backup/$ID.tar.gz
-        pg_basebackup --format=tar --pgdata=- --xlog --gzip --label=$ID > $FILENAME
+        pg_basebackup --format=tar --pgdata=- --wal-method=fetch --gzip --label=$ID > $FILENAME
         echo $FILENAME
 
   - file:

--- a/templates/postgres.12.template.yml
+++ b/templates/postgres.12.template.yml
@@ -154,7 +154,7 @@ run:
         #!/bin/bash
         ID=db-$(date +%F_%T)
         FILENAME=/shared/postgres_backup/$ID.tar.gz
-        pg_basebackup --format=tar --pgdata=- --xlog --gzip --label=$ID > $FILENAME
+        pg_basebackup --format=tar --pgdata=- --wal-method=fetch --gzip --label=$ID > $FILENAME
         echo $FILENAME
 
   - file:

--- a/templates/postgres.13.template.yml
+++ b/templates/postgres.13.template.yml
@@ -229,7 +229,7 @@ run:
         #!/bin/bash
         ID=db-$(date +%F_%T)
         FILENAME=/shared/postgres_backup/$ID.tar.gz
-        pg_basebackup --format=tar --pgdata=- --xlog --gzip --label=$ID > $FILENAME
+        pg_basebackup --format=tar --pgdata=- --wal-method=fetch --gzip --label=$ID > $FILENAME
         echo $FILENAME
 
   - file:

--- a/templates/postgres.template.yml
+++ b/templates/postgres.template.yml
@@ -229,7 +229,7 @@ run:
         #!/bin/bash
         ID=db-$(date +%F_%T)
         FILENAME=/shared/postgres_backup/$ID.tar.gz
-        pg_basebackup --format=tar --pgdata=- --xlog --gzip --label=$ID > $FILENAME
+        pg_basebackup --format=tar --pgdata=- --wal-method=fetch --gzip --label=$ID > $FILENAME
         echo $FILENAME
 
   - file:


### PR DESCRIPTION
`take-database-backup` script tries to use `pg_baseback --xlog` parameter which was remove in postgres >=10.

https://www.postgresql.org/docs/10/app-pgbasebackup.html