### PR TITLE
fixup count of physical cores in discourse-setup

### DIFF
--- a/discourse-setup
+++ b/discourse-setup
@@ -252,7 +252,7 @@ scale_ram_and_cpu() {
     avail_cores=`sysctl hw.ncpu | awk '/hw.ncpu:/ {print $2}'`
   else
     avail_gb=$(check_linux_memory)
-    avail_cores=$((`awk '/cpu cores/ {print $4;exit}' /proc/cpuinfo`*`sort /proc/cpuinfo | uniq | grep -c "physical id"`))
+    avail_cores=`lscpu --parse=core | egrep -v ^# | sort -u | wc -l`
   fi
   echo "Found ${avail_gb}GB of memory and $avail_cores physical CPU cores"
 


### PR DESCRIPTION
Previously parsing /proc/cpuinfo but that fails on Raspberry Pi and presumably other aarch64 platforms
https://meta.discourse.org/t/discourse-setup-line-260-0-syntax-error-operand-expected-error-token-is-0/260991
