### PR TITLE
DEV: Use `plain` buildkit output

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,9 @@ concurrency:
   group: build-${{ format('{0}-{1}', github.head_ref || github.run_number, github.job) }}
   cancel-in-progress: true
 
+env:
+  BUILDKIT_PROGRESS: plain
+
 jobs:
   base:
     runs-on: ubuntu-20.04${{ ((github.event_name != 'schedule') && '-8core') || '' }}


### PR DESCRIPTION
it's much more CI-friendly