### PR TITLE
Use Github's ARM hosted runners for building ARM image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,36 +15,76 @@ env:
 
 jobs:
   base:
-    runs-on: ubuntu-20.04${{ ((github.event_name != 'schedule') && '-8core') || '' }}
+    # `unbuntu-20.04-8core` for arch amd64 non-scheduled builds
+    # `unbuntu-20.04` for arch amd64 scheduled builds
+    # `unbuntu-20.04-8core-arm` for arch arm64 non-scheduled builds
+    # `unbuntu-20.04-2core-arm` for arch arm64 scheduled builds
+    runs-on: ubuntu-20.04${{ ((github.event_name != 'schedule') && '-8core') || (( matrix.arch == 'arm64' && '-2core' ) || '') }}${{ ((matrix.arch == 'arm64') && '-arm' || '') }}
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
     timeout-minutes: 90
     steps:
+      - name: Install Docker
+        if: ${{ matrix.arch == 'arm64' }}
+        run: |
+          # Add Docker's official GPG key:
+          sudo apt-get update
+          sudo apt-get install ca-certificates curl
+          sudo install -m 0755 -d /etc/apt/keyrings
+          sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+          sudo chmod a+r /etc/apt/keyrings/docker.asc
+
+          # Add the repository to Apt sources:
+          echo \
+            "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+            $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+            sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+          sudo apt-get update
+
+          # Install Docker
+          sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin
+
+          # Give the current user permission to run docker without sudo
+          sudo usermod -aG docker $USER
+          sudo apt-get install -y acl
+          sudo setfacl --modify user:$USER:rw /var/run/docker.sock
+      - name: Install Ruby
+        if: ${{ matrix.arch == 'arm64' }}
+        run: |
+          sudo apt-get install -y ruby
       - uses: actions/checkout@v3
         with:
           fetch-depth: 1
+      - name: Set arch helper output
+        id: arch-helper
+        run: |
+          echo "arch_postfix_dash=${{ ((matrix.arch == 'arm64' && '-arm64') || '') }}" >> $GITHUB_OUTPUT
+          echo "arch_postfix_underscore=${{ ((matrix.arch == 'arm64' && '_arm64') || '') }}" >> $GITHUB_OUTPUT
       - name: build slim image
         run: |
-          cd image && ruby auto_build.rb base_slim
+          cd image && ruby auto_build.rb base_slim${{ steps.arch-helper.outputs.arch_postfix_underscore }}
       - name: tag slim images
         id: tag-images
         run: |
           TAG=`date +%Y%m%d-%H%M`
           echo "tag=$(echo $TAG)" >> $GITHUB_OUTPUT
-          docker tag discourse/base:build_slim discourse/base:2.0.$TAG-slim
-          docker tag discourse/base:build_slim discourse/base:slim
+          docker tag discourse/base:build_slim${{ steps.arch-helper.outputs.arch_postfix_underscore }} discourse/base:2.0.$TAG-slim${{ steps.arch-helper.outputs.arch_postfix_dash }}
+          docker tag discourse/base:build_slim${{ steps.arch-helper.outputs.arch_postfix_underscore }} discourse/base:slim${{ steps.arch-helper.outputs.arch_postfix_dash }}
       - name: build release image
         run: |
-          cd image && ruby auto_build.rb base
-      - name: tag release images
+          cd image && ruby auto_build.rb base${{ steps.arch-helper.outputs.arch_postfix_underscore }}
+      - name: tag amd64 release images
         run: |
           TAG=${{ steps.tag-images.outputs.tag }}
-          docker tag discourse/base:build discourse/base:2.0.$TAG
-          docker tag discourse/base:build discourse/base:release
+          docker tag discourse/base:build${{ steps.arch-helper.outputs.arch_postfix_underscore }} discourse/base:2.0.$TAG${{ steps.arch-helper.outputs.arch_postfix_dash }}
+          docker tag discourse/base:build${{ steps.arch-helper.outputs.arch_postfix_underscore }} discourse/base:release${{ steps.arch-helper.outputs.arch_postfix_dash }}
       - name: build test_build image
         run: |
-          cd image && ruby auto_build.rb discourse_test_build
+          cd image && ruby auto_build.rb discourse_test_build${{ steps.arch-helper.outputs.arch_postfix_underscore }}
       - name: run specs
         run: |
