### PR TITLE
Replace egrep with grep -E (egrep is deprecated)

### DIFF
--- a/discourse-doctor
+++ b/discourse-doctor
@@ -209,7 +209,7 @@ dump_yaml() {
 ## read a variable from the config file and stick it in read_config_result
 ##
 read_config() {
-  config_line=$(egrep "^  #?$1:" $web_file)
+  config_line=$(grep -E "^  #?$1:" $web_file)
   read_config_result=$(echo $config_line | awk  -F ":" '{print $2}')
   read_config_result=$(echo $read_config_result | sed "s/^\([\"']\)\(.*\)\1\$/\2/g")
 }

--- a/discourse-setup
+++ b/discourse-setup
@@ -343,13 +343,13 @@ check_port() {
 ## read a variable from the config file
 ##
 read_config() {
-  config_line=`egrep "^  #?$1:" $web_file`
+  config_line=`grep -E "^  #?$1:" $web_file`
   read_config_result=`echo $config_line | awk  -F":" '{print $2}'`
   read_config_result=`echo $read_config_result | sed "s/^\([\"']\)\(.*\)\1\$/\2/g"`
 }
 
 read_default() {
-  config_line=`egrep "^  #?$1:" samples/standalone.yml`
+  config_line=`grep -E "^  #?$1:" samples/standalone.yml`
   read_default_result=`echo $config_line | awk  -F":" '{print $2}'`
   read_default_result=`echo $read_config_result | sed "s/^\([\"']\)\(.*\)\1\$/\2/g"`
 }

--- a/launcher
+++ b/launcher
@@ -174,7 +174,7 @@ check_prereqs() {
   fi
 
   # 2. running an approved storage driver?
-  if ! $docker_path info 2> /dev/null | egrep -q 'Storage Driver: (btrfs|aufs|zfs|overlay2)$'; then
+  if ! $docker_path info 2> /dev/null | grep -Eq 'Storage Driver: (btrfs|aufs|zfs|overlay2)$'; then
     echo "Your Docker installation is not using a supported storage driver.  If we were to proceed you may have a broken install."
     echo "overlay2 is the recommended storage driver, although zfs and aufs may work as well."
     echo "Other storage drivers are known to be problematic."


### PR DESCRIPTION
This PR changes all usages of `egrep` with `grep -E` since GNU deprecated them and decided it was a good idea to print a warning at every invocation, which is super annoying on distributions with up-to-date coreutils: https://unix.stackexchange.com/a/727773