### PR TITLE
FEATURE: Update RUBY_ALLOCATOR to work on both x64 and arm64 automatically

### DIFF
--- a/image/base/slim.Dockerfile
+++ b/image/base/slim.Dockerfile
@@ -3,7 +3,7 @@
 FROM debian:bullseye-slim
 
 ENV PG_MAJOR=13 \
-    RUBY_ALLOCATOR=/usr/lib/libjemalloc.so.1 \
+    RUBY_ALLOCATOR=/usr/lib/libjemalloc.so \
     RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \


### PR DESCRIPTION
While x64 is still on jemalloc 3.6, arm64 is using latest jemalloc.

They have different names for the library file, so we will now use the
symlink to automatically load the one available.