### PR TITLE
Revert "Upgrade Debian to Bookworm"

### DIFF
--- a/image/base/install-imagemagick
+++ b/image/base/install-imagemagick
@@ -5,17 +5,30 @@ set -e
 IMAGE_MAGICK_VERSION="7.1.0-62"
 IMAGE_MAGICK_HASH="d282117bc6d0e91ad1ad685d096623b96ed8e229f911c891d83277b350ef884a"
 
+# We use debian, but GitHub CI is stuck on Ubuntu Bionic, so this must be compatible with both
+LIBJPEGTURBO=$(cat /etc/issue | grep -qi Debian && echo 'libjpeg62-turbo libjpeg62-turbo-dev' || echo 'libjpeg-turbo8 libjpeg-turbo8-dev')
+
+# Ubuntu 22.04/22.10  doesn't have libwebp6
+LIBWEBP=$(cat /etc/issue | grep -qi 'Ubuntu 22' && echo 'libwebp7' || echo 'libwebp6')
+
 PREFIX=/usr/local
 WDIR=/tmp/imagemagick
 
 # Install build deps
 apt -y -q remove imagemagick
 apt -y -q install git make gcc pkg-config autoconf curl g++ yasm cmake \
-    libde265-0 libde265-dev libjpeg62-turbo libjpeg62-turbo-dev x265 libx265-dev libtool \
-    libpng16-16 libpng-dev libwebp7 libwebp-dev libgomp1 \
+    libde265-0 libde265-dev ${LIBJPEGTURBO} x265 libx265-dev libtool \
+    libpng16-16 libpng-dev ${LIBJPEGTURBO} ${LIBWEBP} libwebp-dev libgomp1 \
     libwebpmux3 libwebpdemux2 ghostscript libxml2-dev libxml2-utils librsvg2-dev \
-    libltdl7-dev libbz2-dev gsfonts libtiff-dev libfreetype6-dev libjpeg-dev \
-    libheif1 libaom-dev libheif-dev
+    libltdl7-dev libbz2-dev gsfonts libtiff-dev libfreetype6-dev libjpeg-dev
+
+# Ubuntu doesn't like `bullseye-backports`
+if cat /etc/issue | grep -qi 'Ubuntu 22'; then
+  apt -y install libheif1 libaom-dev libheif-dev
+else
+  # Use backports instead of compiling it
+  apt -y -q install -t bullseye-backports libheif1 libaom-dev libheif-dev
+fi
 
 mkdir -p $WDIR
 cd $WDIR

--- a/image/base/slim.Dockerfile
+++ b/image/base/slim.Dockerfile
@@ -1,6 +1,6 @@
 # NAME:     discourse/base
 # VERSION:  release
-FROM debian:bookworm-slim
+FROM debian:bullseye-slim
 
 ENV PG_MAJOR=13 \
     RUBY_ALLOCATOR=/usr/lib/libjemalloc.so \
@@ -13,7 +13,7 @@ ENV PG_MAJOR=13 \
 
 RUN echo 2.0.`date +%Y%m%d` > /VERSION
 
-RUN echo 'deb http://deb.debian.org/debian bookworm-backports main' > /etc/apt/sources.list.d/bookworm-backports.list
+RUN echo 'deb http://deb.debian.org/debian bullseye-backports main' > /etc/apt/sources.list.d/bullseye-backports.list
 RUN echo "debconf debconf/frontend select Teletype" | debconf-set-selections
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install gnupg sudo curl fping
 RUN sh -c "fping proxy && echo 'Acquire { Retries \"0\"; HTTP { Proxy \"http://proxy:3128\";}; };' > /etc/apt/apt.conf.d/40proxy && apt-get update || true"
@@ -26,7 +26,7 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8
 
 RUN curl https://apt.postgresql.org/pub/repos/apt/ACCC4CF8.asc | apt-key add -
-RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ bookworm-pgdg main" | \
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main" | \
         tee /etc/apt/sources.list.d/postgres.list
 RUN curl --silent --location https://deb.nodesource.com/setup_18.x | sudo bash -
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -


### PR DESCRIPTION
This reverts commit 23e7b55d42a573bfc313ff965ed3c0a1ea7e0f45.

The CI build on `discourse/discourse` and our internal CI is broken
because of this.
