### PR TITLE
Remove stable-specific image logic

### DIFF
--- a/launcher
+++ b/launcher
@@ -93,7 +93,6 @@ config_file=containers/"$config".yml
 cidbootstrap=cids/"$config"_bootstrap.cid
 local_discourse=local_discourse
 image="discourse/base:2.0.20230313-1023"
-image_stable="discourse/base:2.0.20230222-0048"
 docker_path=`which docker.io 2> /dev/null || which docker`
 git_path=`which git`
 
@@ -233,14 +232,6 @@ check_prereqs() {
     echo "Please be patient"
     echo
 
-    pull_image
-  fi
-
-  # use an older image for stable
-  version=$(cat $config_file | $docker_path run $user_args --rm -i -a stdout -a stdin $image ruby -e \
-      "require 'yaml'; puts YAML.load(STDIN.readlines.join)['params']['version']")
-  if [ "$version" = "stable" ]; then
-    image=$image_stable
     pull_image
   fi
 


### PR DESCRIPTION
This was only introduced as a temporary solution for Discourse 2.8, which is now EOL