### PR TITLE
Increase build time for arm64 scheduled build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         arch: [amd64, arm64]
-    timeout-minutes: 30
+    timeout-minutes: ${{ (github.event_name != 'schedule' && 30) || ((matrix.arch == 'arm64' && 45) || 30) }}
     steps:
       - name: Install Docker
         if: ${{ matrix.arch == 'arm64' }}


### PR DESCRIPTION
Scheduled build for arm64 running on 2cores is timing out at 30 minutes.
Let's give it some more time
