### PR TITLE
FEATURE: add offline page template

### DIFF
--- a/templates/offline-page.template.yml
+++ b/templates/offline-page.template.yml
@@ -1,0 +1,28 @@
+run:
+  - replace:
+     filename: "/etc/nginx/conf.d/discourse.conf"
+     global: true
+     from: /server.+{/
+     to: |
+       server {
+         error_page 502 /error_page.html;
+         location /error_page.html {
+           root /var/www/discourse-offline-page/html;
+           internal;
+         }
+         location /error-page.png {
+           root /var/www/discourse-offline-page/html;
+         }
+         location /error-page-dark.png {
+           root /var/www/discourse-offline-page/html;
+         }
+         location /error-page-bg.png {
+           root /var/www/discourse-offline-page/html;
+         }
+         location /error-page-favicon.png {
+           root /var/www/discourse-offline-page/html;
+         }
+
+  - exec:
+      cmd: git clone https://github.com/discourse/discourse-offline-page.git /var/www/discourse-offline-page
+      raise_on_fail: false

--- a/templates/offline-page.template.yml
+++ b/templates/offline-page.template.yml
@@ -10,18 +10,6 @@ run:
            root /var/www/discourse-offline-page/html;
            internal;
          }
-         location /error-page.png {
-           root /var/www/discourse-offline-page/html;
-         }
-         location /error-page-dark.png {
-           root /var/www/discourse-offline-page/html;
-         }
-         location /error-page-bg.png {
-           root /var/www/discourse-offline-page/html;
-         }
-         location /error-page-favicon.png {
-           root /var/www/discourse-offline-page/html;
-         }
 
   - exec:
       cmd: git clone https://github.com/discourse/discourse-offline-page.git /var/www/discourse-offline-page


### PR DESCRIPTION
Add a template to pull and serve static HTML files from https://github.com/discourse/discourse-offline-page when nginx is available, but rails is not.

<img width="1488" alt="Screenshot 2023-11-01 at 1 30 58 PM" src="https://github.com/discourse/discourse_docker/assets/1322534/fdcc5f4f-2a6a-49e2-b0ee-4ac46d00d9c8">
