### PR TITLE
FEATURE: Add early support for aarch64 in dev env

### DIFF
--- a/image/auto_build.rb
+++ b/image/auto_build.rb
@@ -63,6 +63,7 @@ def dev_deps()
     "sed -e 's/\(db_name: discourse\)/\1_development/' ../templates/postgres.template.yml > discourse_dev/postgres.template.yml",
   )
   run("cp ../templates/redis.template.yml discourse_dev/redis.template.yml")
+  run("cp base/install-rust discourse_dev/install-rust")
 end
 
 if ARGV.length != 1

--- a/image/base/install-rust
+++ b/image/base/install-rust
@@ -5,7 +5,7 @@ set -e
 export RUSTUP_HOME=/usr/local/rustup
 export CARGO_HOME=/usr/local/cargo
 export PATH=/usr/local/cargo/bin:$PATH
-export RUST_VERSION=1.68.0
+export RUST_VERSION=1.75.0
 export RUSTUP_VERSION=1.25.2
 
 dpkgArch="$(dpkg --print-architecture)"

--- a/image/discourse_dev/Dockerfile
+++ b/image/discourse_dev/Dockerfile
@@ -36,13 +36,13 @@ RUN mv /shared/postgres_data /shared/postgres_data_orig
 # invocations when used with a mounted volume)
 ADD ensure-database /etc/runit/1.d/ensure-database
 
-RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add - &&\
-    echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list &&\
-    apt update &&\
-    apt install -y google-chrome-stable firefox-esr
+ADD install-rust /tmp/install-rust
+ADD install-selenium /tmp/install-selenium
+RUN /tmp/install-selenium
 
 # Install & Configure MailHog (https://github.com/mailhog/MailHog)
 RUN wget -qO /tmp/mailhog https://github.com/mailhog/MailHog/releases/download/v1.0.1/MailHog_linux_amd64\
     && echo "e2ed634ded49929f089b20045581955ed217672078fd86082dd7a6c67c5d09c7 /tmp/mailhog" | sha256sum -c -\
     && mv /tmp/mailhog /usr/local/bin/mailhog\
-    && chmod +x /usr/local/bin/mailhog
+    && chmod +x /usr/local/bin/mailhog\
+    && rm -rf /tmp/*

--- a/image/discourse_dev/install-selenium
+++ b/image/discourse_dev/install-selenium
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -e
+
+# The chrome webdriver isn’t available for the aarch64 architecture (yet). We
+# have to rely on the geckodriver instead, so we’re just installing firefox and
+# not even chromium.
+# The Selenium gem isn’t shipped with the `selenium-manager` binary for aarch64
+# either (yet). So we have to compile it ourselves.
+if [ "$(dpkg --print-architecture)" = "arm64" ]; then
+    apt update && apt install -y firefox-esr
+    cd /tmp
+    /tmp/install-rust
+    git clone --depth 1 --no-checkout https://github.com/SeleniumHQ/selenium.git
+    cd selenium
+    git sparse-checkout set rust
+    git checkout
+    cd rust
+    cargo build --release
+    cp target/release/selenium-manager /usr/local/bin
+    rustup self uninstall -y
+    cd /
+    rm -rf /tmp/*
+else
+    wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add - &&\
+    echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list &&\
+    apt update &&\
+    apt install -y google-chrome-stable firefox-esr
+fi


### PR DESCRIPTION
This PR adds some new steps to support the aarch64 architecture on Linux.

An updated version of Rust is needed to compile the `selenium-manager` binary as it’s not shipped with the `selenium-webdriver` gem yet.
In the same vein, Google doesn’t ship an aarch64 version of Chrome yet, so it doesn’t make sense to install even Chromium in the image. We have to rely on Firefox to run the system specs.

Related PR: https://github.com/discourse/discourse/pull/25230