### PR TITLE
add env for migrate, precompile and create db on boot

### DIFF
--- a/templates/offline-page.template.yml
+++ b/templates/offline-page.template.yml
@@ -1,3 +1,8 @@
+env:
+  MIGRATE_ON_BOOT: 1
+  PRECOMPILE_ON_BOOT: 1
+  CREATE_DB_ON_BOOT: 1
+
 run:
   - replace:
      filename: "/etc/nginx/conf.d/discourse.conf"


### PR DESCRIPTION
create offline page templates' default env, signify this template wants to migrate and configure on boot.