### PR TITLE
handle IPv6 correctly with native docker IPv6 NAT

### DIFF
--- a/templates/web.ssl.template.yml
+++ b/templates/web.ssl.template.yml
@@ -16,6 +16,7 @@ run:
      from: /listen 80;\s+gzip on;/m
      to: |
        listen 443 ssl http2;
+       listen [::]:443 ssl http2;
        SSL_TEMPLATE_SSL_BLOCK
   - replace:
      filename: "/etc/nginx/conf.d/discourse.conf"


### PR DESCRIPTION
the "listen [::]:443 ssl http2;" is also required in the first rewrite section where it was only rewritten to "listen 443 ssl http2;" Otherwise Discourse will reject requests from pure IP6 webbrowser access.

it has to be:
  - replace: filename: "/etc/nginx/conf.d/discourse.conf" from: /listen 80;\s+listen \[::\]:80;\s+gzip on;/m to: | listen 443 ssl http2; listen [::]:443 ssl http2; SSL_TEMPLATE_SSL_BLOCK

With this change the docker IPv6 NAT is handled correctly by Discourse.

In order to enable IP6 in docker without the userland-proxy do create the file /etc/docker/daemon.json and do restart the docker daemon. Then the original IP6 from the accessing client is visible in Discourse for the admins under last IP address and can be checked with the IP check. With the userland-proxy only the IP4 address of the docker daemon would be shown there.

Here the content of my daemon.json (I just anonymized my DNS servers a little bit with the xxx): {
  "userland-proxy": false,
  "ipv6": true,
  "fixed-cidr-v6": "fd00::/80",
  "experimental": true,
  "ip6tables": true,
  "dns": ["xxx.169.148.34","xxx.214.7.22","8.8.8.8","8.8.4.4"]
}

With this the docker container is not exposed directly to the internet with a global IPv6 but instead it is running with a ULA that is not accessible globally. So IP6 is handled in docker with NAT like IP4.
And Discourse is now reachable by IP4 and IP6 and always the original IP address is visible in Discourse.