### PR TITLE
PERF: Speed up building slim image by setting --jobs to number of cores

### DIFF
--- a/image/base/install-imagemagick
+++ b/image/base/install-imagemagick
@@ -62,7 +62,7 @@ PKG_CONF_LIBDIR=$PREFIX/lib LDFLAGS=-L$PREFIX/lib CFLAGS='-O2 -I$PREFIX/include'
           --with-heic \
           --with-rsvg \
           --with-webp
-make all && make install
+make all -j"$(nproc)" && make install
 
 cd $HOME
 rm -rf $WDIR

--- a/image/base/install-jemalloc
+++ b/image/base/install-jemalloc
@@ -11,7 +11,7 @@ wget -q https://github.com/jemalloc/jemalloc/releases/download/3.6.0/jemalloc-3.
 sha256sum jemalloc-3.6.0.tar.bz2
 echo "e16c2159dd3c81ca2dc3b5c9ef0d43e1f2f45b04548f42db12e7c12d7bdf84fe jemalloc-3.6.0.tar.bz2" | sha256sum -c
 tar --strip-components=1 -xjf jemalloc-3.6.0.tar.bz2
-./configure --prefix=/usr && make && make install
+./configure --prefix=/usr && make -j"$(nproc)" && make install
 cd / && rm -rf /jemalloc-stable
 
 # jemalloc new
@@ -21,6 +21,6 @@ cd /jemalloc-new
 wget -q https://github.com/jemalloc/jemalloc/releases/download/5.3.0/jemalloc-5.3.0.tar.bz2
 sha256sum jemalloc-5.3.0.tar.bz2
 echo "2db82d1e7119df3e71b7640219b6dfe84789bc0537983c3b7ac4f7189aecfeaa jemalloc-5.3.0.tar.bz2" | sha256sum -c
-tar --strip-components=1 -xjf jemalloc-5.3.0.tar.bz2 
-./configure --prefix=/usr --with-install-suffix=5.3.0 && make build_lib && make install_lib
+tar --strip-components=1 -xjf jemalloc-5.3.0.tar.bz2
+./configure --prefix=/usr --with-install-suffix=5.3.0 && make build_lib -j"$(nproc)" && make install_lib
 cd / && rm -rf /jemalloc-new

--- a/image/base/install-redis
+++ b/image/base/install-redis
@@ -15,7 +15,7 @@ tar zxf redis-$REDIS_VERSION.tar.gz
 cd redis-$REDIS_VERSION
 
 # Building and installing binaries.
-make BUILD_TLS=yes && make install PREFIX=/usr
+make -j"$(nproc)" BUILD_TLS=yes && make install PREFIX=/usr
 
 # Add `redis` user and group.
 adduser --system --home /var/lib/redis --quiet --group redis || true


### PR DESCRIPTION
On a M3 Max macbook pro with 14 cores,

Before:

```
=> [25/44] RUN /tmp/install-imagemagick                                 150.6s
=> [27/44] RUN /tmp/install-jemalloc                                     54.9s
=> [31/44] RUN /tmp/install-redis                                        42.9s
```

After:

```
=> [25/44] RUN /tmp/install-imagemagick                                  44.4s
=> [27/44] RUN /tmp/install-jemalloc                                     13.7s
=> [31/44] RUN /tmp/install-redis                                        11.7s
```
