### PR TITLE
Revert "Use Chromium instead of Chrome (#782)"

### DIFF
--- a/image/discourse_dev/Dockerfile
+++ b/image/discourse_dev/Dockerfile
@@ -39,7 +39,6 @@ ADD ensure-database /etc/runit/1.d/ensure-database
 ADD install-rust /tmp/install-rust
 ADD install-selenium /tmp/install-selenium
 RUN /tmp/install-selenium
-RUN apt update && apt install -y chromium-driver firefox-esr
 
 # Install & Configure MailHog (https://github.com/mailhog/MailHog)
 RUN wget -qO /tmp/mailhog https://github.com/mailhog/MailHog/releases/download/v1.0.1/MailHog_linux_amd64\

--- a/image/discourse_dev/install-selenium
+++ b/image/discourse_dev/install-selenium
@@ -1,9 +1,13 @@
 #!/bin/bash
 set -e
 
+# The chrome webdriver isn’t available for the aarch64 architecture (yet). We
+# have to rely on the geckodriver instead, so we’re just installing firefox and
+# not even chromium.
 # The Selenium gem isn’t shipped with the `selenium-manager` binary for aarch64
-# (yet). So we have to compile it ourselves.
+# either (yet). So we have to compile it ourselves.
 if [ "$(dpkg --print-architecture)" = "arm64" ]; then
+    apt update && apt install -y firefox-esr
     cd /tmp
     /tmp/install-rust
     git clone --depth 1 --no-checkout https://github.com/SeleniumHQ/selenium.git
@@ -16,4 +20,9 @@ if [ "$(dpkg --print-architecture)" = "arm64" ]; then
     rustup self uninstall -y
     cd /
     rm -rf /tmp/*
+else
+    wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add - &&\
+    echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list &&\
+    apt update &&\
+    apt install -y google-chrome-stable firefox-esr
 fi

--- a/image/discourse_test/Dockerfile
+++ b/image/discourse_test/Dockerfile
@@ -17,8 +17,10 @@ RUN chown -R discourse . &&\
 
 FROM base AS with_browsers
 
-RUN apt update &&\
-    apt install -y libgconf-2-4 libxss1 firefox-esr chromium-driver &&\
+ADD install-chrome /tmp/install-chrome
+RUN /tmp/install-chrome &&\
+    apt update &&\
+    apt install -y libgconf-2-4 libxss1 firefox-esr &&\
     cd /tmp && wget -q "https://download.mozilla.org/?product=firefox-latest-ssl&os=linux64&lang=en-US" -O firefox.tar.bz2 &&\
     tar xjvf firefox.tar.bz2 && mv /tmp/firefox /opt/firefox-evergreen &&\
     apt clean

--- a/image/discourse_test/install-chrome
+++ b/image/discourse_test/install-chrome
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+# https://googlechromelabs.github.io/chrome-for-testing/ doesn't provide linux/arm64 binaries for chrome or chromedriver
+# yet. Therefore on arm64, we install chromium instead of chrome and install a chromedriver for linux/arm64 from
+# https://github.com/electron/electron/releases/.
+#
+# On the current debian Chromium 120.0.6099.224 is installed so we have to install a chromedriver that is of the same version.
+if [ "$(dpkg --print-architecture)" = "arm64" ]; then
+  apt update && apt install -y chromium unzip &&\
+    wget -q -O /tmp/chromedriver.zip https://github.com/electron/electron/releases/download/v28.2.2/chromedriver-v28.2.2-linux-arm64.zip &&\
+    unzip /tmp/chromedriver.zip -d /tmp/chromedriver &&\
+    mv /tmp/chromedriver/chromedriver /usr/bin &&\
+    rm -rf /tmp/chromedriver /tmp/chromedriver.zip
+else
+  wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add - &&\
+    echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list &&\
+    apt update &&\
+    apt install -y google-chrome-stable
+fi


### PR DESCRIPTION
This reverts commit e6ffa64d9d7622327b134c8397f59edf832e4299.

We need to fix the various Chrome assumptions in Discourse core.
