### PR TITLE
FIX: Cleanup node_modules when using non-standard branch

### DIFF
--- a/templates/web.template.yml
+++ b/templates/web.template.yml
@@ -172,7 +172,7 @@ run:
       cd: $home
       cmd:
         - |-
-          if $version != "tests-passed"; then
+          if [ "$version" != "tests-passed" ]; then
             rm -rf app/assets/javascripts/node_modules
           fi
         - su discourse -c 'yarn install --frozen-lockfile && yarn cache clean'

--- a/templates/web.template.yml
+++ b/templates/web.template.yml
@@ -171,6 +171,10 @@ run:
   - exec:
       cd: $home
       cmd:
+        - |-
+          if $version != "tests-passed"; then
+            rm -rf app/assets/javascripts/node_modules
+          fi
         - su discourse -c 'yarn install --frozen-lockfile && yarn cache clean'
 
   - exec:


### PR DESCRIPTION
Yarn seems to have issues 'downgrading' our set of packages from tests-passed (which are pre-installed in the base image) to the versions on the stable branch.

In the medium term we intend to switch to the pnpm package manager, which shouldn't have this issue. In the meantime, we can work around the problem by deleting the pre-installed node_modules and installing from scratch.