### PR TITLE
DEV: Build/release `discourse/base:release-ruby-3.3.1` for testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,6 +104,37 @@ jobs:
         run: |
           docker tag discourse/base:release${{ steps.arch-helper.outputs.arch_postfix_dash }} discourse/base:aarch64
           docker push discourse/base:aarch64
+  ruby_3_3:
+    runs-on: ubuntu-20.04${{ ((github.event_name != 'schedule') && '-8core') || '' }}
+    timeout-minutes: 30
+    needs: base
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+      - name: build slim image
+        run: |
+          cd image && ruby auto_build.rb base_slim --build-arg="RUBY_VERSION=3.3.1"
+      - name: build release image
+        run: |
+          cd image && ruby auto_build.rb base
+      - name: build test_build image
+        run: |
+          cd image && ruby auto_build.rb discourse_test_build
+      - name: run specs
+        run: |
+          docker run --rm -e RUBY_ONLY=1 -e USE_TURBO=1 -e SKIP_PLUGINS=1 -e SKIP_LINT=1 discourse/discourse_test:build
+      - name: Print summary
+        run: |
+          docker images discourse/base
+      - name: push to dockerhub
+        if: success() && (github.ref == 'refs/heads/main')
+        env:
+          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+        run: |
+          docker login --username discoursebuild --password $DOCKERHUB_PASSWORD
+          docker tag discourse/base:build discourse/base:release-ruby-3.3.1
+          docker push discourse/base:release-ruby-3.3.1
   test:
     runs-on: ubuntu-20.04${{ ((github.event_name != 'schedule') && '-8core') || '' }}
     timeout-minutes: 30

--- a/image/auto_build.rb
+++ b/image/auto_build.rb
@@ -58,10 +58,10 @@ def run(command)
   lines
 end
 
-def build(image)
+def build(image, cli_args)
   lines =
     run(
-      "cd #{image[:name]} && docker buildx build . --load --no-cache --tag #{image[:tag]} #{image[:extra_args] ? image[:extra_args] : ""}",
+      "cd #{image[:name]} && docker buildx build . --load --no-cache --tag #{image[:tag]} #{image[:extra_args] ? image[:extra_args] : ""} #{cli_args}",
     )
   if lines[-1] =~ /successfully built/
     raise "Error building the image for #{image[:name]}: #{lines[-1]}"
@@ -76,7 +76,7 @@ def dev_deps()
   run("cp base/install-rust discourse_dev/install-rust")
 end
 
-if ARGV.length != 1
+if ARGV.length == 0
   puts <<~TEXT
     Usage:
     ruby auto_build.rb IMAGE
@@ -96,5 +96,5 @@ else
   puts "Building #{images[image]}"
   dev_deps() if image == :discourse_dev
 
-  build(images[image])
+  build(images[image], ARGV[1..-1].join(" "))
 end

--- a/image/base/slim.Dockerfile
+++ b/image/base/slim.Dockerfile
@@ -5,13 +5,14 @@ ARG DEBIAN_RELEASE=bullseye
 FROM debian:${DEBIAN_RELEASE}-slim
 
 ARG DEBIAN_RELEASE
+ARG RUBY_VERSION=3.2.4
 ENV PG_MAJOR=13 \
     RUBY_ALLOCATOR=/usr/lib/libjemalloc.so \
     RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
     LEFTHOOK=0 \
-    RUBY_VERSION=3.2.4 \
+    RUBY_VERSION=${RUBY_VERSION} \
     DEBIAN_RELEASE=${DEBIAN_RELEASE}
 
 #LABEL maintainer="Sam Saffron \"https://twitter.com/samsaffron\""


### PR DESCRIPTION
This commit adds a `ruby_3_3` job to our Github workflow which releases
a `discourse/base:release-ruby-3.3.1` Docker image to allow us to test
Ruby 3.3.1 before eventually changing to that version as the default.
