### PR TITLE
Bump base Ruby version to 2.7.6

### DIFF
--- a/image/base/install-ruby
+++ b/image/base/install-ruby
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -e
 
-RUBY_VERSION="2.7.5"
+RUBY_VERSION="2.7.6"
 
-mkdir /src 
+mkdir /src
 git -C /src clone https://github.com/rbenv/ruby-build.git
 cd /src/ruby-build && ./install.sh
 cd / && rm -fr /src


### PR DESCRIPTION
Pulls in fix for CVE-2022-28739

https://www.ruby-lang.org/en/news/2022/04/12/buffer-overrun-in-string-to-float-cve-2022-28739/