### PR TITLE
FIX: rsyslog uses `adm` group now

### DIFF
--- a/image/base/etc/service/rsyslog/run
+++ b/image/base/etc/service/rsyslog/run
@@ -1,7 +1,7 @@
 #!/bin/bash
 exec 2>&1
 cd /
-chgrp syslog /var/log
+chgrp adm /var/log
 chmod g+w /var/log
 rm -f /var/run/rsyslogd.pid
 exec rsyslogd -n


### PR DESCRIPTION
`syslog` group doesn't exist anymore and:

```
# grep -i 'group' /etc/rsyslog.conf
$FileGroup adm
```