### PR TITLE
use DISCOURSE_BASE_URL in mail-receiver sample

### DIFF
--- a/samples/mail-receiver.yml
+++ b/samples/mail-receiver.yml
@@ -27,11 +27,11 @@ env:
 #  POSTCONF_smtpd_tls_security_level: may
 
 
-  ## The URL of the mail processing endpoint of your Discourse forum.
-  ## This is simply your forum's base URL, with `/admin/email/handle_mail`
-  ## appended.  Be careful if you're running a subfolder setup -- in that case,
-  ## the URL needs to have the subfolder included!
-  DISCOURSE_MAIL_ENDPOINT: 'https://discourse.example.com/admin/email/handle_mail'
+  ## The base URL for this Discourse instance.
+  ## This will be whatever your Discourse site URL is. For example,
+  ## https://discourse.example.com. If you're running a subfolder setup,
+  ## be sure to account for that (ie https://example.com/forum).
+  DISCOURSE_BASE_URL: 'https://discourse.example.com'
 
   ## The master API key of your Discourse forum.  You can get this from
   ## the "API" tab of your admin panel.


### PR DESCRIPTION
while `DISCOURSE_MAIL_ENDPOINT` is still accepted by the mail-receiver code, the documentation prefers `DISCOURSE_BASE_URL` and so should this example

see https://github.com/discourse/mail-receiver/blob/deae52039f4679b31e01302dadace3c0f018cec8/README.md