### PR TITLE
FIX: Compiling oxipng didn't work on aarch64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,7 +119,7 @@ jobs:
           docker login --username discoursebuild --password $DOCKERHUB_PASSWORD
           docker push discourse/discourse_dev:release
   aarch64:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: base
     services:
       registry:
@@ -131,10 +131,10 @@ jobs:
         with:
           fetch-depth: 1
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - name: build slim image
         working-directory: image/base
         run: |

--- a/image/base/install-oxipng
+++ b/image/base/install-oxipng
@@ -18,7 +18,7 @@ echo "${OXIPNG_HASH} ${OXIPNG_ARCHIVE}" | sha256sum -c
 tar -zxf ${OXIPNG_ARCHIVE}
 cd ${OXIPNG_DIR}
 
-/usr/local/cargo/bin/cargo build --release
+CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse /usr/local/cargo/bin/cargo build --release
 cp target/release/oxipng /usr/local/bin
 
 cd / && rm -fr /tmp/${OXIPNG_DIR}

--- a/image/base/install-rust
+++ b/image/base/install-rust
@@ -5,16 +5,16 @@ set -e
 export RUSTUP_HOME=/usr/local/rustup
 export CARGO_HOME=/usr/local/cargo
 export PATH=/usr/local/cargo/bin:$PATH
-export RUST_VERSION=1.65.0
-export RUSTUP_VERSION=1.25.1
+export RUST_VERSION=1.68.0
+export RUSTUP_VERSION=1.25.2
 
 dpkgArch="$(dpkg --print-architecture)"
 
 case "${dpkgArch##*-}" in
-    amd64) rustArch='x86_64-unknown-linux-gnu'; rustupSha256='5cc9ffd1026e82e7fb2eec2121ad71f4b0f044e88bca39207b3f6b769aaa799c' ;;
-    armhf) rustArch='armv7-unknown-linux-gnueabihf'; rustupSha256='48c5ecfd1409da93164af20cf4ac2c6f00688b15eb6ba65047f654060c844d85' ;;
-    arm64) rustArch='aarch64-unknown-linux-gnu'; rustupSha256='e189948e396d47254103a49c987e7fb0e5dd8e34b200aa4481ecc4b8e41fb929' ;;
-    i386) rustArch='i686-unknown-linux-gnu'; rustupSha256='0e0be29c560ad958ba52fcf06b3ea04435cb3cd674fbe11ce7d954093b9504fd' ;;
+    amd64) rustArch='x86_64-unknown-linux-gnu'; rustupSha256='bb31eaf643926b2ee9f4d8d6fc0e2835e03c0a60f34d324048aa194f0b29a71c' ;;
+    armhf) rustArch='armv7-unknown-linux-gnueabihf'; rustupSha256='6626b90205d7fe7058754c8e993b7efd91dedc6833a11a225b296b7c2941194f' ;;
+    arm64) rustArch='aarch64-unknown-linux-gnu'; rustupSha256='4ccaa7de6b8be1569f6b764acc28e84f5eca342f5162cd5c810891bff7ed7f74' ;;
+    i386) rustArch='i686-unknown-linux-gnu'; rustupSha256='34392b53a25c56435b411d3e575b63aab962034dd1409ba405e708610c829607' ;;
     *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;;
 esac
 


### PR DESCRIPTION
This uses the new sparse-registry feature from Rust 1.68 which lowers the memory usage. This avoids that cargo is killed due to an OOM issue (exit code 137) during "Updating crates.io index".