### PR TITLE
FEATURE: add ripgrep to the base image

### DIFF
--- a/image/base/slim.Dockerfile
+++ b/image/base/slim.Dockerfile
@@ -45,7 +45,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y install autoconf build-essential c
                        libreadline-dev anacron wget \
                        psmisc whois brotli libunwind-dev \
                        libtcmalloc-minimal4 cmake \
-                       pngcrush pngquant
+                       pngcrush pngquant ripgrep
 RUN sed -i -e 's/start -q anacron/anacron -s/' /etc/cron.d/anacron
 RUN sed -i.bak 's/$ModLoad imklog/#$ModLoad imklog/' /etc/rsyslog.conf
 RUN sed -i.bak 's/module(load="imklog")/#module(load="imklog")/' /etc/rsyslog.conf


### PR DESCRIPTION
ripgrep is going to be used by discourse-ai to extract context from files
on the local disk.

This does increase the size of the image by 1.7MB or so, but heavily simplifies
deployment

Alternative mechanisms exists such as packing the binary in a gem but we
would pay more at install time delays.
