### PR TITLE
DEV: Install all yarn dependencies

### DIFF
--- a/image/base/release.Dockerfile
+++ b/image/base/release.Dockerfile
@@ -8,7 +8,7 @@ RUN cd /var/www/discourse &&\
     sudo -u discourse bundle config --local path ./vendor/bundle &&\
     sudo -u discourse bundle config --local without test development &&\
     sudo -u discourse bundle install --jobs 4 &&\
-    sudo -u discourse yarn install --production --frozen-lockfile &&\
+    sudo -u discourse yarn install --frozen-lockfile &&\
     sudo -u discourse yarn cache clean &&\
     bundle exec rake maxminddb:get &&\
     find /var/www/discourse/vendor/bundle -name tmp -type d -exec rm -rf {} +

--- a/image/base/slim.Dockerfile
+++ b/image/base/slim.Dockerfile
@@ -7,7 +7,8 @@ ENV PG_MAJOR=13 \
     RAILS_ENV=production \
     RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
-    PATH=/usr/local/cargo/bin:$PATH
+    PATH=/usr/local/cargo/bin:$PATH \
+    LEFTHOOK=0
 
 #LABEL maintainer="Sam Saffron \"https://twitter.com/samsaffron\""
 

--- a/templates/web.template.yml
+++ b/templates/web.template.yml
@@ -172,7 +172,7 @@ run:
   - exec:
       cd: $home
       cmd:
-        - su discourse -c 'yarn install --production --frozen-lockfile && yarn cache clean'
+        - su discourse -c 'yarn install --frozen-lockfile && yarn cache clean'
 
   - exec:
       cd: $home


### PR DESCRIPTION
`devDependencies` is often used for things like ember-cli build tooling. Until now we have been moving those things to `dependencies` in our `package.json`, but it makes more sense for us to conform to the industry norms.