-          docker run --rm -e RUBY_ONLY=1 -e USE_TURBO=1 -e SKIP_PLUGINS=1 -e SKIP_LINT=1 discourse/discourse_test:build
+          docker run --rm -e RUBY_ONLY=1 -e USE_TURBO=1 -e SKIP_PLUGINS=1 -e SKIP_LINT=1 discourse/discourse_test:build${{ steps.arch-helper.outputs.arch_postfix_underscore }}
       - name: Print summary
         run: |
           docker images discourse/base
@@ -55,12 +95,19 @@ jobs:
         run: |
           TAG=${{ steps.tag-images.outputs.tag }}
           docker login --username discoursebuild --password $DOCKERHUB_PASSWORD
-          docker push discourse/base:2.0.$TAG-slim
-          docker push discourse/base:slim
-          docker push discourse/base:2.0.$TAG
-          docker push discourse/base:release
+          docker push discourse/base:2.0.$TAG-slim${{ steps.arch-helper.outputs.arch_postfix_dash }}
+          docker push discourse/base:slim${{ steps.arch-helper.outputs.arch_postfix_dash }}
+          docker push discourse/base:2.0.$TAG${{ steps.arch-helper.outputs.arch_postfix_dash }}
+          docker push discourse/base:release${{ steps.arch-helper.outputs.arch_postfix_dash }}
   test:
-    runs-on: ubuntu-20.04${{ ((github.event_name != 'schedule') && '-8core') || '' }}
+    # `unbuntu-20.04-8core` for arch amd64 non-scheduled builds
+    # `unbuntu-20.04` for arch amd64 scheduled builds
+    # `unbuntu-20.04-8core-arm` for arch arm64 non-scheduled builds
+    # `unbuntu-20.04-2core-arm` for arch arm64 scheduled builds
+    runs-on: ubuntu-20.04${{ ((github.event_name != 'schedule') && '-8core') || (( matrix.arch == 'arm64' && '-2core' ) || '') }}${{ ((matrix.arch == 'arm64') && '-arm' || '') }}
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
     timeout-minutes: 30
     needs: base
     defaults:
@@ -70,24 +117,29 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 1
+      - name: Set arch helper output
+        id: arch-helper
+        run: |
+          echo "arch_postfix_dash=${{ ((matrix.arch == 'arm64' && '-arm64') || '') }}" >> $GITHUB_OUTPUT
+          echo "arch_postfix_underscore=${{ ((matrix.arch == 'arm64' && '_arm64') || '') }}" >> $GITHUB_OUTPUT
       - name: build discourse_test:slim
         run: |
           docker buildx build . --load \
-            --build-arg from_tag=slim \
+            --build-arg from_tag=slim${{ steps.arch-helper.outputs.arch_postfix_dash }} \
             --target base \
-            --tag discourse/discourse_test:slim
+            --tag discourse/discourse_test:slim${{ steps.arch-helper.outputs.arch_postfix_dash }}
       - name: build discourse_test:slim-browsers
         run: |
           docker buildx build . --load \
-            --build-arg from_tag=slim \
+            --build-arg from_tag=slim${{ steps.arch-helper.outputs.arch_postfix_dash }} \
             --target with_browsers \
-            --tag discourse/discourse_test:slim-browsers
+            --tag discourse/discourse_test:slim-browsers${{ steps.arch-helper.outputs.arch_postfix_dash }}
       - name: build discourse_test:release
         run: |
           docker buildx build . --load \
-            --build-arg from_tag=release \
+            --build-arg from_tag=release${{ steps.arch-helper.outputs.arch_postfix_dash }} \
             --target release \
-            --tag discourse/discourse_test:release
+            --tag discourse/discourse_test:release${{ steps.arch-helper.outputs.arch_postfix_dash }}
       - name: Print summary
         run: |
           docker images discourse/discourse_test
@@ -97,74 +149,37 @@ jobs:
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
         run: |
           docker login --username discoursebuild --password $DOCKERHUB_PASSWORD
-          docker push discourse/discourse_test:slim
-          docker push discourse/discourse_test:slim-browsers
-          docker push discourse/discourse_test:release
+          docker push discourse/discourse_test:slim${{ steps.arch-helper.outputs.arch_postfix_dash }}
+          docker push discourse/discourse_test:slim-browsers${{ steps.arch-helper.outputs.arch_postfix_dash }}
+          docker push discourse/discourse_test:release${{ steps.arch-helper.outputs.arch_postfix_dash }}
   dev:
