### PR TITLE
DEV: Switch test container to use exec instead of shell entrypoint

### DIFF
--- a/image/discourse_test/Dockerfile
+++ b/image/discourse_test/Dockerfile
@@ -36,4 +36,4 @@ RUN cd /var/www/discourse && sudo -E -u discourse -H bundle exec rake plugin:ins
     sudo -E -u discourse -H bundle exec rake plugin:install_all_gems &&\
     sudo -E -u discourse -H bundle exec ruby script/install_minio_binaries.rb
 
-ENTRYPOINT sudo -E -u discourse -H ruby script/docker_test.rb
+ENTRYPOINT ["sudo", "-E", "-u", "discourse", "-H", "ruby", "script/docker_test.rb"]


### PR DESCRIPTION
This allows command line arguments to be passed.