### PR TITLE
PERF: Uninstall rust toolkit once ruby is built

### DIFF
--- a/image/base/slim.Dockerfile
+++ b/image/base/slim.Dockerfile
@@ -73,14 +73,12 @@ RUN /tmp/install-nginx
 ADD install-redis /tmp/install-redis
 RUN /tmp/install-redis
 
-ADD install-rust /tmp/install-rust
-RUN /tmp/install-rust
-
 ADD install-oxipng /tmp/install-oxipng
 RUN /tmp/install-oxipng
 
+ADD install-rust /tmp/install-rust
 ADD install-ruby /tmp/install-ruby
-RUN /tmp/install-ruby
+RUN /tmp/install-rust && /tmp/install-ruby && rustup self uninstall -y
 
 RUN echo 'gem: --no-document' >> /usr/local/etc/gemrc &&\
     gem update --system

--- a/image/base/slim.Dockerfile
+++ b/image/base/slim.Dockerfile
@@ -73,12 +73,10 @@ RUN /tmp/install-nginx
 ADD install-redis /tmp/install-redis
 RUN /tmp/install-redis
 
-ADD install-oxipng /tmp/install-oxipng
-RUN /tmp/install-oxipng
-
 ADD install-rust /tmp/install-rust
 ADD install-ruby /tmp/install-ruby
-RUN /tmp/install-rust && /tmp/install-ruby && rustup self uninstall -y
+ADD install-oxipng /tmp/install-oxipng
+RUN /tmp/install-rust && /tmp/install-ruby && /tmp/install-oxipng && rustup self uninstall -y
 
 RUN echo 'gem: --no-document' >> /usr/local/etc/gemrc &&\
     gem update --system


### PR DESCRIPTION
This tooling adds significant size to our docker image. We only need rust tooling while installing ruby, and can clean it up immediately afterwards to avoid it persisting in the image