### PR TITLE
DEV: Bump Ruby to 3.3.3

### DIFF
--- a/image/base/slim.Dockerfile
+++ b/image/base/slim.Dockerfile
@@ -5,7 +5,7 @@ ARG DEBIAN_RELEASE=bullseye
 FROM debian:${DEBIAN_RELEASE}-slim
 
 ARG DEBIAN_RELEASE
-ARG RUBY_VERSION=3.3.2
+ARG RUBY_VERSION=3.3.3
 ENV PG_MAJOR=13 \
     RUBY_ALLOCATOR=/usr/lib/libjemalloc.so \
     RUSTUP_HOME=/usr/local/rustup \


### PR DESCRIPTION
Pulls in some bugfixes which may or may not be affecting us.

```
* RubyGems 3.5.11
* Bundler 2.5.11
* REXML 3.2.8
* strscan 3.0.9
* --dump=prism_parsetree is replaced by --parser=prism --dump=parsetree
Invalid encoding symbols raise SyntaxError instead of EncodingError
* Memory leak fix in Ripper parsing
* Bugfixes for YJIT, **{}, Ripper.tokenize, RubyVM::InstructionSequence#to_binary, --with-gmp, and some build environments
```