### PR TITLE
DEV: Build base images for ARM64 platform in a seperate daily job

### DIFF
--- a/.github/workflows/arm64-build.yml
+++ b/.github/workflows/arm64-build.yml
@@ -64,3 +64,50 @@ jobs:
           docker push discourse/base:2.0.$TAG-arm64
           docker push discourse/base:release-arm64
           docker push discourse/base:aarch64
+  test:
+    runs-on: ubuntu-20.04
+    needs: base
+    defaults:
+      run:
+        working-directory: image/discourse_test
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: arm64
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+      - name: build discourse/discourse_test:slim-arm64
+        run: |
+          docker buildx build . --load \
+            --build-arg from_tag=slim-arm64 \
+            --target base \
+            --tag discourse/discourse_test:slim-arm64
+      - name: build discourse/discourse_test:slim-browsers-arm64
+        run: |
+          docker buildx build . --load \
+            --build-arg from_tag=slim-arm64 \
+            --target with_browsers \
+            --tag discourse/discourse_test:slim-browsers-arm64
+      - name: build discourse/discourse_test:release-arm64
+        run: |
+          docker buildx build . --load \
+            --build-arg from_tag=release-arm64 \
+            --target release \
+            --tag discourse/discourse_test:release-arm64
+      - name: Print summary
+        run: |
+          docker images discourse/discourse_test
+      - name: push to dockerhub
+        if: success() && (github.ref == 'refs/heads/main')
+        env:
+          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+        run: |
+          docker login --username discoursebuild --password $DOCKERHUB_PASSWORD
+          docker push discourse/discourse_test:slim-arm64
+          docker push discourse/discourse_test:slim-browsers-arm64
+          docker push discourse/discourse_test:release-arm64

--- a/.github/workflows/arm64-build.yml
+++ b/.github/workflows/arm64-build.yml
@@ -13,6 +13,11 @@ env:
 jobs:
   base:
     runs-on: ubuntu-20.04
+    services:
+      registry:
+        image: registry
+        ports:
+          - 5000:5000
     steps:
       - uses: actions/checkout@v3
         with:
@@ -34,17 +39,19 @@ jobs:
           echo "tag=$(echo $TAG)" >> $GITHUB_OUTPUT
           docker tag discourse/base:build_slim_arm64 discourse/base:2.0.$TAG-slim-arm64
           docker tag discourse/base:build_slim_arm64 discourse/base:slim-arm64
+          docker push localhost:5000/discourse/base:build_slim_arm64
       - name: build release image
         run: |
-          cd image && ruby auto_build.rb base_arm64
+          cd image && ruby auto_build.rb base_arm64 --build-arg from=localhost:5000/discourse/base
       - name: tag release images
         run: |
           TAG=${{ steps.tag-images.outputs.tag }}
           docker tag discourse/base:build_arm64 discourse/base:2.0.$TAG-arm64
           docker tag discourse/base:build_arm64 discourse/base:release-arm64
+          docker push localhost:5000/discourse/base:build_arm64
       - name: build test_build image
         run: |
-          cd image && ruby auto_build.rb discourse_test_build_arm64
+          cd image && ruby auto_build.rb discourse_test_build_arm64 --build-arg from=localhost:5000/discourse/base
       - name: run specs
         run: |
           docker run --rm -e RUBY_ONLY=1 -e USE_TURBO=1 -e SKIP_PLUGINS=1 -e SKIP_LINT=1 discourse/discourse_test:build_arm64
@@ -111,3 +118,28 @@ jobs:
           docker push discourse/discourse_test:slim-arm64
           docker push discourse/discourse_test:slim-browsers-arm64
           docker push discourse/discourse_test:release-arm64
+  dev:
+    runs-on: ubuntu-20.04
+    needs: base
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: arm64
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+      - name: build discourse/discourse_dev:release-arm64 image
+        run: |
+          cd image && ruby auto_build.rb discourse_dev_arm64
+      - name: push to dockerhub
+        if: success() && (github.ref == 'refs/heads/main')
+        env:
+          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+        run: |
+          docker tag discourse/discourse_dev:build_arm64 discourse/discourse_dev:release-arm64
+          docker login --username discoursebuild --password $DOCKERHUB_PASSWORD
+          docker push discourse/discourse_dev:release-arm64

