### PR TITLE
Increase `yarn` network-timeout from 30s to 60s

### DIFF
--- a/templates/web.template.yml
+++ b/templates/web.template.yml
@@ -185,6 +185,7 @@ run:
           if [ "$version" != "tests-passed" ]; then
             rm -rf app/assets/javascripts/node_modules
           fi
+        - su discourse -c 'yarn config set network-timeout 60000 -g'
         - su discourse -c 'yarn install --frozen-lockfile && yarn cache clean'
 
   - exec:


### PR DESCRIPTION
A number of people have reported hitting yarn timeouts on low-spec DO droplets, which causes the build to fail. This should provide a little more leeway