### PR TITLE
DEV: Introduce `enable-ruby-yjit template

### DIFF
--- a/templates/enable-ruby-yjit.yml
+++ b/templates/enable-ruby-yjit.yml
@@ -1,0 +1,2 @@
+env:
+  RUBY_YJIT_ENABLE: 1


### PR DESCRIPTION
This adds the `RUBY_YJIT_ENABLE` environment variable which would enable
Ruby 3.2's YJIT. See
https://github.com/ruby/ruby/blob/master/doc/yjit/yjit.md for more
information about YJIT.