### PR TITLE
DEV: Remove Ember CLI flag from templates

### DIFF
--- a/samples/standalone.yml
+++ b/samples/standalone.yml
@@ -40,7 +40,6 @@ env:
   LC_ALL: en_US.UTF-8
   LANG: en_US.UTF-8
   LANGUAGE: en_US.UTF-8
-  EMBER_CLI_PROD_ASSETS: 1
   # DISCOURSE_DEFAULT_LOCALE: en
 
   ## How many concurrent web requests are supported? Depends on memory and CPU cores.

--- a/samples/web_only.yml
+++ b/samples/web_only.yml
@@ -32,8 +32,6 @@ env:
   LC_ALL: en_US.UTF-8
   LANG: en_US.UTF-8
   LANGUAGE: en_US.UTF-8
-  EMBER_CLI_PROD_ASSETS: 1
-
   # DISCOURSE_DEFAULT_LOCALE: en
 
   ## How many concurrent web requests are supported? Depends on memory and CPU cores.


### PR DESCRIPTION
Ember CLI assets are now the only option in Discourse. This flag is now a no-op.