### PR TITLE
discourse_dev: use local bundler directory for temp install

### DIFF
--- a/image/discourse_dev/postgres_dev.template.yml
+++ b/image/discourse_dev/postgres_dev.template.yml
@@ -43,6 +43,7 @@ run:
 
   - exec: cd tmp && git clone https://github.com/discourse/discourse.git --depth=1
   - exec: chown -R discourse /tmp/discourse
+  - exec: cd /tmp/discourse && sudo -u discourse bundle config --local path ./vendor/bundle
   - exec: cd /tmp/discourse && sudo -u discourse bundle install
   - exec: cd /tmp/discourse && sudo -u discourse yarn install
   - exec: cd /tmp/discourse && sudo -u discourse yarn cache clean


### PR DESCRIPTION
discourse_dev installs a temporary version of Discourse to create a pre-migrated database. Previously this was installing gems in the global bundler directory, which could lead to permissions errors. This commit makes it use a local vendor directory, just like we do in the production install of Discourse.