### PR TITLE
DEV: Add minio install to test image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,24 +26,27 @@ jobs:
       - name: build slim image
         run: |
           cd image && ruby auto_build.rb base_slim
-      - name: build release image
-        run: |
-          cd image && ruby auto_build.rb base
-      - name: build test_build image
-        run: |
-          cd image && ruby auto_build.rb discourse_test_build
-      - name: run specs
-        run: |
-          docker run --rm -e RUBY_ONLY=1 -e USE_TURBO=1 -e SKIP_PLUGINS=1 -e SKIP_LINT=1 discourse/discourse_test:build
-      - name: tag images
+      - name: tag slim images
         id: tag-images
         run: |
           TAG=`date +%Y%m%d-%H%M`
           echo "tag=$(echo $TAG)" >> $GITHUB_OUTPUT
           docker tag discourse/base:build_slim discourse/base:2.0.$TAG-slim
           docker tag discourse/base:build_slim discourse/base:slim
+      - name: build release image
+        run: |
+          cd image && ruby auto_build.rb base
+      - name: tag release images
+        run: |
+          TAG=${{ steps.tag-images.outputs.tag }}
           docker tag discourse/base:build discourse/base:2.0.$TAG
           docker tag discourse/base:build discourse/base:release
+      - name: build test_build image
+        run: |
+          cd image && ruby auto_build.rb discourse_test_build
+      - name: run specs
+        run: |
+          docker run --rm -e RUBY_ONLY=1 -e USE_TURBO=1 -e SKIP_PLUGINS=1 -e SKIP_LINT=1 discourse/discourse_test:build
       - name: Print summary
         run: |
           docker images discourse/base

--- a/image/base/slim.Dockerfile
+++ b/image/base/slim.Dockerfile
@@ -119,4 +119,4 @@ COPY sbin/ /sbin
 RUN useradd discourse -s /bin/bash -m -U &&\
     install -dm 0755 -o discourse -g discourse /var/www/discourse &&\
     sudo -u discourse git clone --filter=tree:0 https://github.com/discourse/discourse.git /var/www/discourse &&\
-    sudo -u discourse git -C /var/www/discourse checkout dev/minio-s3-system-specs
+    sudo -u discourse git -C /var/www/discourse checkout dev/s3-upload-system-specs-with-minio

--- a/image/base/slim.Dockerfile
+++ b/image/base/slim.Dockerfile
@@ -118,4 +118,6 @@ COPY sbin/ /sbin
 # Discourse specific bits
 RUN useradd discourse -s /bin/bash -m -U &&\
     install -dm 0755 -o discourse -g discourse /var/www/discourse &&\
-    sudo -u discourse git clone --filter=tree:0 https://github.com/discourse/discourse.git /var/www/discourse
+    sudo -u discourse git clone --filter=tree:0 https://github.com/discourse/discourse.git /var/www/discourse &&\
+    cd /var/www/discourse &&\
+    git checkout dev/minio-s3-system-specs

--- a/image/base/slim.Dockerfile
+++ b/image/base/slim.Dockerfile
@@ -118,5 +118,4 @@ COPY sbin/ /sbin
 # Discourse specific bits
 RUN useradd discourse -s /bin/bash -m -U &&\
     install -dm 0755 -o discourse -g discourse /var/www/discourse &&\
-    sudo -u discourse git clone --filter=tree:0 https://github.com/discourse/discourse.git /var/www/discourse &&\
-    sudo -u discourse git -C /var/www/discourse checkout dev/s3-upload-system-specs-with-minio
+    sudo -u discourse git clone --filter=tree:0 https://github.com/discourse/discourse.git /var/www/discourse

--- a/image/discourse_test/Dockerfile
+++ b/image/discourse_test/Dockerfile
@@ -35,4 +35,6 @@ RUN cd /var/www/discourse &&\
 RUN cd /var/www/discourse && sudo -E -u discourse -H bundle exec rake plugin:install_all_official &&\
     sudo -E -u discourse -H bundle exec rake plugin:install_all_gems
 
+RUN cd /var/www/discourse && sudo -E -u discourse -H bundle exec script/install_minio_binaries.rb
+
 ENTRYPOINT sudo -E -u discourse -H ruby script/docker_test.rb

--- a/image/discourse_test/Dockerfile
+++ b/image/discourse_test/Dockerfile
@@ -34,6 +34,6 @@ RUN cd /var/www/discourse &&\
 
 RUN cd /var/www/discourse && sudo -E -u discourse -H bundle exec rake plugin:install_all_official &&\
     sudo -E -u discourse -H bundle exec rake plugin:install_all_gems &&\
-    sudo -E -u discourse -H bundle exec script/install_minio_binaries.rb
+    sudo -E -u discourse -H bundle exec ruby script/install_minio_binaries.rb
 
 ENTRYPOINT sudo -E -u discourse -H ruby script/docker_test.rb

--- a/image/discourse_test/Dockerfile
+++ b/image/discourse_test/Dockerfile
@@ -33,8 +33,7 @@ RUN cd /var/www/discourse &&\
     sudo -u discourse yarn cache clean
 
 RUN cd /var/www/discourse && sudo -E -u discourse -H bundle exec rake plugin:install_all_official &&\
-    sudo -E -u discourse -H bundle exec rake plugin:install_all_gems
-
-RUN cd /var/www/discourse && sudo -E -u discourse -H bundle exec script/install_minio_binaries.rb
+    sudo -E -u discourse -H bundle exec rake plugin:install_all_gems &&\
+    sudo -E -u discourse -H bundle exec script/install_minio_binaries.rb
 
 ENTRYPOINT sudo -E -u discourse -H ruby script/docker_test.rb


### PR DESCRIPTION
Relies on https://github.com/discourse/discourse/pull/22975 to be merged first;
the minio_runner gem can self-install minio, but it's better to just bake the binaries
into the test image. Just uses the `script/install_minio.rb` script to use the gem to
install required binaries.

We are adding minio to the core project to run system tests for S3 uploads
using minio as a mock S3 store.