### PR TITLE
FIX: Adapt jemalloc page size for pi5 bookworm PAGESIZE

### DIFF
--- a/image/base/install-jemalloc
+++ b/image/base/install-jemalloc
@@ -7,11 +7,13 @@ set -e
 mkdir /jemalloc-stable
 cd /jemalloc-stable
 
+EXTRA_CONF=$(uname -m | grep -qi 'aarch64' && echo '--with-lg-page=16' || echo '')
+
 wget -q https://github.com/jemalloc/jemalloc/releases/download/3.6.0/jemalloc-3.6.0.tar.bz2
 sha256sum jemalloc-3.6.0.tar.bz2
 echo "e16c2159dd3c81ca2dc3b5c9ef0d43e1f2f45b04548f42db12e7c12d7bdf84fe jemalloc-3.6.0.tar.bz2" | sha256sum -c
 tar --strip-components=1 -xjf jemalloc-3.6.0.tar.bz2
-./configure --prefix=/usr && make -j"$(nproc)" && make install
+./configure --prefix=/usr $EXTRA_CONF && make -j"$(nproc)" && make install
 cd / && rm -rf /jemalloc-stable
 
 # jemalloc new
@@ -22,5 +24,5 @@ wget -q https://github.com/jemalloc/jemalloc/releases/download/5.3.0/jemalloc-5.
 sha256sum jemalloc-5.3.0.tar.bz2
 echo "2db82d1e7119df3e71b7640219b6dfe84789bc0537983c3b7ac4f7189aecfeaa jemalloc-5.3.0.tar.bz2" | sha256sum -c
 tar --strip-components=1 -xjf jemalloc-5.3.0.tar.bz2
-./configure --prefix=/usr --with-install-suffix=5.3.0 && make build_lib -j"$(nproc)" && make install_lib
+./configure --prefix=/usr --with-install-suffix=5.3.0 $EXTRA_CONF && make build_lib -j"$(nproc)" && make install_lib
 cd / && rm -rf /jemalloc-new


### PR DESCRIPTION
Debian Bookwork on Pi 5 uses 64k pages, so we need to adapt the jemalloc.

This should be compatible with pi4 and older too.
