### PR TITLE
DEV: Eliminate warnings and noise during image build

### DIFF
--- a/image/base/install-imagemagick
+++ b/image/base/install-imagemagick
@@ -15,15 +15,15 @@ PREFIX=/usr/local
 WDIR=/tmp/imagemagick
 
 # Install build deps
-apt-get -y -q remove imagemagick
-apt-get -y -q install git make gcc pkg-config autoconf curl g++ yasm cmake \
+apt-get -y remove imagemagick
+apt-get -y install git make gcc pkg-config autoconf curl g++ yasm cmake \
     libde265-0 libde265-dev ${LIBJPEGTURBO} x265 libx265-dev libtool \
     libpng16-16 libpng-dev ${LIBJPEGTURBO} ${LIBWEBP} libwebp-dev libgomp1 \
     libwebpmux3 libwebpdemux2 ghostscript libxml2-dev libxml2-utils librsvg2-dev \
     libltdl7-dev libbz2-dev gsfonts libtiff-dev libfreetype6-dev libjpeg-dev
 
 # Use backports instead of compiling it
-apt-get -y -q install -t bullseye-backports libheif1 libaom-dev libheif-dev
+apt-get -y -t bullseye-backports install libheif1 libaom-dev libheif-dev
 
 mkdir -p $WDIR
 cd $WDIR

--- a/image/base/install-imagemagick
+++ b/image/base/install-imagemagick
@@ -33,7 +33,7 @@ wget -q -O $WDIR/ImageMagick.tar.gz "https://github.com/ImageMagick/ImageMagick/
 sha256sum $WDIR/ImageMagick.tar.gz
 echo "$IMAGE_MAGICK_HASH $WDIR/ImageMagick.tar.gz" | sha256sum -c
 IMDIR=$WDIR/$(tar tzf $WDIR/ImageMagick.tar.gz --wildcards "ImageMagick-*/configure" |cut -d/ -f1)
-tar zxf $WDIR/ImageMagick.tar.gz -C $WDIR
+tar -zxf $WDIR/ImageMagick.tar.gz -C $WDIR
 cd $IMDIR
 PKG_CONF_LIBDIR=$PREFIX/lib LDFLAGS=-L$PREFIX/lib CFLAGS=-I$PREFIX/include ./configure \
           --prefix=$PREFIX \

