### PR TITLE
DEV: install redis data folder if none exists

### DIFF
--- a/templates/redis.template.yml
+++ b/templates/redis.template.yml
@@ -86,4 +86,8 @@ hooks:
     - replace:
        filename: /etc/service/unicorn/run
        from: "# redis"
-       to: sv start redis || exit 1
+       to: |
+         if [ ! -d /shared/redis_data ]; then
+           install -d -m 0755 -o redis -g redis /shared/redis_data
+         fi
+         sv start redis || exit 1


### PR DESCRIPTION
With new launcher rewrite, there are instances where redis data folder may not exist on boot. Allow the boot script to create it.