### PR TITLE
Bump default base image to run Ruby 3.2.2 as default

### DIFF
--- a/launcher
+++ b/launcher
@@ -92,7 +92,7 @@ kernel_min_version='4.4.0'
 config_file=containers/"$config".yml
 cidbootstrap=cids/"$config"_bootstrap.cid
 local_discourse=local_discourse
-image="discourse/base:2.0.20230313-1023"
+image="discourse/base:2.0.20230409-0052"
 docker_path=`which docker.io 2> /dev/null || which docker`
 git_path=`which git`
 


### PR DESCRIPTION
Ruby 3.2.2 was released with a two security fixes. While the security
fixes have been assessed to have low impact on Discourse, we still want
to get the upgrade in as a preventive measure.