### PR TITLE
DEV: Remove use of --squash flag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,18 @@
+# Use the latest 2.1 version of CircleCI pipeline process engine.
+# See: https://circleci.com/docs/configuration-reference
+version: 2.1
+
+# Define a job to be invoked later in a workflow.
+# See: https://circleci.com/docs/configuration-reference/#jobs
+jobs:
+  build:
+    working_directory: image
+    docker:
+      - image: cimg/base:current
+    resource_class: arm.medium
+    steps:
+      - checkout
+      - run:
+          name: Build application Docker image
+          command: |
+            cd base && docker buildx build . --load --platform linux/arm64 --tag discourse/base:build_slim -f slim.Dockerfile

--- a/image/auto_build.rb
+++ b/image/auto_build.rb
@@ -1,13 +1,27 @@
 # simple build file to be used locally by Sam
 #
-require 'pty'
-require 'optparse'
+require "pty"
+require "optparse"
 
 images = {
-  base_slim: { name: 'base', tag: "discourse/base:build_slim", squash: true, extra_args: '-f slim.Dockerfile' },
-  base: { name: 'base', tag: "discourse/base:build", extra_args: '-f release.Dockerfile' },
-  discourse_test_build: { name: 'discourse_test', tag: "discourse/discourse_test:build", squash: false},
-  discourse_dev: { name: 'discourse_dev', tag: "discourse/discourse_dev:build", squash: false },
+  base_slim: {
+    name: "base",
+    tag: "discourse/base:build_slim",
+    extra_args: "-f slim.Dockerfile",
+  },
+  base: {
+    name: "base",
+    tag: "discourse/base:build",
+    extra_args: "-f release.Dockerfile",
+  },
+  discourse_test_build: {
+    name: "discourse_test",
+    tag: "discourse/discourse_test:build",
+  },
+  discourse_dev: {
+    name: "discourse_dev",
+    tag: "discourse/discourse_dev:build",
+  },
 }
 
 def run(command)
@@ -30,12 +44,19 @@ def run(command)
 end
 
 def build(image)
-  lines = run("cd #{image[:name]} && docker build . --no-cache --tag #{image[:tag]} #{image[:squash] ? '--squash' : ''} #{image[:extra_args] ? image[:extra_args] : ''}")
-  raise "Error building the image for #{image[:name]}: #{lines[-1]}" if lines[-1] =~ /successfully built/
+  lines =
+    run(
+      "cd #{image[:name]} && docker build . --no-cache --tag #{image[:tag]} #{image[:extra_args] ? image[:extra_args] : ""}",
+    )
+  if lines[-1] =~ /successfully built/
+    raise "Error building the image for #{image[:name]}: #{lines[-1]}"
+  end
 end
 
 def dev_deps()
-  run("sed -e 's/\(db_name: discourse\)/\1_development/' ../templates/postgres.template.yml > discourse_dev/postgres.template.yml")
+  run(
+    "sed -e 's/\(db_name: discourse\)/\1_development/' ../templates/postgres.template.yml > discourse_dev/postgres.template.yml",
+  )
   run("cp ../templates/redis.template.yml discourse_dev/redis.template.yml")
 end
 


### PR DESCRIPTION
Why this change?

In CI, we are seeing the following warning message:

```
WARNING: experimental flag squash is removed with BuildKit. You should squash inside build using a multi-stage Dockerfile for efficiency.
```

Basically, the `--squash` flag has not been working for quite some time
and is redundant.