### PR TITLE
DEV: Remove meaningless line

### DIFF
--- a/image/discourse_test/Dockerfile
+++ b/image/discourse_test/Dockerfile
@@ -33,7 +33,6 @@ RUN cd /var/www/discourse &&\
     sudo -u discourse yarn cache clean
 
 RUN cd /var/www/discourse && sudo -E -u discourse -H bundle exec rake plugin:install_all_official &&\
-    sudo -E -u discourse -H bundle exec rake plugin:install_all_gems &&\
     sudo -E -u discourse -H bundle exec ruby script/install_minio_binaries.rb
 
 ENTRYPOINT ["sudo", "-E", "-u", "discourse", "-H", "ruby", "script/docker_test.rb"]


### PR DESCRIPTION
Why this change?

The rake task is essentially a noop after https://github.com/discourse/discourse/commit/dec68d780c58ef0954865b786d04b653c20e26fa