--- a/.github/workflows/arm64-build.yml
+++ b/.github/workflows/arm64-build.yml
@@ -1,0 +1,66 @@
+on:
+  pull_request:
+  schedule:
+    - cron: "0 0 * * *"
+
+concurrency:
+  group: build-arm64-${{ format('{0}-{1}', github.head_ref || github.run_number, github.job) }}
+  cancel-in-progress: true
+
+env:
+  BUILDKIT_PROGRESS: plain
+
+jobs:
+  base:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: arm64
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+      - name: build slim image
+        run: |
+          cd image && ruby auto_build.rb base_slim_arm64
+      - name: tag slim images
+        id: tag-images
+        run: |
+          TAG=`date +%Y%m%d-%H%M`
+          echo "tag=$(echo $TAG)" >> $GITHUB_OUTPUT
+          docker tag discourse/base:build_slim_arm64 discourse/base:2.0.$TAG-slim-arm64
+          docker tag discourse/base:build_slim_arm64 discourse/base:slim-arm64
+      - name: build release image
+        run: |
+          cd image && ruby auto_build.rb base_arm64
+      - name: tag release images
+        run: |
+          TAG=${{ steps.tag-images.outputs.tag }}
+          docker tag discourse/base:build_arm64 discourse/base:2.0.$TAG-arm64
+          docker tag discourse/base:build_arm64 discourse/base:release-arm64
+      - name: build test_build image
+        run: |
+          cd image && ruby auto_build.rb discourse_test_build_arm64
+      - name: run specs
+        run: |
+          docker run --rm -e RUBY_ONLY=1 -e USE_TURBO=1 -e SKIP_PLUGINS=1 -e SKIP_LINT=1 discourse/discourse_test:build_arm64
+      - name: Print summary
+        run: |
+          docker images discourse/base
+      - name: push to dockerhub
+        if: success() && (github.ref == 'refs/heads/main')
+        env:
+          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+        run: |
+          TAG=${{ steps.tag-images.outputs.tag }}
+          docker login --username discoursebuild --password $DOCKERHUB_PASSWORD
+          docker push discourse/base:2.0.$TAG-slim-arm64
+          docker push discourse/base:slim-arm64
+          docker tag discourse/base:slim-arm64 discourse/base:aarch64
+          docker push discourse/base:2.0.$TAG-arm64
+          docker push discourse/base:release-arm64
+          docker push discourse/base:aarch64

--- a/.github/workflows/arm64-build.yml
+++ b/.github/workflows/arm64-build.yml
@@ -29,25 +29,26 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v2
-      - name: build slim image
-        run: |
-          cd image && ruby auto_build.rb base_slim_arm64
-      - name: tag slim images
-        id: tag-images
-        run: |
-          TAG=`date +%Y%m%d-%H%M`
-          echo "tag=$(echo $TAG)" >> $GITHUB_OUTPUT
-          docker tag discourse/base:build_slim_arm64 discourse/base:2.0.$TAG-slim-arm64
-          docker tag discourse/base:build_slim_arm64 discourse/base:slim-arm64
-          docker push localhost:5000/discourse/base:build_slim_arm64
+      # - name: build slim image
+      #   run: |
+      #     cd image && ruby auto_build.rb base_slim_arm64
+      # - name: tag slim images
+      #   id: tag-images
+      #   run: |
+      #     TAG=`date +%Y%m%d-%H%M`
+      #     echo "tag=$(echo $TAG)" >> $GITHUB_OUTPUT
+      #     docker tag discourse/base:build_slim_arm64 discourse/base:2.0.$TAG-slim-arm64
+      #     docker tag discourse/base:build_slim_arm64 discourse/base:slim-arm64
+      #     docker push localhost:5000/discourse/base:build_slim_arm64
       - name: build release image
         run: |
-          cd image && ruby auto_build.rb base_arm64 --build-arg from=localhost:5000/discourse/base
+          cd image && ruby auto_build.rb base_arm64 --build-arg from=tgxworld/base
       - name: tag release images
         run: |
