### PR TITLE
DEV: Ensure secure file permissions by default

### DIFF
--- a/discourse-setup
+++ b/discourse-setup
@@ -884,7 +884,7 @@ then
   DATE=`date +"%Y-%m-%d-%H%M%S"`
   BACKUP=$app_name.yml.$DATE.bak
   echo Saving old file as $BACKUP
-  cp $web_file containers/$BACKUP
+  install -m0600 $web_file containers/$BACKUP
   if [ "$DEBUG" != "1" ]
   then
     echo "Stopping existing container in 5 seconds or Control-C to cancel."
@@ -902,7 +902,7 @@ else
   then
     check_ports
   fi
-  cp -v $web_template $web_file
+  install -v -m0600 $web_template $web_file
   if [ "$data_name" == "data" ]
   then
     echo "--------------------------------------------------"
@@ -918,7 +918,7 @@ else
       echo "Problem changing DISCOURSE_DB_PASSWORD" in $web_file
     fi
 
-    cp -v $data_template $data_file
+    install -v -m0600 $data_template $data_file
     quote=\'
     sed -i -e "s/password ${quote}SOME_SECRET${quote}/password '$DISCOURSE_DB_PASSWORD'/w $changelog" $data_file
     if  [ -s $changelog ]

--- a/launcher
+++ b/launcher
@@ -278,6 +278,16 @@ check_prereqs() {
     fi
     exit 1
   fi
+
+  # 8. container definition file is accessible and is not insecure (world-readable)
+  if [[ ! -e "$config_file" || ! -r "$config_file" ]]; then
+    echo "ERROR: $config_file does not exist or is not readable."
+    echo
+    echo "Available configs ( `cd containers && ls -dm *.yml | tr -s '\n' ' ' | awk '{ gsub(/\.yml/, ""); print }'`)"
+    exit 1
+  elif [[ "$(find $config_file -perm -004)" ]]; then
+    echo "WARNING: $config_file file is world-readable. You can secure this file by running: chmod o-rwx $config_file"
+  fi
 }
 
 
@@ -485,15 +495,6 @@ fi
 
   exit 0
 }
-
-if [ ! "$command" == "setup" ]; then
-  if [[ ! -e $config_file ]]; then
-    echo "Config file was not found, ensure $config_file exists"
-    echo
-    echo "Available configs ( `cd containers && ls -dm *.yml | tr -s '\n' ' ' | awk '{ gsub(/\.yml/, ""); print }'`)"
-    exit 1
-  fi
-fi
 
 docker_version=($($docker_path --version))
 docker_version=${test[2]//,/}


### PR DESCRIPTION
`discourse-setup` will now ensure container definitions are
installed with `0600` permissions mode only.

`launcher` will now throw a warning when an existing container
definition is world-readable.

Also clean up leftover `launcher setup` logic which no longer exists.
Merge pre-existing logic into `check_prereqs` function.