### PR TITLE
Install latest Postgres client version besides the one for PG_MAJOR

### DIFF
--- a/image/base/slim.Dockerfile
+++ b/image/base/slim.Dockerfile
@@ -3,7 +3,6 @@
 FROM debian:bullseye-slim
 
 ENV PG_MAJOR=13 \
-    PG_CLIENT_MAJOR=15 \
     RUBY_ALLOCATOR=/usr/lib/libjemalloc.so.1 \
     RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
@@ -41,7 +40,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y install autoconf build-essential c
                        libssl-dev libyaml-dev libtool \
                        libpcre3 libpcre3-dev zlib1g zlib1g-dev \
                        libxml2-dev gawk parallel \
-                       postgresql-${PG_MAJOR} postgresql-client-${PG_CLIENT_MAJOR:-$PG_MAJOR} \
+                       postgresql-${PG_MAJOR} postgresql-client \
                        postgresql-contrib-${PG_MAJOR} libpq-dev postgresql-${PG_MAJOR}-pgvector \
                        libreadline-dev anacron wget \
                        psmisc whois brotli libunwind-dev \

--- a/image/base/slim.Dockerfile
+++ b/image/base/slim.Dockerfile
@@ -41,7 +41,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y install autoconf build-essential c
                        libssl-dev libyaml-dev libtool \
                        libpcre3 libpcre3-dev zlib1g zlib1g-dev \
                        libxml2-dev gawk parallel \
-                       postgresql-${PG_MAJOR} postgresql-client-${PG_CLIENT_MAJOR} \
+                       postgresql-${PG_MAJOR} postgresql-client-${PG_CLIENT_MAJOR:-$PG_MAJOR} \
                        postgresql-contrib-${PG_MAJOR} libpq-dev postgresql-${PG_MAJOR}-pgvector \
                        libreadline-dev anacron wget \
                        psmisc whois brotli libunwind-dev \

--- a/image/base/slim.Dockerfile
+++ b/image/base/slim.Dockerfile
@@ -3,6 +3,7 @@
 FROM debian:bullseye-slim
 
 ENV PG_MAJOR=13 \
+    PG_CLIENT_MAJOR=15 \
     RUBY_ALLOCATOR=/usr/lib/libjemalloc.so.1 \
     RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
@@ -40,7 +41,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y install autoconf build-essential c
                        libssl-dev libyaml-dev libtool \
                        libpcre3 libpcre3-dev zlib1g zlib1g-dev \
                        libxml2-dev gawk parallel \
-                       postgresql-${PG_MAJOR} postgresql-client-${PG_MAJOR} \
+                       postgresql-${PG_MAJOR} postgresql-client-${PG_CLIENT_MAJOR} \
                        postgresql-contrib-${PG_MAJOR} libpq-dev postgresql-${PG_MAJOR}-pgvector \
                        libreadline-dev anacron wget \
                        psmisc whois brotli libunwind-dev \


### PR DESCRIPTION
Before, if a remote server is upgraded to a newer PG version, it wouldn't be able to be backed up from inside the application, since `pg_dump` would be a lower version, resulting in this:

```
pg_dump: error: server version: 15.3; pg_dump version: 13.11 (Debian 13.11-1.pgdg110+1)
pg_dump: error: aborting because of server version mismatch
```

With this change, `postgresql-${PG_MAJOR}` pulls in `postgresql-client` for the server version, AND `postgresql-client` metapackage pulls in the latest version available in the upstream Apt repository.

This guarantees there will be a `pg_dump` for the latest version available, so a remote server freshly upgraded to that latest version will always be able to be backed up from inside the application (since [`pg_wrapper`](https://github.com/credativ/postgresql-common/blob/master/pg_wrapper#L110) chooses the latest locally available version for remote connections).
