### PR TITLE
FIX: Use `sharedscripts` in `/etc/logrotate.d/rails`

### DIFF
--- a/templates/web.template.yml
+++ b/templates/web.template.yml
@@ -285,6 +285,7 @@ run:
                 missingok
                 delaycompress
                 compress
+                sharedscripts
                 postrotate
                 sv 1 unicorn
                 endscript


### PR DESCRIPTION
This commit adds `sharedscripts` which will ensure that our `postrotate`
script is only ran once even if multiple log files in the `/shared/log/rails/`
are rotated. If `sharedscripts` is not specified, we are sending `sv 1
unicorn` once per log file rotated and this has resulted in weird
behaviours like our Sidekiq process hanging indefinitely.

Note the following from the manpage for logrotate:

```
sharedscripts
Normally, prerotate and postrotate scripts are run for each log which is rotated and the absolute path to the log file is passed as first argument to the script. That means a single script may be run multiple times for log file entries which match multiple files (such as the /var/log/news/* example). If sharedscripts is specified, the scripts are only run once, no matter how many logs match the wildcarded pattern, and whole pattern is passed to them.
```
