### PR TITLE
Compile oxipng from source

### DIFF
--- a/image/base/install-oxipng
+++ b/image/base/install-oxipng
@@ -2,20 +2,23 @@
 set -e
 
 # version check: https://github.com/shssoichiro/oxipng/releases
-OXIPNG_VERSION="7.0.0"
-OXIPNG_FILE="oxipng-${OXIPNG_VERSION}-x86_64-unknown-linux-musl.tar.gz"
-OXIPNG_HASH="f794df937abcc2ef9357dcc52c39908f390461921fcbd19793f35d33120bfc8e"
+OXIPNG_VERSION="8.0.0"
+OXIPNG_HASH="ef96d6340e70900de0a38ace8f5f20878f6c256b18b0c59cd87f2b515437b87b"
+OXIPNG_ARCHIVE="v${OXIPNG_VERSION}.tar.gz"
+OXIPNG_DIR="oxipng-${OXIPNG_VERSION}"
 
 # Install other deps
-apt -y -q install advancecomp jhead jpegoptim libjpeg-turbo-progs optipng
+apt-get -y install advancecomp jhead jpegoptim libjpeg-turbo-progs optipng
 
-mkdir /oxipng-install
-cd /oxipng-install
+cd /tmp
+wget -q https://github.com/shssoichiro/oxipng/archive/refs/tags/${OXIPNG_ARCHIVE}
+sha256sum ${OXIPNG_ARCHIVE}
+echo "${OXIPNG_HASH} ${OXIPNG_ARCHIVE}" | sha256sum -c
 
-wget -q https://github.com/shssoichiro/oxipng/releases/download/v${OXIPNG_VERSION}/${OXIPNG_FILE}
-sha256sum ${OXIPNG_FILE}
-echo "${OXIPNG_HASH} ${OXIPNG_FILE}" | sha256sum -c
+tar -zxf ${OXIPNG_ARCHIVE}
+cd ${OXIPNG_DIR}
 
-tar --strip-components=1 -xzf $OXIPNG_FILE
-cp -v ./oxipng /usr/local/bin
-cd / && rm -fr /oxipng-install
+/usr/local/cargo/bin/cargo build --release
+cp target/release/oxipng /usr/local/bin
+
+cd / && rm -fr /tmp/${OXIPNG_DIR}

--- a/image/base/slim.Dockerfile
+++ b/image/base/slim.Dockerfile
@@ -69,14 +69,14 @@ RUN /tmp/install-jemalloc
 ADD install-nginx /tmp/install-nginx
 RUN /tmp/install-nginx
 
-ADD install-oxipng /tmp/install-oxipng
-RUN /tmp/install-oxipng
-
 ADD install-redis /tmp/install-redis
 RUN /tmp/install-redis
 
 ADD install-rust /tmp/install-rust
 RUN /tmp/install-rust
+
+ADD install-oxipng /tmp/install-oxipng
+RUN /tmp/install-oxipng
 
 ADD install-ruby /tmp/install-ruby
 RUN /tmp/install-ruby


### PR DESCRIPTION
Download oxipng source from GitHub and compile it.

Also uses v8.0.0 instead of v7.0.0. There is a breaking change in the changelog, "Revamp alpha optimization", presumably that only impacts the files generated.

I'm not sure if it's still necessary to install the deps as Cargo pulls down what it needs, but leaving.