### PR TITLE
Add template to enable an IPv6 listener

### DIFF
--- a/samples/standalone.yml
+++ b/samples/standalone.yml
@@ -11,8 +11,10 @@ templates:
   - "templates/postgres.template.yml"
   - "templates/redis.template.yml"
   - "templates/web.template.yml"
+  ## Uncomment the next line to enable the IPv6 listener
+  #- "templates/web.ipv6.template.yml"
   - "templates/web.ratelimited.template.yml"
-## Uncomment these two lines if you wish to add Lets Encrypt (https)
+  ## Uncomment these two lines if you wish to add Lets Encrypt (https)
   #- "templates/web.ssl.template.yml"
   #- "templates/web.letsencrypt.ssl.template.yml"
 

--- a/samples/web_only.yml
+++ b/samples/web_only.yml
@@ -3,8 +3,10 @@
 
 templates:
   - "templates/web.template.yml"
+  ## Uncomment the next line to enable the IPv6 listener
+  #- "templates/web.ipv6.template.yml"
   - "templates/web.ratelimited.template.yml"
-## Uncomment these two lines if you wish to add Lets Encrypt (https)
+  ## Uncomment these two lines if you wish to add Lets Encrypt (https)
   #- "templates/web.ssl.template.yml"
   #- "templates/web.letsencrypt.ssl.template.yml"
 

--- a/templates/web.ipv6.template.yml
+++ b/templates/web.ipv6.template.yml
@@ -1,0 +1,8 @@
+run:
+  - exec: echo "Enabling IPv6 listener"
+  - replace:
+      filename: "/etc/nginx/conf.d/discourse.conf"
+      from: listen 80;
+      to: |
+        listen 80;
+        listen [::]:80;


### PR DESCRIPTION
By default nginx in the container only listens for IPv4 connections. Some users
want to enable direct IPv6 connectivity to the container either via forwarding
or NAT. This provides an easy method to allow that.
