### PR TITLE
DEV: Run system tests as part of the build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
           cd image && ruby auto_build.rb discourse_test_build${{ steps.arch-helper.outputs.arch_postfix_underscore }}
       - name: run specs
         run: |
-          docker run --rm -e RUBY_ONLY=1 -e USE_TURBO=1 -e SKIP_PLUGINS=1 -e SKIP_LINT=1 discourse/discourse_test:build${{ steps.arch-helper.outputs.arch_postfix_underscore }}
+          docker run --rm -e RUN_SYSTEM_TESTS=1 -e RUBY_ONLY=1 -e USE_TURBO=1 -e SKIP_PLUGINS=1 -e SKIP_LINT=1 discourse/discourse_test:build${{ steps.arch-helper.outputs.arch_postfix_underscore }}
       - name: Print summary
         run: |
           docker images discourse/base


### PR DESCRIPTION
This commit changes the `base` Github workflow to run system specs as
well. This was previously excluded but it is important for us to run
system specs too since dependecies in the base image can cause system
tests to fail.
