### PR TITLE
FIX: Run `yarn install` when building development image

### DIFF
--- a/image/discourse_dev/postgres_dev.template.yml
+++ b/image/discourse_dev/postgres_dev.template.yml
@@ -44,6 +44,8 @@ run:
   - exec: cd tmp && git clone https://github.com/discourse/discourse.git --depth=1
   - exec: chown -R discourse /tmp/discourse
   - exec: cd /tmp/discourse && sudo -u discourse bundle install
+  - exec: cd /tmp/discourse && sudo -u discourse yarn install
+  - exec: cd /tmp/discourse && sudo -u discourse yarn cache clean
   - exec: cd /tmp/discourse && sudo -u discourse bundle exec rake db:migrate
   - exec: cd /tmp/discourse && sudo -u discourse RAILS_ENV=test bundle exec rake db:migrate
   - exec: rm -fr /tmp/discourse


### PR DESCRIPTION
The rails app now leans on JS dependencies being present in node_modules