### PR TITLE
DEV: Ubuntu installs do not like bullseye-backports

### DIFF
--- a/image/base/install-imagemagick
+++ b/image/base/install-imagemagick
@@ -8,8 +8,8 @@ IMAGE_MAGICK_HASH="d282117bc6d0e91ad1ad685d096623b96ed8e229f911c891d83277b350ef8
 # We use debian, but GitHub CI is stuck on Ubuntu Bionic, so this must be compatible with both
 LIBJPEGTURBO=$(cat /etc/issue | grep -qi Debian && echo 'libjpeg62-turbo libjpeg62-turbo-dev' || echo 'libjpeg-turbo8 libjpeg-turbo8-dev')
 
-# Ubuntu 22.04 (Jammy) doesn't have libwebp6
-LIBWEBP=$(cat /etc/issue | grep -qi 'Ubuntu 22.04' && echo 'libwebp7' || echo 'libwebp6')
+# Ubuntu 22.04/22.10  doesn't have libwebp6
+LIBWEBP=$(cat /etc/issue | grep -qi 'Ubuntu 22' && echo 'libwebp7' || echo 'libwebp6')
 
 PREFIX=/usr/local
 WDIR=/tmp/imagemagick
@@ -22,8 +22,13 @@ apt -y -q install git make gcc pkg-config autoconf curl g++ yasm cmake \
     libwebpmux3 libwebpdemux2 ghostscript libxml2-dev libxml2-utils librsvg2-dev \
     libltdl7-dev libbz2-dev gsfonts libtiff-dev libfreetype6-dev libjpeg-dev
 
-# Use backports instead of compiling it
-apt -y -q install -t bullseye-backports libheif1 libaom-dev libheif-dev
+# Ubuntu doesn't like `bullseye-backports`
+if cat /etc/issue | grep -qi 'Ubuntu 22'; then
+  apt -y install libheif1 libaom-dev libheif-dev
+else
+  # Use backports instead of compiling it
+  apt -y -q install -t bullseye-backports libheif1 libaom-dev libheif-dev
+fi
 
 mkdir -p $WDIR
 cd $WDIR


### PR DESCRIPTION
Check for Ubuntu 22.04 and 22.10 versions before trying to use
`bullseye-backports` otherwise they throw this error.

```
E: The value 'bullseye-backports' is invalid for APT::Default-Release as
such a release is not available in the sources failed
```
