### PR TITLE
FIX: Allow other commands to executed for the `discourse_test` image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# Use an existing docker image as a base
+FROM ubuntu
+
+# Update and install sudo
+RUN apt-get update && apt-get install -y sudo
+
+# Create a new user
+RUN useradd -m discourse
+
+# Set the entrypoint
+ENTRYPOINT ["sudo", "-H", "-u", "discourse", "-E", "/bin/bash", "-c"]
+
+# Set the default command
+CMD ["echo Hello, world!"]

--- a/image/discourse_test/Dockerfile
+++ b/image/discourse_test/Dockerfile
@@ -36,4 +36,5 @@ RUN cd /var/www/discourse && sudo -E -u discourse -H bundle exec rake plugin:ins
     sudo -E -u discourse -H bundle exec rake plugin:install_all_gems &&\
     sudo -E -u discourse -H bundle exec ruby script/install_minio_binaries.rb
 
-ENTRYPOINT sudo -E -u discourse -H ruby script/docker_test.rb
+CMD ["ruby script/docker_test.rb"]
+ENTRYPOINT ["sudo", "-E", "-u", "discourse", "-H", "/bin/bash", "-c"]


### PR DESCRIPTION
Why this change?

This sets the default command that is run to `ruby script/docker_test.rb` to allow
other commands to be run for the image since the `ENTRYPOINT` is no
longer `sudo -E -u discourse -H ruby script/docker_test.rb` but instead
`sudo -E -u discourse -H`.