-    runs-on: ubuntu-20.04${{ ((github.event_name != 'schedule') && '-8core') || '' }}
+    # `unbuntu-20.04-8core` for arch amd64 non-scheduled builds
+    # `unbuntu-20.04` for arch amd64 scheduled builds
+    # `unbuntu-20.04-8core-arm` for arch arm64 non-scheduled builds
+    # `unbuntu-20.04-2core-arm` for arch arm64 scheduled builds
+    runs-on: ubuntu-20.04${{ ((github.event_name != 'schedule') && '-8core') || (( matrix.arch == 'arm64' && '-2core' ) || '') }}${{ ((matrix.arch == 'arm64') && '-arm' || '') }}
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
     timeout-minutes: 30
     needs: base
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 1
+      - name: Set arch helper output
+        id: arch-helper
+        run: |
+          echo "arch_postfix_dash=${{ ((matrix.arch == 'arm64' && '-arm64') || '') }}" >> $GITHUB_OUTPUT
+          echo "arch_postfix_underscore=${{ ((matrix.arch == 'arm64' && '_arm64') || '') }}" >> $GITHUB_OUTPUT
       - name: build discourse_dev image
         run: |
-          cd image && ruby auto_build.rb discourse_dev
-      - name: push to dockerhub
-        if: success() && (github.ref == 'refs/heads/main')
-        env:
-          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
-        run: |
-          docker tag discourse/discourse_dev:build discourse/discourse_dev:release
-          docker login --username discoursebuild --password $DOCKERHUB_PASSWORD
-          docker push discourse/discourse_dev:release
-  aarch64:
-    runs-on: ubuntu-20.04${{ ((github.event_name != 'schedule') && '-8core') || '-2core' }}-arm
-    needs: base
-    steps:
-      - name: Install Docker
-        run: |
-          # Add Docker's official GPG key:
-          sudo apt-get update
-          sudo apt-get install ca-certificates curl
-          sudo install -m 0755 -d /etc/apt/keyrings
-          sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
-          sudo chmod a+r /etc/apt/keyrings/docker.asc
-          # Add the repository to Apt sources:
-          echo \
-            "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
-            $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
-            sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-          sudo apt-get update
-          # Install Docker
-          sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin
-          # Give the current user permission to run docker without sudo
-          sudo usermod -aG docker $USER
-          sudo apt-get install -y acl
-          sudo setfacl --modify user:$USER:rw /var/run/docker.sock
-      - name: Install Ruby
-        run: |
-          sudo apt-get install -y ruby
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 1
-      - name: build slim image
-        run: |
-          cd image && ruby auto_build.rb base_slim_arm64
-      - name: build release image
-        run: |
-          cd image && ruby auto_build.rb base_arm64
-      - name: tag release image as release
-        working-directory: image/base
-        run: |
-          docker tag discourse/base:build_arm64 discourse/base:aarch64
-      - name: Print summary
-        run: docker images discourse/base
+          cd image && ruby auto_build.rb discourse_dev${{ steps.arch-helper.outputs.arch_postfix_underscore }}
       - name: push to dockerhub
         if: success() && (github.ref == 'refs/heads/main')
         env:
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
         run: |
           docker login --username discoursebuild --password $DOCKERHUB_PASSWORD
-          docker push discourse/base:aarch64
+          docker tag discourse/discourse_dev:build${{ steps.arch-helper.outputs.arch_postfix_underscore }} discourse/discourse_dev:release${{ steps.arch-helper.outputs.arch_postfix_dash }}
+          docker push discourse/discourse_dev:release${{ steps.arch-helper.outputs.arch_postfix_dash }}

--- a/image/auto_build.rb
+++ b/image/auto_build.rb
@@ -28,10 +28,20 @@ images = {
     name: "discourse_test",
     tag: "discourse/discourse_test:build",
   },
+  discourse_test_build_arm64: {
+    name: "discourse_test",
+    tag: "discourse/discourse_test:build_arm64",
+    extra_args: "--platform linux/arm64 --build-arg=\"from_tag=build_arm64\"",
+  },
   discourse_dev: {
     name: "discourse_dev",
     tag: "discourse/discourse_dev:build",
   },
