### PR TITLE
FIX: Unset RAILS_ENV to allow running both dev stuff and test

### DIFF
--- a/image/discourse_dev/Dockerfile
+++ b/image/discourse_dev/Dockerfile
@@ -1,7 +1,9 @@
 # NAME:     discourse/discourse_dev
 # VERSION:  release
 FROM discourse/base:release
-ENV RAILS_ENV development
+
+# Unset RAILS_ENV to allow running both dev stuff and tests
+ENV RAILS_ENV=
 
 #LABEL maintainer="Sam Saffron \"https://twitter.com/samsaffron\""
 


### PR DESCRIPTION
Trying to run specs with RAILS_ENV=development ends up like:

```
/usr/local/lib/ruby/gems/2.7.0/gems/bootsnap-1.11.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30: warning: ⛔️ WARNING: Sidekiq testing API enabled, but this is not the test environment.  Your jobs will not go to Redis.

Randomized with seed 1716
FF

Failures:

  1) CategoryBadge escapes HTML in category names / descriptions
     Failure/Error: DB.test_transaction = ActiveRecord::Base.connection.current_transaction

     NoMethodError:
       undefined method `test_transaction=' for #<MiniSqlMultisiteConnection:0x000055a7662ea1e0>
     # ./spec/rails_helper.rb:284:in `block (2 levels) in <top (required)>'
     # ./spec/rails_helper.rb:277:in `block (2 levels) in <top (required)>'

```