### PR TITLE
FEATURE: Bump Ruby to 3.3.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,37 +104,6 @@ jobs:
         run: |
           docker tag discourse/base:release${{ steps.arch-helper.outputs.arch_postfix_dash }} discourse/base:aarch64
           docker push discourse/base:aarch64
-  ruby_3_3:
-    runs-on: ubuntu-20.04${{ ((github.event_name != 'schedule') && '-8core') || '' }}
-    timeout-minutes: 30
-    needs: base
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 1
-      - name: build slim image
-        run: |
-          cd image && ruby auto_build.rb base_slim --build-arg="RUBY_VERSION=3.3.1"
-      - name: build release image
-        run: |
-          cd image && ruby auto_build.rb base
-      - name: build test_build image
-        run: |
-          cd image && ruby auto_build.rb discourse_test_build
-      - name: run specs
-        run: |
-          docker run --rm -e RUBY_ONLY=1 -e USE_TURBO=1 -e SKIP_PLUGINS=1 -e SKIP_LINT=1 discourse/discourse_test:build
-      - name: Print summary
-        run: |
-          docker images discourse/base
-      - name: push to dockerhub
-        if: success() && (github.ref == 'refs/heads/main')
-        env:
-          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
-        run: |
-          docker login --username discoursebuild --password $DOCKERHUB_PASSWORD
-          docker tag discourse/base:build discourse/base:release-ruby-3.3.1
-          docker push discourse/base:release-ruby-3.3.1
   test:
     runs-on: ubuntu-20.04${{ ((github.event_name != 'schedule') && '-8core') || '' }}
     timeout-minutes: 30

--- a/image/base/slim.Dockerfile
+++ b/image/base/slim.Dockerfile
@@ -5,7 +5,7 @@ ARG DEBIAN_RELEASE=bullseye
 FROM debian:${DEBIAN_RELEASE}-slim
 
 ARG DEBIAN_RELEASE
-ARG RUBY_VERSION=3.2.4
+ARG RUBY_VERSION=3.3.1
 ENV PG_MAJOR=13 \
     RUBY_ALLOCATOR=/usr/lib/libjemalloc.so \
     RUSTUP_HOME=/usr/local/rustup \


### PR DESCRIPTION
Bumping Ruby to 3.3.1 to pull in latest performance and memory
improvements made to YJIT. On Discourse hosting services with Ruby 3.3.1 + YJIT, we saw an
estimate 10-20% improvement in time spent executing Ruby code over Ruby
3.2.3 + YJIT.