+  discourse_dev_arm64: {
+    name: "discourse_dev",
+    tag: "discourse/discourse_dev:build_arm64",
+    extra_args: "--platform linux/arm64 --build-arg=\"from_tag=slim-arm64\"",
+  }
 }
 
 def run(command)

--- a/image/base/slim.Dockerfile
+++ b/image/base/slim.Dockerfile
@@ -27,7 +27,7 @@ ENV LANGUAGE en_US.UTF-8
 
 RUN curl https://apt.postgresql.org/pub/repos/apt/ACCC4CF8.asc | apt-key add -
 RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main" | \
-        tee /etc/apt/sources.list.d/postgres.list
+    tee /etc/apt/sources.list.d/postgres.list
 RUN curl --silent --location https://deb.nodesource.com/setup_18.x | sudo bash -
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list
@@ -36,16 +36,16 @@ RUN apt-get -y update
 # X11 libraries, mailutils
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends git rsyslog logrotate cron ssh-client less
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install autoconf build-essential ca-certificates rsync \
-                       libxslt-dev libcurl4-openssl-dev \
-                       libssl-dev libyaml-dev libtool \
-                       libpcre3 libpcre3-dev zlib1g zlib1g-dev \
-                       libxml2-dev gawk parallel \
-                       postgresql-${PG_MAJOR} postgresql-client \
-                       postgresql-contrib-${PG_MAJOR} libpq-dev postgresql-${PG_MAJOR}-pgvector \
-                       libreadline-dev anacron wget \
-                       psmisc whois brotli libunwind-dev \
-                       libtcmalloc-minimal4 cmake \
-                       pngcrush pngquant ripgrep
+    libxslt-dev libcurl4-openssl-dev \
+    libssl-dev libyaml-dev libtool \
+    libpcre3 libpcre3-dev zlib1g zlib1g-dev \
+    libxml2-dev gawk parallel \
+    postgresql-${PG_MAJOR} postgresql-client \
+    postgresql-contrib-${PG_MAJOR} libpq-dev postgresql-${PG_MAJOR}-pgvector \
+    libreadline-dev anacron wget \
+    psmisc whois brotli libunwind-dev \
+    libtcmalloc-minimal4 cmake \
+    pngcrush pngquant ripgrep
 RUN sed -i -e 's/start -q anacron/anacron -s/' /etc/cron.d/anacron
 RUN sed -i.bak 's/$ModLoad imklog/#$ModLoad imklog/' /etc/rsyslog.conf
 RUN sed -i.bak 's/module(load="imklog")/#module(load="imklog")/' /etc/rsyslog.conf

--- a/image/discourse_dev/Dockerfile
+++ b/image/discourse_dev/Dockerfile
@@ -1,6 +1,7 @@
 # NAME:     discourse/discourse_dev
 # VERSION:  release
-FROM discourse/base:slim
+ARG from_tag=slim
+FROM discourse/base:$from_tag
 
 #LABEL maintainer="Sam Saffron \"https://twitter.com/samsaffron\""
 
@@ -37,8 +38,14 @@ RUN mv /shared/postgres_data /shared/postgres_data_orig
 ADD ensure-database /etc/runit/1.d/ensure-database
 
 ADD install-rust /tmp/install-rust
-ADD install-selenium /tmp/install-selenium
-RUN /tmp/install-selenium
+ADD install-selenium-manager /tmp/install-selenium-manager
+ADD install-chrome /tmp/install-chrome
+
+RUN /tmp/install-selenium-manager &&\
+    /tmp/install-chrome
+
+RUN apt update &&\
+    apt install -y firefox-esr
 
 # Install & Configure MailHog (https://github.com/mailhog/MailHog)
 RUN wget -qO /tmp/mailhog https://github.com/mailhog/MailHog/releases/download/v1.0.1/MailHog_linux_amd64\

