### PR TITLE
Setting bundler version to 2.4.1 which is same as version that generated lockfile to avoid failing script

### DIFF
--- a/image/base/slim.Dockerfile
+++ b/image/base/slim.Dockerfile
@@ -84,7 +84,7 @@ RUN /tmp/install-ruby
 RUN echo 'gem: --no-document' >> /usr/local/etc/gemrc &&\
     gem update --system
 
-RUN gem install bundler pups --force &&\
+RUN gem install bundler -v 2.1.4 pups --force &&\
     mkdir -p /pups/bin/ &&\
     ln -s /usr/local/bin/pups /pups/bin/pups
 


### PR DESCRIPTION
Issue - 
```
Status: Downloaded newer image for discourse/discourse_dev:release
docker.io/discourse/discourse_dev:release
49120aa3aeb6f62b848725f057e1b612ccf3dba7e9d32722a9c482d4366bc49c
Installing gems...
Bundler 2.4.3 is running, but your lockfile was generated with 2.4.1. Installing Bundler 2.4.1 and restarting using that version.
Fetching gem metadata from https://rubygems.org/.
Fetching bundler 2.4.1

Retrying download gem from https://rubygems.org/ due to error (2/4): Bundler::PermissionError There was an error while trying to write to `/usr/local/lib/ruby/gems/3.1.0/cache/bundler-2.4.1.gem`. It is likely that you need to grant write permissions for that path.

Retrying download gem from https://rubygems.org/ due to error (3/4): Bundler::PermissionError There was an error while trying to write to `/usr/local/lib/ruby/gems/3.1.0/cache/bundler-2.4.1.gem`. It is likely that you need to grant write permissions for that path.

Retrying download gem from https://rubygems.org/ due to error (4/4): Bundler::PermissionError There was an error while trying to write to `/usr/local/lib/ruby/gems/3.1.0/cache/bundler-2.4.1.gem`. It is likely that you need to grant write permissions for that path.

There was an error installing the locked bundler version (2.4.1), rerun with the `--verbose` flag for more details. Going on using bundler 2.4.3.
Fetching gem metadata from https://rubygems.org/.........
Fetching https://github.com/discourse/mail.git
There was an error while trying to write to `/usr/local/lib/ruby/gems/3.1.0/cache/bundler/git`. It is likely that
you need to grant write permissions for that path.
```

Many people are facing this issue - 

https://meta.discourse.org/t/install-discourse-for-development-using-docker/102009/232