### PR TITLE
Bump yarn timeout during initial install

### DIFF
--- a/image/base/release.Dockerfile
+++ b/image/base/release.Dockerfile
@@ -8,7 +8,7 @@ RUN cd /var/www/discourse &&\
     sudo -u discourse bundle config --local path ./vendor/bundle &&\
     sudo -u discourse bundle config --local without test development &&\
     sudo -u discourse bundle install --jobs 4 &&\
-    sudo -u discourse yarn install --production --frozen-lockfile &&\
+    sudo -u discourse yarn install --production --frozen-lockfile --network-timeout=600000 &&\
     sudo -u discourse yarn cache clean &&\
     bundle exec rake maxminddb:get &&\
     find /var/www/discourse/vendor/bundle -name tmp -type d -exec rm -rf {} +


### PR DESCRIPTION
Our aarch64 image is built using Docker QEMU on GitHub actions. This is very slow, and often fails due to this yarn timeout. This increase should reduce build failures.