--- a/image/discourse_dev/install-chrome
+++ b/image/discourse_dev/install-chrome
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+# https://googlechromelabs.github.io/chrome-for-testing/ doesn't provide linux/arm64 binaries for chrome or chromedriver
+# yet. Therefore on arm64, we install chromium instead of chrome and installs a chromedriver for linux/arm64 from
+# https://github.com/electron/electron/releases/.
+#
+# On that on the current debian, Chromium 120.0.6099.224 is installed so we have to install a chromedriver that is of the
+# same version.
+if [ "$(dpkg --print-architecture)" = "arm64" ]; then
+  apt update && apt install -y chromium unzip &&\
+    wget -q -O /tmp/chromedriver.zip https://github.com/electron/electron/releases/download/v28.2.2/chromedriver-v28.2.2-linux-arm64.zip &&\
+    unzip /tmp/chromedriver.zip -d /tmp/chromedriver &&\
+    mv /tmp/chromedriver/chromedriver /usr/bin &&\
+    rm -rf /tmp/chromedriver /tmp/chromedriver.zip
+else
+  wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add - &&\
+    echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list &&\
+    apt update &&\
+    apt install -y google-chrome-stable
+fi

--- a/image/discourse_dev/install-selenium-manager
+++ b/image/discourse_dev/install-selenium-manager
@@ -1,13 +1,9 @@
 #!/bin/bash
 set -e
 
-# The chrome webdriver isn’t available for the aarch64 architecture (yet). We
-# have to rely on the geckodriver instead, so we’re just installing firefox and
-# not even chromium.
 # The Selenium gem isn’t shipped with the `selenium-manager` binary for aarch64
 # either (yet). So we have to compile it ourselves.
 if [ "$(dpkg --print-architecture)" = "arm64" ]; then
-    apt update && apt install -y firefox-esr
     cd /tmp
     /tmp/install-rust
     git clone --depth 1 --no-checkout https://github.com/SeleniumHQ/selenium.git
@@ -20,9 +16,4 @@ if [ "$(dpkg --print-architecture)" = "arm64" ]; then
     rustup self uninstall -y
     cd /
     rm -rf /tmp/*
-else
-    wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add - &&\
-    echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list &&\
-    apt update &&\
-    apt install -y google-chrome-stable firefox-esr
 fi

--- a/image/discourse_test/Dockerfile
+++ b/image/discourse_test/Dockerfile
@@ -17,10 +17,11 @@ RUN chown -R discourse . &&\
 
 FROM base AS with_browsers
 
-RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add - &&\
-    echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list &&\
-    apt update &&\
-    apt install -y libgconf-2-4 libxss1 google-chrome-stable firefox-esr &&\
+ADD install-chrome /tmp/install-chrome
+RUN /tmp/install-chrome
+
+RUN apt update &&\
+    apt install -y libgconf-2-4 libxss1 firefox-esr &&\
     cd /tmp && wget -q "https://download.mozilla.org/?product=firefox-latest-ssl&os=linux64&lang=en-US" -O firefox.tar.bz2 &&\
     tar xjvf firefox.tar.bz2 && mv /tmp/firefox /opt/firefox-evergreen &&\
     apt clean
@@ -28,7 +29,7 @@ RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo ap
 FROM with_browsers AS release
 
 RUN cd /var/www/discourse &&\
-    sudo -u discourse bundle install --jobs=4 &&\
+    sudo -u discourse bundle install &&\
     sudo -E -u discourse -H yarn install &&\
     sudo -u discourse yarn cache clean
 

--- a/image/discourse_test/install-chrome
+++ b/image/discourse_test/install-chrome
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+# https://googlechromelabs.github.io/chrome-for-testing/ doesn't provide linux/arm64 binaries for chrome or chromedriver
+# yet. Therefore on arm64, we install chromium instead of chrome and installs a chromedriver for linux/arm64 from
+# https://github.com/electron/electron/releases/.
+#
+# On that on the current debian, Chromium 120.0.6099.224 is installed so we have to install a chromedriver that is of the
+# same version.
+if [ "$(dpkg --print-architecture)" = "arm64" ]; then
+  apt update && apt install -y chromium unzip &&\
+    wget -q -O /tmp/chromedriver.zip https://github.com/electron/electron/releases/download/v28.2.2/chromedriver-v28.2.2-linux-arm64.zip &&\
+    unzip /tmp/chromedriver.zip -d /tmp/chromedriver &&\
+    mv /tmp/chromedriver/chromedriver /usr/bin &&\
+    rm -rf /tmp/chromedriver /tmp/chromedriver.zip
+else
+  wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add - &&\
+    echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list &&\
+    apt update &&\
+    apt install -y google-chrome-stable
+fi


### PR DESCRIPTION
## Why this change?

We have been given access to Github's private beta of ARM hosted
runners. Switching to ARM runners should drastically speed up the time
required for us to build our ARM image.
