### PR TITLE
FIX: Remove `bundle config jobs`

### DIFF
--- a/image/base/release.Dockerfile
+++ b/image/base/release.Dockerfile
@@ -9,8 +9,7 @@ RUN cd /var/www/discourse &&\
     sudo -u discourse bundle config --local deployment true &&\
     sudo -u discourse bundle config --local path ./vendor/bundle &&\
     sudo -u discourse bundle config --local without test development &&\
-    sudo -u discourse bundle config --local jobs $(($(nproc) - 1)) && \
-    sudo -u discourse bundle install &&\
+    sudo -u discourse bundle install --jobs $(($(nproc) - 1)) &&\
     sudo -u discourse yarn install --frozen-lockfile &&\
     sudo -u discourse yarn cache clean &&\
     find /var/www/discourse/vendor/bundle -name tmp -type d -exec rm -rf {} +

--- a/image/discourse_bench/Dockerfile
+++ b/image/discourse_bench/Dockerfile
@@ -13,7 +13,7 @@ RUN git config --global user.email "you@example.com" &&\
     git config --global user.name "Your Name"
 
 RUN git pull &&\
-    sudo -u discourse bundle install --standalone
+    sudo -u discourse bundle install --jobs $(($(nproc) - 1)) --standalone
 
 RUN gem install facter &&\
     gem install mailcatcher

--- a/image/discourse_bench/run_bench.sh
+++ b/image/discourse_bench/run_bench.sh
@@ -10,7 +10,7 @@ redis-server /etc/redis/redis.conf
 git pull
 
 # install needed gems
-sudo -E -u discourse bundle install
+sudo -E -u discourse bundle install --jobs $(($(nproc) - 1))
 
 # start mailcatcher
 mailcatcher --http-ip 0.0.0.0

--- a/image/discourse_dev/postgres_dev.template.yml
+++ b/image/discourse_dev/postgres_dev.template.yml
@@ -47,7 +47,7 @@ run:
   - exec: cd tmp && git clone https://github.com/discourse/discourse.git --depth=1
   - exec: chown -R discourse /tmp/discourse
   - exec: cd /tmp/discourse && sudo -u discourse bundle config --local path ./vendor/bundle
-  - exec: cd /tmp/discourse && sudo -u discourse bundle install
+  - exec: cd /tmp/discourse && sudo -u discourse bundle install --jobs $(($(nproc) - 1))
   - exec: cd /tmp/discourse && sudo -u discourse yarn install
   - exec: cd /tmp/discourse && sudo -u discourse yarn cache clean
   - exec: cd /tmp/discourse && sudo -u discourse bundle exec rake db:migrate

--- a/image/discourse_fast_switch/create_switch.rb
+++ b/image/discourse_fast_switch/create_switch.rb
@@ -1,13 +1,13 @@
-require 'fileutils'
+require "fileutils"
 
-puts "-"*100,"creating switch","-"*100
+puts "-" * 100, "creating switch", "-" * 100
 
 system("cd /var/www/discourse && git pull")
 
-['24', '25'].each do |v|
+%w[24 25].each do |v|
   bin = "/usr/local/bin/use_#{v}"
 
-File.write(bin, <<RUBY
+  File.write(bin, <<RUBY)
 #!/usr/ruby_24/bin/ruby
 
 Dir.glob('/usr/ruby_#{v}/bin/*').each do |file|
@@ -16,9 +16,10 @@ Dir.glob('/usr/ruby_#{v}/bin/*').each do |file|
 end
 
 RUBY
-)
 
   system("chmod +x #{bin}")
   system("use_#{v} && gem update --system && gem install bundler --force")
-  system("use_#{v} && cd /var/www/discourse && sudo -u discourse bundle install --deployment --jobs 4 --without test development")
+  system(
+    "use_#{v} && cd /var/www/discourse && sudo -u discourse bundle install --deployment --jobs $(($(nproc) - 1)) --without test development",
+  )
 end

--- a/image/discourse_test/Dockerfile
+++ b/image/discourse_test/Dockerfile
@@ -29,7 +29,7 @@ RUN /tmp/install-chrome &&\
 FROM with_browsers AS release
 
 RUN cd /var/www/discourse &&\
-    sudo -u discourse bundle install &&\
+    sudo -u discourse bundle install --jobs $(($(nproc) - 1)) &&\
     sudo -E -u discourse -H yarn install &&\
     sudo -u discourse yarn cache clean
 

