### PR TITLE
DEV: Create partial clone of discourse repository

### DIFF
--- a/image/base/slim.Dockerfile
+++ b/image/base/slim.Dockerfile
@@ -122,5 +122,4 @@ COPY sbin/ /sbin
 # Discourse specific bits
 RUN useradd discourse -s /bin/bash -m -U &&\
     install -dm 0755 -o discourse -g discourse /var/www/discourse &&\
-    sudo -u discourse git clone --depth 1 https://github.com/discourse/discourse.git /var/www/discourse &&\
-    sudo -u discourse git -C /var/www/discourse remote set-branches --add origin tests-passed
+    sudo -u discourse git clone --filter=tree:0 https://github.com/discourse/discourse.git /var/www/discourse

--- a/templates/web.template.yml
+++ b/templates/web.template.yml
@@ -88,10 +88,8 @@ run:
       cmd:
         - sudo -H -E -u discourse git reset --hard
         - sudo -H -E -u discourse git clean -f
-        - sudo -H -E -u discourse git remote set-branches --add origin main
-        - sudo -H -E -u discourse git remote set-branches origin $version
-        - sudo -H -E -u discourse git fetch --depth 1 origin $version
-        - sudo -H -E -u discourse git checkout $version
+        - sudo -H -E -u discourse git fetch --prune --prune-tags origin $version
+        - sudo -H -E -u discourse bash -c 'if [[ $(git symbolic-ref --short HEAD) == $version ]] ; then (git pull) ; else (git -c advice.detachedHead=false checkout $version) ; fi'
         - mkdir -p tmp
         - chown discourse:www-data tmp
         - mkdir -p tmp/pids


### PR DESCRIPTION
A treeless clone is nearly as small as a shallow clone, but it contains the full history which makes it possible to easily checkout tags and commits and allows all features of docker_manager to work correctly.

See https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone/ for more information on treeless clones.

Also this change makes it possible to correctly pull the main branch which didn't work before.