### PR TITLE
DEV: Remove use of `--squash` flag and switch to buildx

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,11 +18,6 @@ jobs:
     runs-on: ubuntu-20.04${{ ((github.event_name != 'schedule') && '-8core') || '' }}
     timeout-minutes: 90
     steps:
-      - name: enable experimental docker features
-        run: |
-          sudo bash -c 'echo "{ \"cgroup-parent\": \"/actions_job\",\"experimental\":true}" > /etc/docker/daemon.json'
-          sudo service docker restart
-          docker version -f '{{.Server.Experimental}}'
       - uses: actions/checkout@v3
         with:
           fetch-depth: 1
@@ -142,14 +137,9 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@v2
       - name: build slim image
-        working-directory: image/base
         run: |
-          docker buildx build . --load \
-            -f slim.Dockerfile \
-            --platform linux/arm64 \
-            --tag discourse/base:aarch64-slim
-          docker tag discourse/base:aarch64-slim localhost:5000/discourse/base:aarch64-slim
-          docker push localhost:5000/discourse/base:aarch64-slim
+          cd image && ruby auto_build.rb base_slim_arm64
+          docker tag discourse/base:aarch64-slim localhost:5000/discourse/base:build_slim_arm64
       - name: tag slim image as release
         working-directory: image/base
         run: |

--- a/image/auto_build.rb
+++ b/image/auto_build.rb
@@ -1,13 +1,32 @@
 # simple build file to be used locally by Sam
 #
-require 'pty'
-require 'optparse'
+require "pty"
+require "optparse"
 
 images = {
-  base_slim: { name: 'base', tag: "discourse/base:build_slim", squash: true, extra_args: '-f slim.Dockerfile' },
-  base: { name: 'base', tag: "discourse/base:build", extra_args: '-f release.Dockerfile' },
-  discourse_test_build: { name: 'discourse_test', tag: "discourse/discourse_test:build", squash: false},
-  discourse_dev: { name: 'discourse_dev', tag: "discourse/discourse_dev:build", squash: false },
+  base_slim: {
+    name: "base",
+    tag: "discourse/base:build_slim",
+    extra_args: "-f slim.Dockerfile",
+  },
+  base_slim_arm64: {
+    name: "base",
+    tag: "discourse/base:build_slim_arm64",
+    extra_args: "-f slim.Dockerfile --platform linux/arm64",
+  },
+  base: {
+    name: "base",
+    tag: "discourse/base:build",
+    extra_args: "-f release.Dockerfile",
+  },
+  discourse_test_build: {
+    name: "discourse_test",
+    tag: "discourse/discourse_test:build",
+  },
+  discourse_dev: {
+    name: "discourse_dev",
+    tag: "discourse/discourse_dev:build",
+  },
 }
 
 def run(command)
@@ -30,12 +49,19 @@ def run(command)
 end
 
 def build(image)
-  lines = run("cd #{image[:name]} && docker build . --no-cache --tag #{image[:tag]} #{image[:squash] ? '--squash' : ''} #{image[:extra_args] ? image[:extra_args] : ''}")
-  raise "Error building the image for #{image[:name]}: #{lines[-1]}" if lines[-1] =~ /successfully built/
+  lines =
+    run(
+      "cd #{image[:name]} && docker buildx build . --load --no-cache --tag #{image[:tag]} #{image[:extra_args] ? image[:extra_args] : ""}",
+    )
+  if lines[-1] =~ /successfully built/
+    raise "Error building the image for #{image[:name]}: #{lines[-1]}"
+  end
 end
 
 def dev_deps()
-  run("sed -e 's/\(db_name: discourse\)/\1_development/' ../templates/postgres.template.yml > discourse_dev/postgres.template.yml")
+  run(
+    "sed -e 's/\(db_name: discourse\)/\1_development/' ../templates/postgres.template.yml > discourse_dev/postgres.template.yml",
+  )
   run("cp ../templates/redis.template.yml discourse_dev/redis.template.yml")
 end
 


### PR DESCRIPTION
## Why this change?

In CI, we are seeing the following warning message:

```
WARNING: experimental flag squash is removed with BuildKit. You should squash inside build using a multi-stage Dockerfile for efficiency.
```

Basically, the `--squash` flag has not been working for quite some time and is redundant.

## What does this change do?

* This change removes the use of the `--squash` flag.

* This change uses the `buildx` tool in `auto_build.rb` as we prepare to build images for multiple platforms.