### PR TITLE
FIX: Remove duplicate anacron cron jobs

### DIFF
--- a/image/base/etc/cron.d/anacron
+++ b/image/base/etc/cron.d/anacron
@@ -3,4 +3,4 @@
 SHELL=/bin/sh
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 
-30 7    * * *   root	/usr/sbin/anacron -s >/dev/null
+30 7    * * *   root    /usr/sbin/anacron -s >/dev/null

--- a/image/base/slim.Dockerfile
+++ b/image/base/slim.Dockerfile
@@ -46,7 +46,6 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y install autoconf build-essential c
                        psmisc whois brotli libunwind-dev \
                        libtcmalloc-minimal4 cmake \
                        pngcrush pngquant
-RUN sed -i -e 's/start -q anacron/anacron -s/' /etc/cron.d/anacron
 RUN sed -i.bak 's/$ModLoad imklog/#$ModLoad imklog/' /etc/rsyslog.conf
 RUN sed -i.bak 's/module(load="imklog")/#module(load="imklog")/' /etc/rsyslog.conf
 RUN dpkg-divert --local --rename --add /sbin/initctl

--- a/templates/web.template.yml
+++ b/templates/web.template.yml
@@ -28,15 +28,7 @@ run:
   - exec: /usr/local/bin/ruby -e 'if ENV["DISCOURSE_SMTP_ADDRESS"] == "smtp.example.com"; puts "Aborting! Mail is not configured!"; exit 1; end'
   - exec: /usr/local/bin/ruby -e 'if ENV["DISCOURSE_HOSTNAME"] == "discourse.example.com"; puts "Aborting! Domain is not configured!"; exit 1; end'
   - exec: /usr/local/bin/ruby -e 'if (ENV["DISCOURSE_CDN_URL"] || "")[0..1] == "//"; puts "Aborting! CDN must have a protocol specified. Once fixed you should rebake your posts now to correct all posts."; exit 1; end'
-  # TODO: move to base image (anacron can not be fired up using rc.d)
-  - exec: rm -f /etc/cron.d/anacron
-  - file:
-     path: /etc/cron.d/anacron
-     contents: |
-        SHELL=/bin/sh
-        PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 
-        30 7    * * *   root	/usr/sbin/anacron -s >/dev/null
   - file:
      path: /etc/runit/1.d/copy-env
      chmod: "+x"


### PR DESCRIPTION
Both `cron.d_anacron` and `anacron` exist in `/etc/cron.d` with the same contents, so it's getting run twice.