### PR TITLE
DEV: Bump Ruby to 3.2.4

### DIFF
--- a/image/base/slim.Dockerfile
+++ b/image/base/slim.Dockerfile
@@ -11,7 +11,7 @@ ENV PG_MAJOR=13 \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
     LEFTHOOK=0 \
-    RUBY_VERSION=3.2.3 \
+    RUBY_VERSION=3.2.4 \
     DEBIAN_RELEASE=${DEBIAN_RELEASE}
 
 #LABEL maintainer="Sam Saffron \"https://twitter.com/samsaffron\""


### PR DESCRIPTION
This commit updates Ruby to 3.2.4 which includes security fixes for the
following CVEs:

* CVE-2024-27282: Arbitrary memory address read vulnerability with Regex search
* CVE-2024-27281: RCE vulnerability with .rdoc_options in RDoc
* CVE-2024-27280: Buffer overread vulnerability in StringIO
