### PR TITLE
DEV: Bump default base image for launcher to `discourse/base:2.0.20240502-0021`

### DIFF
--- a/launcher
+++ b/launcher
@@ -92,7 +92,7 @@ kernel_min_version='4.4.0'
 config_file=containers/"$config".yml
 cidbootstrap=cids/"$config"_bootstrap.cid
 local_discourse=local_discourse
-image="discourse/base:2.0.20231218-0429"
+image="discourse/base:2.0.20240502-0021"
 docker_path=`which docker.io 2> /dev/null || which docker`
 git_path=`which git`
 


### PR DESCRIPTION
This is necessary to pull in 303b646c3c48fc3179af954433d9fa797e70a3b9
