### PR TITLE
FEATURE: Fix Discourse installation support in China

### DIFF
--- a/templates/web.china.template.yml
+++ b/templates/web.china.template.yml
@@ -1,10 +1,21 @@
 hooks:
+  before_code:
+    - exec:
+        cmd:
+          - su discourse -c 'git config --global url."https://mirror.ghproxy.com/https://github.com/".insteadOf "https://github.com/"'
+
   before_web:
     - exec:
-       cmd:
-         - gem sources --add https://gems.ruby-china.com/ --remove https://rubygems.org/
+        cmd:
+          - su discourse -c 'gem sources --add https://mirrors.tuna.tsinghua.edu.cn/rubygems/ --remove https://rubygems.org/'
+
+  before_yarn:
+    - exec:
+        cmd:
+          - su discourse -c 'yarn config set registry https://registry.npmmirror.com --global'
+          - su discourse -c 'cd $home && sed -i "s#https://registry.yarnpkg.com#https://registry.npmmirror.com#g" yarn.lock'
 
   before_bundle_exec:
     - exec:
-       cmd:
-         - su discourse -c 'bundle config mirror.https://rubygems.org https://gems.ruby-china.com/'
+        cmd:
+          - su discourse -c 'bundle config mirror.https://rubygems.org https://mirrors.tuna.tsinghua.edu.cn/rubygems'

--- a/templates/web.template.yml
+++ b/templates/web.template.yml
@@ -179,6 +179,7 @@ run:
 
   - exec:
       cd: $home
+      hook: yarn
       cmd:
         - |-
           if [ "$version" != "tests-passed" ]; then


### PR DESCRIPTION
This PR does 2 things:

1. Added a new yarn hook to replace the npm mirror before `yarn install`.
2. Modified `web.china.template.yml` to add more mirror sources.

Below is an explanation of these modifications:

- The GitHub proxy added in `web.china.template.yml` has existed in China for many years, and its repository https://github.com/hunshcn/gh-proxy has 6k+ stars, which can ensure its security and stability.
- The NPM mirror site added in `web.china.template.yml` is maintained by Alibaba Group, one of the largest Internet companies in China.
- Modified the Gem mirror in `web.china.template.yml` to the mirror provided by Tsinghua University, one of the top universities in China.
- The reason why sed is used to replace the `yarn.lock` file is because `yarn install --frozen-lockfile` is used for installation below. If the url is not replaced, the NPM mirror will not take effect.

After applying these modifications, I successfully installed Discourse on the Tencent Cloud China server. No more network problems.