--- a/image/base/install-imagemagick
+++ b/image/base/install-imagemagick
@@ -14,6 +14,8 @@ LIBWEBP=$(cat /etc/issue | grep -qi 'Ubuntu 22.04' && echo 'libwebp7' || echo 'l
 PREFIX=/usr/local
 WDIR=/tmp/imagemagick
 
+export DEBIAN_FRONTEND=noninteractive
+
 # Install build deps
 apt-get -y remove imagemagick
 apt-get -y install git make gcc pkg-config autoconf curl g++ yasm cmake \

--- a/image/base/install-imagemagick
+++ b/image/base/install-imagemagick
@@ -15,15 +15,15 @@ PREFIX=/usr/local
 WDIR=/tmp/imagemagick
 
 # Install build deps
-apt -y -q remove imagemagick
-apt -y -q install git make gcc pkg-config autoconf curl g++ yasm cmake \
+apt-get -y -q remove imagemagick
+apt-get -y -q install git make gcc pkg-config autoconf curl g++ yasm cmake \
     libde265-0 libde265-dev ${LIBJPEGTURBO} x265 libx265-dev libtool \
     libpng16-16 libpng-dev ${LIBJPEGTURBO} ${LIBWEBP} libwebp-dev libgomp1 \
     libwebpmux3 libwebpdemux2 ghostscript libxml2-dev libxml2-utils librsvg2-dev \
     libltdl7-dev libbz2-dev gsfonts libtiff-dev libfreetype6-dev libjpeg-dev
 
 # Use backports instead of compiling it
-apt -y -q install -t bullseye-backports libheif1 libaom-dev libheif-dev
+apt-get -y -q install -t bullseye-backports libheif1 libaom-dev libheif-dev
 
 mkdir -p $WDIR
 cd $WDIR

--- a/image/base/install-nginx
+++ b/image/base/install-nginx
@@ -24,7 +24,38 @@ git submodule update --init
 
 cd /tmp/nginx-$VERSION
 # ignoring depracations with -Wno-deprecated-declarations while we wait for this https://github.com/google/ngx_brotli/issues/39#issuecomment-254093378
-./configure --with-cc-opt='-g -O2 -fPIE -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -Wno-deprecated-declarations' --with-ld-opt='-Wl,-Bsymbolic-functions -fPIE -pie -Wl,-z,relro -Wl,-z,now' --prefix=/usr/share/nginx --conf-path=/etc/nginx/nginx.conf --http-log-path=/var/log/nginx/access.log --error-log-path=/var/log/nginx/error.log --lock-path=/var/lock/nginx.lock --pid-path=/run/nginx.pid --http-client-body-temp-path=/var/lib/nginx/body --http-fastcgi-temp-path=/var/lib/nginx/fastcgi --http-proxy-temp-path=/var/lib/nginx/proxy --http-scgi-temp-path=/var/lib/nginx/scgi --http-uwsgi-temp-path=/var/lib/nginx/uwsgi --with-debug --with-pcre-jit --with-ipv6 --with-http_ssl_module --with-http_stub_status_module --with-http_realip_module --with-http_auth_request_module --with-http_addition_module --with-http_dav_module --with-http_gunzip_module --with-http_gzip_static_module --with-http_v2_module --with-http_sub_module --with-stream --with-stream_ssl_module --with-mail --with-mail_ssl_module --with-threads --add-module=/tmp/ngx_brotli
+./configure --with-cc-opt='-g -O2 -fPIE -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -Wno-deprecated-declarations' \
+    --with-ld-opt='-Wl,-Bsymbolic-functions -fPIE -pie -Wl,-z,relro -Wl,-z,now' \
+    --prefix=/usr/share/nginx \
+    --conf-path=/etc/nginx/nginx.conf \
+    --http-log-path=/var/log/nginx/access.log \
+    --error-log-path=/var/log/nginx/error.log \
+    --lock-path=/var/lock/nginx.lock \
+    --pid-path=/run/nginx.pid \
+    --http-client-body-temp-path=/var/lib/nginx/body \
+    --http-fastcgi-temp-path=/var/lib/nginx/fastcgi \
+    --http-proxy-temp-path=/var/lib/nginx/proxy \
+    --http-scgi-temp-path=/var/lib/nginx/scgi \
+    --http-uwsgi-temp-path=/var/lib/nginx/uwsgi \
+    --with-debug \
+    --with-pcre-jit \
+    --with-ipv6 \
+    --with-http_ssl_module \
+    --with-http_stub_status_module \
+    --with-http_realip_module \
+    --with-http_auth_request_module \
+    --with-http_addition_module \
+    --with-http_dav_module \
+    --with-http_gunzip_module \
+    --with-http_gzip_static_module \
+    --with-http_v2_module \
+    --with-http_sub_module \
+    --with-stream \
+    --with-stream_ssl_module \
+    --with-mail \
+    --with-mail_ssl_module \
+    --with-threads \
+    --add-module=/tmp/ngx_brotli
 
 make install
 

--- a/image/base/install-nginx
+++ b/image/base/install-nginx
@@ -15,7 +15,7 @@ tar zxf nginx-$NGINX_VERSION.tar.gz
 cd nginx-$NGINX_VERSION
 
 # nginx-common for boilerplate files etc.
-apt install -y nginx-common
+apt-get -y install nginx-common
 
 cd /tmp
 # this is the reason we are compiling by hand...

--- a/image/base/install-nginx
+++ b/image/base/install-nginx
@@ -2,15 +2,17 @@
 set -e
 
 # version check: https://nginx.org/en/download.html
-VERSION=1.23.3
-HASH="75cb5787dbb9fae18b14810f91cc4343f64ce4c24e27302136fb52498042ba54"
+NGINX_VERSION=1.23.3
+NGINX_HASH="75cb5787dbb9fae18b14810f91cc4343f64ce4c24e27302136fb52498042ba54"
+NGINX_TEMP_DIR=/var/lib/nginx
+NGINX_LOG_DIR=/var/log/nginx
 
 cd /tmp
-wget -q https://nginx.org/download/nginx-$VERSION.tar.gz
-sha256sum nginx-$VERSION.tar.gz
-echo "$HASH nginx-$VERSION.tar.gz" | sha256sum -c
-tar zxf nginx-$VERSION.tar.gz
-cd nginx-$VERSION
+wget -q https://nginx.org/download/nginx-$NGINX_VERSION.tar.gz
+sha256sum nginx-$NGINX_VERSION.tar.gz
+echo "$NGINX_HASH nginx-$NGINX_VERSION.tar.gz" | sha256sum -c
+tar zxf nginx-$NGINX_VERSION.tar.gz
+cd nginx-$NGINX_VERSION
 
 # nginx-common for boilerplate files etc.
 apt install -y nginx-common
@@ -22,21 +24,21 @@ git clone https://github.com/google/ngx_brotli.git
 cd /tmp/ngx_brotli
 git submodule update --init
 
-cd /tmp/nginx-$VERSION
+cd /tmp/nginx-$NGINX_VERSION
 # ignoring depracations with -Wno-deprecated-declarations while we wait for this https://github.com/google/ngx_brotli/issues/39#issuecomment-254093378
 ./configure --with-cc-opt='-g -O2 -fPIE -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -Wno-deprecated-declarations' \
     --with-ld-opt='-Wl,-Bsymbolic-functions -fPIE -pie -Wl,-z,relro -Wl,-z,now' \
     --prefix=/usr/share/nginx \
     --conf-path=/etc/nginx/nginx.conf \
-    --http-log-path=/var/log/nginx/access.log \
-    --error-log-path=/var/log/nginx/error.log \
+    --http-log-path=${NGINX_LOG_DIR}/access.log \
+    --error-log-path=${NGINX_LOG_DIR}/error.log \
     --lock-path=/var/lock/nginx.lock \
     --pid-path=/run/nginx.pid \
-    --http-client-body-temp-path=/var/lib/nginx/body \
-    --http-fastcgi-temp-path=/var/lib/nginx/fastcgi \
-    --http-proxy-temp-path=/var/lib/nginx/proxy \
-    --http-scgi-temp-path=/var/lib/nginx/scgi \
-    --http-uwsgi-temp-path=/var/lib/nginx/uwsgi \
+    --http-client-body-temp-path=${NGINX_TEMP_DIR}/body \
+    --http-fastcgi-temp-path=${NGINX_TEMP_DIR}/fastcgi \
+    --http-proxy-temp-path=${NGINX_TEMP_DIR}/proxy \
+    --http-scgi-temp-path=${NGINX_TEMP_DIR}/scgi \
+    --http-uwsgi-temp-path=${NGINX_TEMP_DIR}/uwsgi \
     --with-debug \
     --with-pcre-jit \
     --with-http_ssl_module \

--- a/image/base/install-nginx
+++ b/image/base/install-nginx
@@ -11,7 +11,7 @@ cd /tmp
 wget -q https://nginx.org/download/nginx-$NGINX_VERSION.tar.gz
 sha256sum nginx-$NGINX_VERSION.tar.gz
 echo "$NGINX_HASH nginx-$NGINX_VERSION.tar.gz" | sha256sum -c
-tar zxf nginx-$NGINX_VERSION.tar.gz
+tar -zxf nginx-$NGINX_VERSION.tar.gz
 cd nginx-$NGINX_VERSION
 
 # nginx-common for boilerplate files etc.

--- a/image/base/install-nginx
+++ b/image/base/install-nginx
@@ -7,6 +7,8 @@ NGINX_HASH="75cb5787dbb9fae18b14810f91cc4343f64ce4c24e27302136fb52498042ba54"
 NGINX_TEMP_DIR=/var/lib/nginx
 NGINX_LOG_DIR=/var/log/nginx
 
+export DEBIAN_FRONTEND=noninteractive
+
 cd /tmp
 wget -q https://nginx.org/download/nginx-$NGINX_VERSION.tar.gz
 sha256sum nginx-$NGINX_VERSION.tar.gz

--- a/image/base/install-nginx
+++ b/image/base/install-nginx
@@ -39,7 +39,6 @@ cd /tmp/nginx-$VERSION
     --http-uwsgi-temp-path=/var/lib/nginx/uwsgi \
     --with-debug \
     --with-pcre-jit \
-    --with-ipv6 \
     --with-http_ssl_module \
     --with-http_stub_status_module \
     --with-http_realip_module \

--- a/image/base/install-oxipng
+++ b/image/base/install-oxipng
@@ -7,6 +7,8 @@ OXIPNG_HASH="ef96d6340e70900de0a38ace8f5f20878f6c256b18b0c59cd87f2b515437b87b"
 OXIPNG_ARCHIVE="v${OXIPNG_VERSION}.tar.gz"
 OXIPNG_DIR="oxipng-${OXIPNG_VERSION}"
 
+export DEBIAN_FRONTEND=noninteractive
+
 # Install other deps
 apt-get -y install advancecomp jhead jpegoptim libjpeg-turbo-progs optipng
 

--- a/image/base/install-redis
+++ b/image/base/install-redis
@@ -11,7 +11,7 @@ wget -q http://download.redis.io/releases/redis-$REDIS_VERSION.tar.gz
 sha256sum redis-$REDIS_VERSION.tar.gz
 echo "$REDIS_HASH redis-$REDIS_VERSION.tar.gz" | sha256sum -c
 
-tar zxf redis-$REDIS_VERSION.tar.gz
+tar -zxf redis-$REDIS_VERSION.tar.gz
 cd redis-$REDIS_VERSION
 
 # Building and installing binaries.

--- a/image/base/install-ruby
+++ b/image/base/install-ruby
@@ -4,7 +4,7 @@ set -e
 RUBY_VERSION="3.2.1"
 export CONFIGURE_OPTS="--enable-yjit"
 
-apt-get -y install --no-install-recommends ruby bison libffi-dev
+apt-get -y --no-install-recommends install ruby bison libffi-dev
 
 mkdir /src
 git -C /src clone https://github.com/rbenv/ruby-build.git

--- a/image/base/install-ruby
+++ b/image/base/install-ruby
@@ -3,6 +3,7 @@ set -e
 
 RUBY_VERSION="3.2.1"
 export CONFIGURE_OPTS="--enable-yjit"
+export DEBIAN_FRONTEND=noninteractive
 
 apt-get -y --no-install-recommends install ruby bison libffi-dev
 

--- a/image/base/install-rust
+++ b/image/base/install-rust
@@ -19,7 +19,7 @@ case "${dpkgArch##*-}" in
 esac
 
 url="https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/${rustArch}/rustup-init"
-wget "$url"
+wget -q "$url"
 echo "${rustupSha256} *rustup-init" | sha256sum -c -
 chmod +x rustup-init
 ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${rustArch}

--- a/image/base/slim.Dockerfile
+++ b/image/base/slim.Dockerfile
@@ -25,12 +25,14 @@ ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8
 
-RUN curl --no-progress-meter https://apt.postgresql.org/pub/repos/apt/ACCC4CF8.asc | apt-key add -
-RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main" | \
-        tee /etc/apt/sources.list.d/postgres.list
-RUN curl --silent --location https://deb.nodesource.com/setup_18.x | sudo bash -
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list
+RUN curl -sS https://apt.postgresql.org/pub/repos/apt/ACCC4CF8.asc | gpg --dearmor > /usr/share/keyrings/pgdg.gpg
+RUN echo "deb [signed-by=/usr/share/keyrings/pgdg.gpg] https://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main" > /etc/apt/sources.list.d/postgres.list
+
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor > /usr/share/keyrings/yarn.gpg
+RUN echo "deb [signed-by=/usr/share/keyrings/yarn.gpg] https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list
+
+RUN curl -sS https://deb.nodesource.com/setup_18.x | sudo bash -
+
 RUN apt-get -y update
 # install these without recommends to avoid pulling in e.g.
 # X11 libraries, mailutils

--- a/image/base/slim.Dockerfile
+++ b/image/base/slim.Dockerfile
@@ -25,7 +25,7 @@ ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8
 
-RUN curl https://apt.postgresql.org/pub/repos/apt/ACCC4CF8.asc | apt-key add -
+RUN curl --no-progress-meter https://apt.postgresql.org/pub/repos/apt/ACCC4CF8.asc | apt-key add -
 RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main" | \
         tee /etc/apt/sources.list.d/postgres.list
 RUN curl --silent --location https://deb.nodesource.com/setup_18.x | sudo bash -


### PR DESCRIPTION
This eliminates most of the warnings in the build process from `apt` and `apt-key`. It also disables the progress output from a couple `wget` and `curl` commands which weren't already.

Removed the deprecated option `--with-ipv6` for nginx.