### PR TITLE
FIX: Reorder yarn/bundle install for compatibility

### DIFF
--- a/templates/web.template.yml
+++ b/templates/web.template.yml
@@ -155,14 +155,14 @@ run:
 
   - exec:
       cd: $home
-      hook: bundle_exec
       cmd:
-        - su discourse -c 'bundle install --deployment --retry 3 --jobs 4 --verbose --without test development'
+        - "[ ! -d 'node_modules' ] || su discourse -c 'yarn install --production --frozen-lockfile && yarn cache clean'"
 
   - exec:
       cd: $home
+      hook: bundle_exec
       cmd:
-        - "[ ! -d 'node_modules' ] || su discourse -c 'yarn install --production --frozen-lockfile && yarn cache clean'"
+        - su discourse -c 'bundle install --deployment --retry 3 --jobs 4 --verbose --without test development'
 
   - exec:
       cd: $home


### PR DESCRIPTION
Some existing templates (e.g. those written by following [the multisite guide](https://meta.discourse.org/t/multisite-configuration-with-docker/14084)) use the `after_bundle_exec` hook to run application code like `multisite:migrate`. Relatively recently, the ruby app has started depending on `yarn` dependencies for basic functionality, and therefore requires `yarn install` to have been run to avoid errors.

This commit moves the `yarn install` step before `bundle install`, so that existing users of the `after_bundle_exec` hook do not need to update their templates.