-          TAG=${{ steps.tag-images.outputs.tag }}
-          docker tag discourse/base:build_arm64 discourse/base:2.0.$TAG-arm64
-          docker tag discourse/base:build_arm64 discourse/base:release-arm64
+          # TAG=${{ steps.tag-images.outputs.tag }}
+          # docker tag discourse/base:build_arm64 discourse/base:2.0.$TAG-arm64
+          # docker tag discourse/base:build_arm64 discourse/base:release-arm64
+          docker tag discourse/base:build_arm64 localhost:5000/discourse/base:build_arm64
           docker push localhost:5000/discourse/base:build_arm64
       - name: build test_build image
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,31 +119,3 @@ jobs:
           docker tag discourse/discourse_dev:build discourse/discourse_dev:release
           docker login --username discoursebuild --password $DOCKERHUB_PASSWORD
           docker push discourse/discourse_dev:release
-  aarch64:
-    runs-on: ubuntu-latest
-    needs: base
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 1
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v2
-      - name: build slim image
-        run: |
-          cd image && ruby auto_build.rb base_slim_arm64
-      - name: tag slim image as release
-        working-directory: image/base
-        run: |
-          docker tag discourse/base:build_slim_arm64 discourse/base:aarch64
-      - name: Print summary
-        run: docker images discourse/base
-      - name: push to dockerhub
-        if: success() && (github.ref == 'refs/heads/main')
-        env:
-          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
-        run: |
-          docker login --username discoursebuild --password $DOCKERHUB_PASSWORD
-          docker push discourse/base:aarch64

--- a/image/auto_build.rb
+++ b/image/auto_build.rb
@@ -19,13 +19,28 @@ images = {
     tag: "discourse/base:build",
     extra_args: "-f release.Dockerfile",
   },
+  base_arm64: {
+    name: "base",
+    tag: "discourse/base:build_arm64",
+    extra_args: "-f release.Dockerfile --platform linux/arm64",
+  },
   discourse_test_build: {
     name: "discourse_test",
     tag: "discourse/discourse_test:build",
   },
+  discourse_test_build_arm64: {
+    name: "discourse_test",
+    tag: "discourse/discourse_test:build_arm64",
+    extra_args: "--platform linux/arm64",
+  },
   discourse_dev: {
     name: "discourse_dev",
     tag: "discourse/discourse_dev:build",
+  },
+  discourse_dev_arm64: {
+    name: "discourse_dev",
+    tag: "discourse/discourse_dev:build_arm64",
+    extra_args: "--platform linux/arm64",
   },
 }
 

--- a/image/base/release.Dockerfile
+++ b/image/base/release.Dockerfile
@@ -11,6 +11,7 @@ RUN cd /var/www/discourse &&\
     sudo -u discourse bundle config --local without test development &&\
     sudo -u discourse bundle config --local jobs 4 && \
     sudo -u discourse bundle install &&\
+    sudo -u discourse yarn config set network-timeout 600000 &&\
     sudo -u discourse yarn install --frozen-lockfile &&\
     sudo -u discourse yarn cache clean &&\
     find /var/www/discourse/vendor/bundle -name tmp -type d -exec rm -rf {} +

--- a/image/discourse_test/Dockerfile
+++ b/image/discourse_test/Dockerfile
@@ -1,6 +1,7 @@
 ARG from_tag=build
+ARG from=discourse/base
 
-FROM discourse/base:$from_tag AS base
+FROM $from:$from_tag AS base
 ENV RAILS_ENV test
 
 WORKDIR /var/www/discourse


### PR DESCRIPTION
Why this change?

We're currently building a base image for arm64 platforms as part of the
CI workflow. However, building it on Github action via emulation is too
slow and makes it meaningless to include as part of the CI workflow.

What does this change do?

This change moves the building of the bage image targeting the arm64
platform completely to a scheduled job that runs outside of the normal
CI workflow. This will also enable us to build the images for the test
and dev environment eventually as part of the workflow which we intend
to do in a follow up commit.