### PR TITLE
Revert "FEATURE: Bump base image used by launcher to pull in Ruby 3.3…

### DIFF
--- a/launcher
+++ b/launcher
@@ -92,7 +92,7 @@ kernel_min_version='4.4.0'
 config_file=containers/"$config".yml
 cidbootstrap=cids/"$config"_bootstrap.cid
 local_discourse=local_discourse
-image="discourse/base:2.0.20240520-0116"
+image="discourse/base:2.0.20240502-0021"
 docker_path=`which docker.io 2> /dev/null || which docker`
 git_path=`which git`
 


### PR DESCRIPTION
….1 (#802)"

This reverts commit 01ce8cf8f935bf8aeb3d96a7b124ba33a612c07d.

We are investigating incompatibilities with Discourse stable.