### PR TITLE
FIX: Install plugin gems in `discourse/discourse_test` image

### DIFF
--- a/image/discourse_test/Dockerfile
+++ b/image/discourse_test/Dockerfile
@@ -33,7 +33,7 @@ RUN cd /var/www/discourse &&\
     sudo -u discourse yarn cache clean
 
 RUN cd /var/www/discourse && sudo -E -u discourse -H bundle exec rake plugin:install_all_official &&\
-    sudo -E -u discourse -H bundle exec rake plugin:install_all_gems &&\
+    LOAD_PLUGINS=1 sudo -E -u discourse -H bundle exec rake plugin:install_all_gems &&\
     sudo -E -u discourse -H bundle exec ruby script/install_minio_binaries.rb
 
 ENTRYPOINT ["sudo", "-E", "-u", "discourse", "-H", "ruby", "script/docker_test.rb"]


### PR DESCRIPTION
Why this change?

In
https://github.com/discourse/discourse/commit/dec68d780c58ef0954865b786d04b653c20e26fa,
the `plugin:install_all_gems` Rake task was made a noop because the Rake
task itself was flawed and running a Rake task will actually activate
all plugins which installs the required gems in the process. However,
plugins are not automatically activated in the test environment which
this image operates in. As such, we need to set `LOAD_PLUGINS` to `1` when
running the `plugin:install_all_gems` Rake task.