### PR TITLE
PERF: Use `-O2` gcc compilation flag for imagemagick

### DIFF
--- a/image/base/install-imagemagick
+++ b/image/base/install-imagemagick
@@ -40,7 +40,7 @@ echo "$IMAGE_MAGICK_HASH $WDIR/ImageMagick.tar.gz" | sha256sum -c
 IMDIR=$WDIR/$(tar tzf $WDIR/ImageMagick.tar.gz --wildcards "ImageMagick-*/configure" |cut -d/ -f1)
 tar zxf $WDIR/ImageMagick.tar.gz -C $WDIR
 cd $IMDIR
-PKG_CONF_LIBDIR=$PREFIX/lib LDFLAGS=-L$PREFIX/lib CFLAGS=-I$PREFIX/include ./configure \
+PKG_CONF_LIBDIR=$PREFIX/lib LDFLAGS=-L$PREFIX/lib CFLAGS='-O2 -I$PREFIX/include' ./configure \
           --prefix=$PREFIX \
           --enable-static \
           --enable-bounds-checking \


### PR DESCRIPTION
Why this change?

We have noticed that our compiled imagemagick binary is slower than the
distributed binaries in the same environment and started debugging why.
One thing I noticed is that distributed binaries usually include the
`-O2` gcc compilation flag. When applying it locally, I saw significant
speed up.

Without -O2 flag:

```
root@1d7277f72a4f:/# time convert -limit memory 10GiB -limit disk 10GiB -size $(seq 8000 8500 | shuf | head -n1)x9000 xc:"rgb($(shuf -i 0-255 -n1),$(shuf -i 0-255 -n1),$(shuf -i 0-255 -n1))" random_image.png

real	0m3.376s
user	0m6.355s
sys	0m0.410s
root@1d7277f72a4f:/# time identify -format "%Q" random_image.png
92
real	0m1.018s
user	0m0.883s
sys	0m0.135s
```

With -O2 flag:

```
root@0779afa71102:/# time convert -limit memory 10GiB -limit disk 10GiB -size $(seq 8000 8500 | shuf | head -n1)x9000 xc:"rgb($(shuf -i 0-255 -n1),$(shuf -i 0-255 -n1),$(shuf -i 0-255 -n1))" random_image.png

real	0m1.118s
user	0m1.555s
sys	0m1.680s
root@0779afa71102:/# time identify -format "%Q" random_image.png
92
real	0m0.330s
user	0m0.197s
sys	0m0.133s
```
