### PR TITLE
discourse_test: Only apply `ENTRYPOINT` to release image

### DIFF
--- a/image/discourse_test/Dockerfile
+++ b/image/discourse_test/Dockerfile
@@ -5,7 +5,6 @@ ENV RAILS_ENV test
 
 WORKDIR /var/www/discourse
 ENV LANG en_US.UTF-8
-ENTRYPOINT sudo -E -u discourse -H ruby script/docker_test.rb
 
 # configure Git to suppress warnings
 RUN sudo -E -u discourse -H git config --global user.email "you@example.com" &&\
@@ -35,3 +34,5 @@ RUN cd /var/www/discourse &&\
 
 RUN cd /var/www/discourse && sudo -E -u discourse -H bundle exec rake plugin:install_all_official &&\
     sudo -E -u discourse -H bundle exec rake plugin:install_all_gems
+
+ENTRYPOINT sudo -E -u discourse -H ruby script/docker_test.rb


### PR DESCRIPTION
The slim images aren't able to run the full `rake docker:test` task, so having it as the entrypoint doesn't make sense. We only want it as the entrypoint on `discourse_test:release`