### PR TITLE
DEV: Improve support for Ubuntu 20 and Debian 12

### DIFF
--- a/image/base/install-imagemagick
+++ b/image/base/install-imagemagick
@@ -8,8 +8,8 @@ IMAGE_MAGICK_HASH="d282117bc6d0e91ad1ad685d096623b96ed8e229f911c891d83277b350ef8
 # We use debian, but GitHub CI is stuck on Ubuntu Bionic, so this must be compatible with both
 LIBJPEGTURBO=$(cat /etc/issue | grep -qi Debian && echo 'libjpeg62-turbo libjpeg62-turbo-dev' || echo 'libjpeg-turbo8 libjpeg-turbo8-dev')
 
-# Ubuntu 22.04/22.10  doesn't have libwebp6
-LIBWEBP=$(cat /etc/issue | grep -qi 'Ubuntu 22' && echo 'libwebp7' || echo 'libwebp6')
+# Ubuntu 22.04/22.10 and Debian 12  doesn't have libwebp6
+LIBWEBP=$(cat /etc/issue | grep -qiE 'Ubuntu 22|Debian.*12' && echo 'libwebp7' || echo 'libwebp6')
 
 PREFIX=/usr/local
 WDIR=/tmp/imagemagick
@@ -22,13 +22,7 @@ apt -y -q install git make gcc pkg-config autoconf curl g++ yasm cmake \
     libwebpmux3 libwebpdemux2 ghostscript libxml2-dev libxml2-utils librsvg2-dev \
     libltdl7-dev libbz2-dev gsfonts libtiff-dev libfreetype6-dev libjpeg-dev
 
-# Ubuntu doesn't like `bullseye-backports`
-if cat /etc/issue | grep -qi 'Ubuntu 22'; then
-  apt -y install libheif1 libaom-dev libheif-dev
-else
-  # Use backports instead of compiling it
-  apt -y -q install -t bullseye-backports libheif1 libaom-dev libheif-dev
-fi
+apt -y install libheif1 libaom-dev libheif-dev
 
 mkdir -p $WDIR
 cd $WDIR


### PR DESCRIPTION
I've been looking to improve the guide to setting up a development environment and tested the different versions of Ubuntu and Debian (fresh dev installation on cloud hosting)

What does this PR is to fix *Ubuntu 20* and *Debian 12* installations.
*Ubuntu 20* is still [officially supported](https://wiki.ubuntu.com/Releases).

In short:
* Removed the Debian backports usage. The `libheif` and `libaom` libraries are not backported.
* `libwebp7` is required in *Debian 12*.

*Debian 10* and *Ubuntu 18* are voluntarily ignored in the changes because they are either no longer supported or too old.

## Debian 

There is no backports installed by default. 
E.g. Debian 11:

```
E: The value 'bullseye-backports' is invalid for APT::Default-Release as such a release is not available in the sources
failed
```

Looking at the Debian backports:
* *Debian 11 Bullseye* https://backports.debian.org/bullseye-backports/overview/
* *Debian 12 Bookworm*: https://backports.debian.org/bookworm-backports/overview/

The libraries are not backported. I don't see any reason to try to use them.
### 10

The script fails on `ImageMagick`. The required version doesn't match.

`checking for libheif >= 1.4.0... no`

```
# apt show libheif1
Package: libheif1
Version: 1.3.2-2~deb10u1
```

It's possible to compile from source. 
This distribution is fairly old, and It seems to be a good idea to use at least the same version as Discourse (*Debian 11*)
### 11

With the change introduced in this PR, it works great.
Discourse uses the `bullseyes-slim` docker image, and the `bullseye-backports` is included by default.
### 12

```
# cat /etc/issue
Debian GNU/Linux 12 \n \l
```
With the change introduced in this PR, it works great.

## Ubuntu

### 18

Similar to *Debian 10*, this can work with some effort. However, the distribution is fairly old and unsupported.
To make it work, you need at least Node 16 and *libeom*/*heif* compiled from the source.
We can skip it.

### 20
With the change introduced in this PR, it works great.

### 22
It works great as it is.
