### PR TITLE
DEV: add plugin_compatibility hook

### DIFF
--- a/templates/web.template.yml
+++ b/templates/web.template.yml
@@ -189,6 +189,7 @@ run:
       cd: $home
       cmd:
         - su discourse -c 'LOAD_PLUGINS=0 bundle exec rake plugin:pull_compatible_all'
+      hook: plugin_compatibility
       raise_on_fail: false
 
   - exec:


### PR DESCRIPTION
add a plugin_compatibility hook, useful for de-authing after plugin pulls and checkouts