### PR TITLE
Create sqlite-dep.template.yml

### DIFF
--- a/templates/sqlite-dep.template.yml
+++ b/templates/sqlite-dep.template.yml
@@ -1,0 +1,14 @@
+# This template adds the 'sqlite' gem for import scripts depending on it
+
+params:
+  home: /var/www/discourse
+
+hooks:
+  after_bundle_exec:
+    - exec:
+        cd: $home
+        cmd:
+          - echo "gem 'sqlite3'" >> Gemfile
+          - apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y sqlite3 libsqlite3-dev
+          - su discourse -c 'bundle config unset deployment'
+          - su discourse -c 'bundle install --no-deployment --path vendor/bundle --jobs 4 --without test development'


### PR DESCRIPTION
Add template for those times when you just need sqlite3.

Doh! Should I have named it sqlite3-dep.template.yml? (EDIT: Well, I googled a bit and it seems sqlite3 is just the current version of sqlite, so I think the suggested filename is appropriate. :grin: )