### PR TITLE
DEV: add pg and redis gem for protocol-aware healthcheck

### DIFF
--- a/templates/cache-dns.template.yml
+++ b/templates/cache-dns.template.yml
@@ -15,5 +15,6 @@
 
 hooks:
   after_bundle_exec:
+    - exec: "gem install pg redis"
     - exec: "mkdir -p /etc/service/cache_critical_dns/"
     - exec: "cp /var/www/discourse/script/cache_critical_dns /etc/service/cache_critical_dns/run"


### PR DESCRIPTION
The cache_critical_dns script is going to be updated to perform a
healthcheck on the Redis and Postgres hosts prior to caching the
hostname and IP address resolved via DNS. In order to perform a
protocol-aware healthcheck (i.e. a PG/Redis PING-PONG transaction) the
pg and redis gems are required. Ensure the gems are only installed if
the DNS caching behaviour is enabled via templates.