### PR TITLE
Correct parameter naming for PTY.spawn

### DIFF
--- a/image/auto_build.rb
+++ b/image/auto_build.rb
@@ -12,9 +12,9 @@ images = {
 
 def run(command)
   lines = []
-  PTY.spawn(command) do |stdin, stdout, pid|
+  PTY.spawn(command) do |stdout, stdin, pid|
     begin
-      stdin.each do |line|
+      stdout.each do |line|
         lines << line
         puts line
       end


### PR DESCRIPTION
Per the docs, first parameter for the block is STDOUT + STDERR, 2nd one is STDIN:

https://ruby-doc.org/3.1.3/exts/pty/PTY.html#method-c-spawn

As it is now, the method looks like it's reading from STDIN, though in fact it's reading from an incorrectly named parameter for STDOUT.