### PR TITLE
DEV: update to use IM7 syntax magick in validation command

### DIFF
--- a/image/base/install-imagemagick
+++ b/image/base/install-imagemagick
@@ -69,4 +69,4 @@ rm -rf $WDIR
 ldconfig /usr/local/lib
 
 # Validate ImageMagick install
-test $(convert -version | grep -o -e png -e tiff -e jpeg -e freetype -e heic -e webp | wc -l) -eq 6
+test $(magick -version | grep -o -e png -e tiff -e jpeg -e freetype -e heic -e webp | wc -l) -eq 6


### PR DESCRIPTION
We've been using IM7 in this file since Jul 2018 (https://github.com/discourse/discourse_docker/commit/97001f25eaad69e60b1283184c59db56ddc5035d), this change updates the use of `convert` to `magick`. When IM7's binary is installed, it creates a symbolic link from `convert` to the `magick` executable anyway.