### PR TITLE
Move `RAILS_ENV` to release image; build discourse_dev from slim

### DIFF
--- a/image/base/release.Dockerfile
+++ b/image/base/release.Dockerfile
@@ -3,6 +3,8 @@ ARG tag=build_slim
 
 FROM $from:$tag
 
+ENV RAILS_ENV=production
+
 RUN cd /var/www/discourse &&\
     sudo -u discourse bundle config --local deployment true &&\
     sudo -u discourse bundle config --local path ./vendor/bundle &&\

--- a/image/base/slim.Dockerfile
+++ b/image/base/slim.Dockerfile
@@ -4,7 +4,6 @@ FROM debian:bullseye-slim
 
 ENV PG_MAJOR=13 \
     RUBY_ALLOCATOR=/usr/lib/libjemalloc.so.1 \
-    RAILS_ENV=production \
     RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \

--- a/image/discourse_dev/Dockerfile
+++ b/image/discourse_dev/Dockerfile
@@ -1,9 +1,6 @@
 # NAME:     discourse/discourse_dev
 # VERSION:  release
-FROM discourse/base:release
-
-# Unset RAILS_ENV to allow running both dev stuff and tests
-ENV RAILS_ENV=
+FROM discourse/base:slim
 
 #LABEL maintainer="Sam Saffron \"https://twitter.com/samsaffron\""
 


### PR DESCRIPTION
Unfortunately there is no way to 'unset' an ENV in a Dockerfile. We were working around this by setting `RAILS_ENV` to an empty string in the discourse_dev dockerfile, but that didn't work in every situation.

The discourse_dev image doesn't rely on anything in the 'release' layer of the base image. In fact, it deletes the entire contents of `/var/www/*`.

This commit resolves the situation by:

- Moving the `RAILS_ENV=production` line to the 'release' layer of the base image
- Updating the discourse_dev image to be based on the 'slim' base image

This should also make the discourse_dev image much smaller, with no loss of functionality.

(ref https://github.com/discourse/discourse/pull/22765)