### PR TITLE
Allow namespacing locally built images

### DIFF
--- a/launcher
+++ b/launcher
@@ -91,7 +91,7 @@ kernel_min_version='4.4.0'
 
 config_file=containers/"$config".yml
 cidbootstrap=cids/"$config"_bootstrap.cid
-local_discourse=local_discourse
+local_discourse="${DISCOURSE_NAMESPACE:-local_discourse}"
 image="discourse/base:2.0.20230222-0048"
 image_stable="discourse/base:2.0.20230222-0048"
 docker_path=`which docker.io 2> /dev/null || which docker`


### PR DESCRIPTION
We have a system that manages local Docker images on our machines, and we need images to have an appropriate prefix for things to work properly.

This change allows changing the image namespace by setting the `DISCOURSE_NAMESPACE` environment variable, defaulting to `local_discourse` when not set.