### PR TITLE
Skip attempting `maxminddb:get` during build

### DIFF
--- a/image/base/release.Dockerfile
+++ b/image/base/release.Dockerfile
@@ -10,5 +10,4 @@ RUN cd /var/www/discourse &&\
     sudo -u discourse bundle install --jobs 4 &&\
     sudo -u discourse yarn install --frozen-lockfile &&\
     sudo -u discourse yarn cache clean &&\
-    bundle exec rake maxminddb:get &&\
     find /var/www/discourse/vendor/bundle -name tmp -type d -exec rm -rf {} +


### PR DESCRIPTION
Fetching the maxmind database requires a license key, which we do not include during our base image build. This rake task has been failing with an error for some time

```
MaxMind IP database updates require a license
```

Following https://github.com/discourse/discourse/commit/0330f51d75b34c41666266d5fee4174b136be728, the task now hard-fails and breaks the build.