### PR TITLE
FEATURE: Bump base image used by launcher to pull in Ruby 3.3.1 take 2

### DIFF
--- a/launcher
+++ b/launcher
@@ -92,7 +92,7 @@ kernel_min_version='4.4.0'
 config_file=containers/"$config".yml
 cidbootstrap=cids/"$config"_bootstrap.cid
 local_discourse=local_discourse
-image="discourse/base:2.0.20240502-0021"
+image="discourse/base:2.0.20240602-0023"
 docker_path=`which docker.io 2> /dev/null || which docker`
 git_path=`which git`
 


### PR DESCRIPTION
First attempt in 01ce8cf8f935bf8aeb3d96a7b124ba33a612c07d was reverted because our new base image was not compatible with the stable branch of discourse/discourse.