### PR TITLE
Increase yarn timeout for micro instances

### DIFF
--- a/templates/web.template.yml
+++ b/templates/web.template.yml
@@ -171,6 +171,11 @@ run:
   - exec:
       cd: $home
       cmd:
+        - "su discourse -c 'yarn config set network-timeout 600000 -g'"
+        
+  - exec:
+      cd: $home
+      cmd:
         - |-
           if [ "$version" != "tests-passed" ]; then
             rm -rf app/assets/javascripts/node_modules


### PR DESCRIPTION
I'm testing on an Oracle Cloud VM.Standard.E2.1.Micro instance and it routinely failed with:

```
I, [2024-02-26T20:00:17.772624 #1]  INFO -- : > cd /var/www/discourse && su discourse -c 'yarn install --frozen-lockfile && yarn cache clean'
warning Resolution field "unset-value@2.0.1" is incompatible with requested version "unset-value@^1.0.0"
warning Pattern ["wrap-ansi-cjs@npm:wrap-ansi@^7.0.0"] is trying to unpack in the same destination "/home/discourse/.cache/yarn/v6/npm-wrap-ansi-cjs-7.0.0-67e145cff510a6a6984bdf1152911d69d2eb9e43-integrity/node_modules/wrap-ansi-cjs" as pattern ["wrap-ansi@^7.0.0"]. This could result in non-deterministic behavior, skipping.
error An unexpected error occurred: "https://registry.yarnpkg.com/date-fns/-/date-fns-2.30.0.tgz: ESOCKETTIMEDOUT".
```

Digging around I found [an explanation](https://mariolurig.com/coding/fixing-yarn-esockettimedout-error-discourse-setup/):

> **Here’s what is going wrong.** Yarn has a default timeout that is fine if you are using the minimum recommended for Discourse, but with a _micro_ instance, it takes too long. To fix this, you have to manually edit one of the install scripts that runs for the new Docker container Discourse is building.

This patch increases yarns network-timeout to 600000, which solves the problem for my instances. It should have no impact on other instances except that it will take longer to fail if there is something wrong with the network.

Note: this number is in ms, so this new setting amounts to 10 minutes. The default is 60 seconds. After making this change, the `yarn install` step took 44.09s. `¯\_(ツ)_/¯` Maybe double the timeout instead? I'm willing to do some testing if that seems helpful.

See also:

* [Stuck on yarn install, Time out](https://meta.discourse.org/t/stuck-on-yarn-install-time-out/227738)
* [Discourse Installation Failure on Fresh Server: FAILED TO BOOTSTRAP](https://meta.discourse.org/t/discourse-installation-failure-on-fresh-server-failed-to-bootstrap/264143)