### PR TITLE
DEV: Updated vanilla.template.yml

### DIFF
--- a/templates/import/vanilla.template.yml
+++ b/templates/import/vanilla.template.yml
@@ -8,8 +8,9 @@ hooks:
     - exec:
         cd: /etc/service
         cmd:
-          - rm -R nginx
-          - rm -R cron
+          - echo "" > unicorn/run
+          - echo "" > nginx/run
+          - echo "" > cron/run
 
     - exec:
         cd: /etc/runit/3.d

--- a/templates/import/vanilla.template.yml
+++ b/templates/import/vanilla.template.yml
@@ -102,6 +102,13 @@ hooks:
         cmd:
           - mkdir -p /shared/import/data
           - chown discourse -R /shared/import
+  
+  before_code:
+    - exec:
+        cd: $home
+        cmd: 
+          # Add your discourse core fork and pull custom code 
+          - su discourse -c 'git remote set-url origin https://github.com/{github_username}/discourse.git'
 
   after_bundle_exec:
     - exec:

--- a/templates/import/vanilla.template.yml
+++ b/templates/import/vanilla.template.yml
@@ -110,15 +110,6 @@ hooks:
           - git config --global --add safe.directory /var/www/discourse
           - git remote set-url origin https://github.com/{github_username}/discourse.git
           
-
-  after_code:
-    - exec: 
-        cd: $home
-        cmd: 
-          # Pulls the code from the vanilla branch
-          - git fetch origin vanilla
-          - git reset --hard origin/vanilla
-
   after_bundle_exec:
     - exec:
         cd: $home

--- a/templates/import/vanilla.template.yml
+++ b/templates/import/vanilla.template.yml
@@ -102,20 +102,32 @@ hooks:
           - mkdir -p /shared/import/data
           - chown discourse -R /shared/import
 
+  before_code:
+    - exec:
+        cd: $home
+        cmd: 
+          # Add your discourse core fork and pull custom code 
+          - git config --global --add safe.directory /var/www/discourse
+          - git remote set-url origin https://github.com/{github_username}/discourse.git
+          
+
+  after_code:
+    - exec: 
+        cd: $home
+        cmd: 
+          # Pulls the code from the vanilla branch
+          - git fetch origin vanilla
+          - git reset --hard origin/vanilla
+
   after_bundle_exec:
     - exec:
         cd: $home
         cmd:
-          # Add your discourse core fork and pull custom code
-          - git config --global --add safe.directory /var/www/discourse
-          - git remote add import https://github.com/{github_username}/discourse.git
-          - git fetch import vanilla
-          - git reset --hard import/vanilla
-          # Creates the database from the data to be imported
-          - sh /usr/local/bin/import_vanilla.sh
-          - rake db:migrate
           # Add the gems used in the script
           - echo "gem 'mysql2'" >> Gemfile 
           - echo "gem 'ruby-bbcode-to-md', :github => 'nlalonde/ruby-bbcode-to-md'" >> Gemfile
           - su discourse -c 'bundle config unset deployment'
           - su discourse -c 'bundle install --no-deployment --path vendor/bundle --jobs 4 --without test development'
+          - service mariadb start
+          # imports the DB into mysql
+          - sh /usr/local/bin/import_flarum_test.sh 

--- a/templates/import/vanilla.template.yml
+++ b/templates/import/vanilla.template.yml
@@ -8,7 +8,6 @@ hooks:
     - exec:
         cd: /etc/service
         cmd:
-          - rm -R unicorn
           - rm -R nginx
           - rm -R cron
 
@@ -36,7 +35,7 @@ hooks:
     - exec:
         cmd:
           - mkdir -p /shared/import/mysql/data
-          - apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y nano libmariadbclient-dev mariadb-server
+          - apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y nano libmariadb-dev mariadb-server
           - sed -Ei 's/^log/#&/' /etc/mysql/my.cnf
 
     - file:
@@ -95,10 +94,7 @@ hooks:
             sv stop mysql
           fi
 
-          cd $home
-          echo "The Vanilla import is starting..."
-          echo
-          su discourse -c 'bundle exec ruby script/import_scripts/vanilla.rb'
+          echo "import_vanilla.sh completed"
 
     - exec:
         cd: $home
@@ -110,7 +106,16 @@ hooks:
     - exec:
         cd: $home
         cmd:
-          - echo "gem 'mysql2'" >> Gemfile
+          # Add your discourse core fork and pull custom code
+          - git config --global --add safe.directory /var/www/discourse
+          - git remote add import https://github.com/{github_username}/discourse.git
+          - git fetch import vanilla
+          - git reset --hard import/vanilla
+          # Creates the database from the data to be imported
+          - sh /usr/local/bin/import_vanilla.sh
+          - rake db:migrate
+          # Add the gems used in the script
+          - echo "gem 'mysql2'" >> Gemfile 
           - echo "gem 'ruby-bbcode-to-md', :github => 'nlalonde/ruby-bbcode-to-md'" >> Gemfile
           - su discourse -c 'bundle config unset deployment'
           - su discourse -c 'bundle install --no-deployment --path vendor/bundle --jobs 4 --without test development'

--- a/templates/import/vanilla.template.yml
+++ b/templates/import/vanilla.template.yml
@@ -102,14 +102,6 @@ hooks:
           - mkdir -p /shared/import/data
           - chown discourse -R /shared/import
 
-  before_code:
-    - exec:
-        cd: $home
-        cmd: 
-          # Add your discourse core fork and pull custom code 
-          - git config --global --add safe.directory /var/www/discourse
-          - git remote set-url origin https://github.com/{github_username}/discourse.git
-          
   after_bundle_exec:
     - exec:
         cd: $home

--- a/templates/import/vanilla.template.yml
+++ b/templates/import/vanilla.template.yml
@@ -1,17 +1,13 @@
 # This template installs MariaDB and all dependencies needed for importing from vanilla.
+env:
+  UNICORN_SIDEKIQS: 0
+
 
 params:
   home: /var/www/discourse
 
 hooks:
   after_web_config:
-    - exec:
-        cd: /etc/service
-        cmd:
-          - echo "" > unicorn/run
-          - echo "" > nginx/run
-          - echo "" > cron/run
-
     - exec:
         cd: /etc/runit/3.d
         cmd:


### PR DESCRIPTION
While doing a migrations training following [this meta guide ](https://meta.discourse.org/t/set-up-an-environment-to-migrate-another-forum-to-discourse/88252 ) I found a couple of issues and some things I thought could be improved. 

**Problems and Solutions**

- The usage of `rm -R unicorn` doesn't work anymore as noted [here](https://meta.discourse.org/t/migrate-a-phpbb3-forum-to-discourse/30810/768) due to our migration from Ubuntu to Debian. Because of this, that line of code has been removed which fixed the issue.
- The usage of the old libmariadb package has been updated.
-  The Fetch and reset done to pull custom changes within the Docker instance cause all gems installed in the `vanilla.template.yml` to disappear. Since we reset the gemfile doing so, all installed gems during the import build process get removed (at least from the gemfile) so they don’t work anymore. I updated the `vanilla.template.yml` to execute the fetch and reset before the gems are installed so this doesn't happen anymore. 
- This is not a problem per se but when the `vanila_import.sh` script was run it was also executing the import script. The guide has a step to execute the migration script and recommends the use of `tmux` for longer sessions, but this doesn't allow it. It seemed logical to remove it and allow the user to decide when to execute the migration script