--- a/templates/import/mbox.template.yml
+++ b/templates/import/mbox.template.yml
@@ -34,4 +34,4 @@ hooks:
           - apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y libsqlite3-dev
           - echo "gem 'sqlite3'" >> Gemfile
           - su discourse -c 'bundle config unset deployment'
-          - su discourse -c 'bundle install --no-deployment --path vendor/bundle --jobs 4 --without test development'
+          - su discourse -c 'bundle install --no-deployment --path vendor/bundle --jobs $(($(nproc) - 1)) --without test development'

--- a/templates/import/mssql-dep.template.yml
+++ b/templates/import/mssql-dep.template.yml
@@ -22,4 +22,4 @@ hooks:
         cmd:
           - echo "gem 'tiny_tds'" >> Gemfile
           - su discourse -c 'bundle config unset deployment'
-          - su discourse -c 'bundle install --no-deployment --path vendor/bundle --jobs 4 --without test development'
+          - su discourse -c 'bundle install --no-deployment --path vendor/bundle --jobs $(($(nproc) - 1)) --without test development'

--- a/templates/import/mysql-dep.template.yml
+++ b/templates/import/mysql-dep.template.yml
@@ -11,4 +11,4 @@ hooks:
           - echo "gem 'mysql2'" >> Gemfile
           - apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y libmariadb-dev
           - su discourse -c 'bundle config unset deployment'
-          - su discourse -c 'bundle install --no-deployment --path vendor/bundle --jobs 4 --without test development'
+          - su discourse -c 'bundle install --no-deployment --path vendor/bundle --jobs $(($(nproc) - 1)) --without test development'

--- a/templates/import/phpbb3.template.yml
+++ b/templates/import/phpbb3.template.yml
@@ -114,4 +114,4 @@ hooks:
           - echo "gem 'mysql2'" >> Gemfile
           - echo "gem 'ruby-bbcode-to-md', :github => 'nlalonde/ruby-bbcode-to-md'" >> Gemfile
           - su discourse -c 'bundle config unset deployment'
-          - su discourse -c 'bundle install --no-deployment --path vendor/bundle --jobs 4 --without test development'
+          - su discourse -c 'bundle install --no-deployment --path vendor/bundle --jobs $(($(nproc) - 1)) --without test development'

--- a/templates/import/vanilla.template.yml
+++ b/templates/import/vanilla.template.yml
@@ -98,12 +98,12 @@ hooks:
         cmd:
           - mkdir -p /shared/import/data
           - chown discourse -R /shared/import
-  
+
   before_code:
     - exec:
         cd: $home
-        cmd: 
-          # Add your discourse core fork and pull custom code 
+        cmd:
+          # Add your discourse core fork and pull custom code
           - su discourse -c 'git remote set-url origin https://github.com/{github_username}/discourse.git'
 
   after_bundle_exec:
@@ -111,10 +111,10 @@ hooks:
         cd: $home
         cmd:
           # Add the gems used in the script
-          - echo "gem 'mysql2'" >> Gemfile 
+          - echo "gem 'mysql2'" >> Gemfile
           - echo "gem 'ruby-bbcode-to-md', :github => 'nlalonde/ruby-bbcode-to-md'" >> Gemfile
           - su discourse -c 'bundle config unset deployment'
-          - su discourse -c 'bundle install --no-deployment --path vendor/bundle --jobs 4 --without test development'
+          - su discourse -c 'bundle install --no-deployment --path vendor/bundle --jobs $(($(nproc) - 1)) --without test development'
           - service mariadb start
           # imports the DB into mysql
-          - sh /usr/local/bin/import_flarum_test.sh 
+          - sh /usr/local/bin/import_flarum_test.sh

--- a/templates/web.template.yml
+++ b/templates/web.template.yml
@@ -192,7 +192,7 @@ run:
       cd: $home
       hook: bundle_exec
       cmd:
-        - su discourse -c 'bundle install --retry 3'
+        - su discourse -c 'bundle install --jobs $(($(nproc) - 1)) --retry 3'
 
   - exec:
       cd: $home


### PR DESCRIPTION
This fixes a regression introduced in
bbefa1e5f387bcad0fac79fea00b39f15f6dee4e. Basically, we cannot configure
the default bundle jobs when building the image because the number of
cores used to build the image can be different from the number of cores
on the machine running the image.
