### PR TITLE
FIX: Relax min kernel version

### DIFF
--- a/launcher
+++ b/launcher
@@ -87,7 +87,7 @@ docker_min_version='17.03.1'
 docker_rec_version='17.06.2'
 git_min_version='1.8.0'
 git_rec_version='1.8.0'
-kernel_min_version='4.14.0'
+kernel_min_version='4.4.0'
 
 config_file=containers/"$config".yml
 cidbootstrap=cids/"$config"_bootstrap.cid


### PR DESCRIPTION
Users reported Discourse installing fine on kernel 4.4+.

See https://meta.discourse.org/t/kernel-version-upgrade-required-when-manually-updating-discourse/253756?u=falco
