### PR TITLE
Make oxipng work on non-x64 architectures

### DIFF
--- a/image/base/install-oxipng
+++ b/image/base/install-oxipng
@@ -9,6 +9,13 @@ OXIPNG_HASH="f794df937abcc2ef9357dcc52c39908f390461921fcbd19793f35d33120bfc8e"
 # Install other deps
 apt -y -q install advancecomp jhead jpegoptim libjpeg-turbo-progs optipng
 
+if [ $(dpkg --print-architecture) != "amd64" ]; then
+  cargo install oxipng@${OXIPNG_VERSION}
+  rm -rf /usr/local/cargo/registry
+  
+  exit 0
+fi
+
 mkdir /oxipng-install
 cd /oxipng-install
 

--- a/image/base/slim.Dockerfile
+++ b/image/base/slim.Dockerfile
@@ -69,14 +69,14 @@ RUN /tmp/install-jemalloc
 ADD install-nginx /tmp/install-nginx
 RUN /tmp/install-nginx
 
-ADD install-oxipng /tmp/install-oxipng
-RUN /tmp/install-oxipng
-
 ADD install-redis /tmp/install-redis
 RUN /tmp/install-redis
 
 ADD install-rust /tmp/install-rust
 RUN /tmp/install-rust
+
+ADD install-oxipng /tmp/install-oxipng
+RUN /tmp/install-oxipng
 
 ADD install-ruby /tmp/install-ruby
 RUN /tmp/install-ruby


### PR DESCRIPTION
On non-x64 architectures we'll install it via cargo rather than downloading a binary from github releases (sorry for ruining your alphabetically sorted install script list)