### PR TITLE
DEV: Use yarn `--frozen-lockfile` in production

### DIFF
--- a/image/base/release.Dockerfile
+++ b/image/base/release.Dockerfile
@@ -8,7 +8,7 @@ RUN cd /var/www/discourse &&\
     sudo -u discourse bundle config --local path ./vendor/bundle &&\
     sudo -u discourse bundle config --local without test development &&\
     sudo -u discourse bundle install --jobs 4 &&\
-    sudo -u discourse yarn install --production &&\
+    sudo -u discourse yarn install --production --frozen-lockfile &&\
     sudo -u discourse yarn cache clean &&\
     bundle exec rake maxminddb:get &&\
     find /var/www/discourse/vendor/bundle -name tmp -type d -exec rm -rf {} +

--- a/templates/web.template.yml
+++ b/templates/web.template.yml
@@ -162,7 +162,7 @@ run:
   - exec:
       cd: $home
       cmd:
-        - "[ ! -d 'node_modules' ] || su discourse -c 'yarn install --production && yarn cache clean'"
+        - "[ ! -d 'node_modules' ] || su discourse -c 'yarn install --production --frozen-lockfile && yarn cache clean'"
 
   - exec:
       cd: $home


### PR DESCRIPTION
This ensures that a `yarn install` will never modify the lockfile. We always want to use the lockfile from source control.