### PR TITLE
DEV: Install bundler version used by Discourse as a default.

### DIFF
--- a/image/base/slim.Dockerfile
+++ b/image/base/slim.Dockerfile
@@ -80,7 +80,7 @@ RUN /tmp/install-rust && /tmp/install-ruby && /tmp/install-oxipng && rustup self
 RUN echo 'gem: --no-document' >> /usr/local/etc/gemrc &&\
     gem update --system
 
-RUN gem install bundler pups --force &&\
+RUN gem install pups --force &&\
     mkdir -p /pups/bin/ &&\
     ln -s /usr/local/bin/pups /pups/bin/pups
 
@@ -118,4 +118,5 @@ COPY sbin/ /sbin
 # Discourse specific bits
 RUN useradd discourse -s /bin/bash -m -U &&\
     install -dm 0755 -o discourse -g discourse /var/www/discourse &&\
-    sudo -u discourse git clone --filter=tree:0 https://github.com/discourse/discourse.git /var/www/discourse
+    sudo -u discourse git clone --filter=tree:0 https://github.com/discourse/discourse.git /var/www/discourse &&\
+    gem install bundler --conservative -v $(awk '/BUNDLED WITH/ { getline; gsub(/ /,""); print $0 }' /var/www/discourse/Gemfile.lock)


### PR DESCRIPTION
Why this change?

Previously we were running `gem install bundler` to install bundler but
this would install the latest bundler version instead of the bundler
version being used by Discourse. As a result, we end up having to
install bundler over and over again when using the image most of the
time.