### PR TITLE
DEV: Set RUBY_VERSION and DEBIAN_RELEASE env

### DIFF
--- a/image/base/install-ruby
+++ b/image/base/install-ruby
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-RUBY_VERSION="3.2.2"
+RUBY_VERSION=$1
 export CONFIGURE_OPTS="--enable-yjit"
 
 apt-get -y install --no-install-recommends ruby bison libffi-dev

--- a/image/base/slim.Dockerfile
+++ b/image/base/slim.Dockerfile
@@ -1,13 +1,18 @@
 # NAME:     discourse/base
 # VERSION:  release
-FROM debian:bullseye-slim
 
+ARG DEBIAN_RELEASE=bullseye
+FROM debian:${DEBIAN_RELEASE}-slim
+
+ARG DEBIAN_RELEASE
 ENV PG_MAJOR=13 \
     RUBY_ALLOCATOR=/usr/lib/libjemalloc.so \
     RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    LEFTHOOK=0
+    LEFTHOOK=0 \
+    RUBY_VERSION=3.2.3 \
+    DEBIAN_RELEASE=${DEBIAN_RELEASE}
 
 #LABEL maintainer="Sam Saffron \"https://twitter.com/samsaffron\""
 
@@ -27,7 +32,7 @@ ENV LANGUAGE en_US.UTF-8
 
 RUN curl https://apt.postgresql.org/pub/repos/apt/ACCC4CF8.asc | apt-key add -
 RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main" | \
-        tee /etc/apt/sources.list.d/postgres.list
+    tee /etc/apt/sources.list.d/postgres.list
 RUN curl --silent --location https://deb.nodesource.com/setup_18.x | sudo bash -
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list
@@ -36,16 +41,16 @@ RUN apt-get -y update
 # X11 libraries, mailutils
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends git rsyslog logrotate cron ssh-client less
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install autoconf build-essential ca-certificates rsync \
-                       libxslt-dev libcurl4-openssl-dev \
-                       libssl-dev libyaml-dev libtool \
-                       libpcre3 libpcre3-dev zlib1g zlib1g-dev \
-                       libxml2-dev gawk parallel \
-                       postgresql-${PG_MAJOR} postgresql-client \
-                       postgresql-contrib-${PG_MAJOR} libpq-dev postgresql-${PG_MAJOR}-pgvector \
-                       libreadline-dev anacron wget \
-                       psmisc whois brotli libunwind-dev \
-                       libtcmalloc-minimal4 cmake \
-                       pngcrush pngquant ripgrep
+    libxslt-dev libcurl4-openssl-dev \
+    libssl-dev libyaml-dev libtool \
+    libpcre3 libpcre3-dev zlib1g zlib1g-dev \
+    libxml2-dev gawk parallel \
+    postgresql-${PG_MAJOR} postgresql-client \
+    postgresql-contrib-${PG_MAJOR} libpq-dev postgresql-${PG_MAJOR}-pgvector \
+    libreadline-dev anacron wget \
+    psmisc whois brotli libunwind-dev \
+    libtcmalloc-minimal4 cmake \
+    pngcrush pngquant ripgrep
 RUN sed -i -e 's/start -q anacron/anacron -s/' /etc/cron.d/anacron
 RUN sed -i.bak 's/$ModLoad imklog/#$ModLoad imklog/' /etc/rsyslog.conf
 RUN sed -i.bak 's/module(load="imklog")/#module(load="imklog")/' /etc/rsyslog.conf
@@ -75,7 +80,7 @@ RUN /tmp/install-redis
 ADD install-rust /tmp/install-rust
 ADD install-ruby /tmp/install-ruby
 ADD install-oxipng /tmp/install-oxipng
-RUN /tmp/install-rust && /tmp/install-ruby && /tmp/install-oxipng && rustup self uninstall -y
+RUN /tmp/install-rust && /tmp/install-ruby $RUBY_VERSION && /tmp/install-oxipng && rustup self uninstall -y
 
 RUN echo 'gem: --no-document' >> /usr/local/etc/gemrc &&\
     gem update --system


### PR DESCRIPTION
## Why this change?

These envs allow the Debian release name and Ruby version to be easily determined without having to know which commands to run.