### PR TITLE
Use Github hosted ARM runners to build arm64/aarch64 release image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,24 +120,45 @@ jobs:
           docker login --username discoursebuild --password $DOCKERHUB_PASSWORD
           docker push discourse/discourse_dev:release
   aarch64:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04${{ ((github.event_name != 'schedule') && '-8core') || '-2core' }}-arm
     needs: base
     steps:
+      - name: Install Docker
+        run: |
+          # Add Docker's official GPG key:
+          sudo apt-get update
+          sudo apt-get install ca-certificates curl
+          sudo install -m 0755 -d /etc/apt/keyrings
+          sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+          sudo chmod a+r /etc/apt/keyrings/docker.asc
+          # Add the repository to Apt sources:
+          echo \
+            "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+            $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+            sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+          sudo apt-get update
+          # Install Docker
+          sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin
+          # Give the current user permission to run docker without sudo
+          sudo usermod -aG docker $USER
+          sudo apt-get install -y acl
+          sudo setfacl --modify user:$USER:rw /var/run/docker.sock
+      - name: Install Ruby
+        run: |
+          sudo apt-get install -y ruby
       - uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v2
       - name: build slim image
         run: |
           cd image && ruby auto_build.rb base_slim_arm64
-      - name: tag slim image as release
+      - name: build release image
+        run: |
+          cd image && ruby auto_build.rb base_arm64
+      - name: tag release image as release
         working-directory: image/base
         run: |
-          docker tag discourse/base:build_slim_arm64 discourse/base:aarch64
+          docker tag discourse/base:build_arm64 discourse/base:aarch64
       - name: Print summary
         run: docker images discourse/base
       - name: push to dockerhub

--- a/image/auto_build.rb
+++ b/image/auto_build.rb
@@ -19,6 +19,11 @@ images = {
     tag: "discourse/base:build",
     extra_args: "-f release.Dockerfile",
   },
+  base_arm64: {
+    name: "base",
+    tag: "discourse/base:build_arm64",
+    extra_args: "-f release.Dockerfile --platform linux/arm64 --build-arg=\"tag=build_slim_arm64\"",
+  },
   discourse_test_build: {
     name: "discourse_test",
     tag: "discourse/discourse_test:build",

--- a/image/base/release.Dockerfile
+++ b/image/base/release.Dockerfile
@@ -9,7 +9,7 @@ RUN cd /var/www/discourse &&\
     sudo -u discourse bundle config --local deployment true &&\
     sudo -u discourse bundle config --local path ./vendor/bundle &&\
     sudo -u discourse bundle config --local without test development &&\
-    sudo -u discourse bundle config --local jobs 4 && \
+    sudo -u discourse bundle config --local jobs $(($(nproc) - 1)) && \
     sudo -u discourse bundle install &&\
     sudo -u discourse yarn install --frozen-lockfile &&\
     sudo -u discourse yarn cache clean &&\


### PR DESCRIPTION
### Why this change?

We have been given access to Github's private beta of ARM hosted
runners. Switching to ARM runners should drastically speed up the time
required for us to build our ARM image.

### What does this change do?

1. Switch to use Github's ARM hosted runners.
2. Build release image for arm64 as well. We previously only built the
   slim image because building the release image through emulation is
   way too slow so we skipped the release image.
3. Update `bundle` in `release.Dockerfile` to install gems in parallel
   based on the number of cores instead of hardcoding it to 4 jobs.
