### PR TITLE
DEV: Configure bundle jobs to 4

### DIFF
--- a/image/base/release.Dockerfile
+++ b/image/base/release.Dockerfile
@@ -9,7 +9,8 @@ RUN cd /var/www/discourse &&\
     sudo -u discourse bundle config --local deployment true &&\
     sudo -u discourse bundle config --local path ./vendor/bundle &&\
     sudo -u discourse bundle config --local without test development &&\
-    sudo -u discourse bundle install --jobs 4 &&\
+    sudo -u discourse bundle config --local jobs 4 && \
+    sudo -u discourse bundle install &&\
     sudo -u discourse yarn install --frozen-lockfile &&\
     sudo -u discourse yarn cache clean &&\
     find /var/www/discourse/vendor/bundle -name tmp -type d -exec rm -rf {} +


### PR DESCRIPTION
This ensures that we be default runs bundle install with at least 4
jobs.