### PR TITLE
Revert "bump base image for Ruby 3.1.3"

### DIFF
--- a/launcher
+++ b/launcher
@@ -91,7 +91,7 @@ git_rec_version='1.8.0'
 config_file=containers/"$config".yml
 cidbootstrap=cids/"$config"_bootstrap.cid
 local_discourse=local_discourse
-image="discourse/base:2.0.20221221-0050"
+image="discourse/base:2.0.20220818-0047"
 docker_path=`which docker.io 2> /dev/null || which docker`
 git_path=`which git`
 


### PR DESCRIPTION
This reverts commit 0595fc28210d1b563723b31baf55995afe856caf.

This image is currently incompatible with the Discourse stable branch.