### PR TITLE
Bump timeout for arm64 scheduled builds to 60 mins.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         arch: [amd64, arm64]
-    timeout-minutes: ${{ (github.event_name != 'schedule' && 30) || ((matrix.arch == 'arm64' && 45) || 30) }}
+    timeout-minutes: ${{ (github.event_name != 'schedule' && 30) || ((matrix.arch == 'arm64' && 60) || 30) }}
     steps:
       - name: Install Docker
         if: ${{ matrix.arch == 'arm64' }}


### PR DESCRIPTION
We are hitting timeouts at 45mins.
