### PR TITLE
Build `discourse/base` and `discourse/discourse_test` image for bookworm

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,6 +104,51 @@ jobs:
         run: |
           docker tag discourse/base:release${{ steps.arch-helper.outputs.arch_postfix_dash }} discourse/base:aarch64
           docker push discourse/base:aarch64
+  base_bookworm:
+    runs-on: ubuntu-20.04${{ ((github.event_name != 'schedule') && '-8core') || '' }}
+    timeout-minutes: ${{ github.event_name != 'schedule' && 30 }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+      - name: build slim image
+        run: |
+          cd image && ruby auto_build.rb base_slim_bookworm
+      - name: tag slim images
+        id: tag-images
+        run: |
+          TAG=`date +%Y%m%d-%H%M`
+          echo "tag=$(echo $TAG)" >> $GITHUB_OUTPUT
+          docker tag discourse/base:build_slim_bookworm discourse/base:2.0.$TAG-slim-bookworm
+          docker tag discourse/base:build_slim_bookworm discourse/base:slim-bookworm
+      - name: build release image
+        run: |
+          cd image && ruby auto_build.rb base_bookworm
+      - name: tag release images
+        run: |
+          TAG=${{ steps.tag-images.outputs.tag }}
+          docker tag discourse/base:build_bookworm discourse/base:2.0.$TAG-bookworm
+          docker tag discourse/base:build_bookworm discourse/base:release-bookworm
+      - name: build test_build image
+        run: |
+          cd image && ruby auto_build.rb discourse_test_build_bookworm
+      - name: run specs
+        run: |
+          docker run --rm -e RUBY_ONLY=1 -e USE_TURBO=1 -e SKIP_PLUGINS=1 -e SKIP_LINT=1 discourse/discourse_test:build_bookworm
+      - name: Print summary
+        run: |
+          docker images discourse/base
+      - name: push to dockerhub
+        if: success() && (github.ref == 'refs/heads/main')
+        env:
+          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+        run: |
+          TAG=${{ steps.tag-images.outputs.tag }}
+          docker login --username discoursebuild --password $DOCKERHUB_PASSWORD
+          docker push discourse/base:2.0.$TAG-slim-bookworm
+          docker push discourse/base:slim-bookworm
+          docker push discourse/base:2.0.$TAG-bookworm
+          docker push discourse/base:release-bookworm
   test:
     runs-on: ubuntu-20.04${{ ((github.event_name != 'schedule') && '-8core') || '' }}
     timeout-minutes: 30
@@ -145,6 +190,47 @@ jobs:
           docker push discourse/discourse_test:slim
           docker push discourse/discourse_test:slim-browsers
           docker push discourse/discourse_test:release
+  test_bookworm:
+    runs-on: ubuntu-20.04${{ ((github.event_name != 'schedule') && '-8core') || '' }}
+    timeout-minutes: 30
+    needs: base_bookworm
+    defaults:
+      run:
+        working-directory: image/discourse_test
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+      - name: build discourse_test:slim-bookworm
+        run: |
+          docker buildx build . --load \
+            --build-arg from_tag=slim-bookworm \
+            --target base \
+            --tag discourse/discourse_test:slim-bookworm
+      - name: build discourse_test:slim-browsers-bookworm
+        run: |
+          docker buildx build . --load \
+            --build-arg from_tag=slim-bookworm \
+            --target with_browsers \
+            --tag discourse/discourse_test:slim-browsers-bookworm
+      - name: build discourse_test:release-bookworm
+        run: |
+          docker buildx build . --load \
+            --build-arg from_tag=release-bookworm \
+            --target release \
+            --tag discourse/discourse_test:release-bookworm
+      - name: Print summary
+        run: |
+          docker images discourse/discourse_test
+      - name: push to dockerhub
+        if: success() && (github.ref == 'refs/heads/main')
+        env:
+          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+        run: |
+          docker login --username discoursebuild --password $DOCKERHUB_PASSWORD
+          docker push discourse/discourse_test:slim-bookworm
+          docker push discourse/discourse_test:slim-browsers-bookworm
+          docker push discourse/discourse_test:release-bookworm
   dev:
     runs-on: ubuntu-20.04${{ ((github.event_name != 'schedule') && '-8core') || '' }}
     timeout-minutes: 30

--- a/image/auto_build.rb
+++ b/image/auto_build.rb
@@ -9,6 +9,11 @@ images = {
     tag: "discourse/base:build_slim",
     extra_args: "-f slim.Dockerfile",
   },
+  base_slim_bookworm: {
+    name: "base",
+    tag: "discourse/base:build_slim_bookworm",
+    extra_args: "-f slim.Dockerfile --build-arg=\"DEBIAN_RELEASE=bookworm\"",
+  },
   base_slim_arm64: {
     name: "base",
     tag: "discourse/base:build_slim_arm64",
@@ -19,6 +24,11 @@ images = {
     tag: "discourse/base:build",
     extra_args: "-f release.Dockerfile",
   },
+  base_bookworm: {
+    name: "base",
+    tag: "discourse/base:build_bookworm",
+    extra_args: "-f release.Dockerfile --build-arg=\"tag=build_slim_bookworm\"",
+  },
   base_arm64: {
     name: "base",
     tag: "discourse/base:build_arm64",
@@ -27,6 +37,11 @@ images = {
   discourse_test_build: {
     name: "discourse_test",
     tag: "discourse/discourse_test:build",
+  },
+  discourse_test_build_bookworm: {
+    name: "discourse_test",
+    tag: "discourse/discourse_test:build_bookworm",
+    extra_args: "--build-arg=\"from_tag=build_bookworm\"",
   },
   discourse_test_build_arm64: {
     name: "discourse_test",

--- a/image/base/install-imagemagick
+++ b/image/base/install-imagemagick
@@ -9,7 +9,7 @@ IMAGE_MAGICK_HASH="d282117bc6d0e91ad1ad685d096623b96ed8e229f911c891d83277b350ef8
 LIBJPEGTURBO=$(cat /etc/issue | grep -qi Debian && echo 'libjpeg62-turbo libjpeg62-turbo-dev' || echo 'libjpeg-turbo8 libjpeg-turbo8-dev')
 
 # Ubuntu 22.04/22.10  doesn't have libwebp6
-LIBWEBP=$(cat /etc/issue | grep -qi 'Ubuntu 22' && echo 'libwebp7' || echo 'libwebp6')
+LIBWEBP=$(cat /etc/issue | grep -qiE 'Debian GNU/Linux 12|Ubuntu 22' && echo 'libwebp7' || echo 'libwebp6')
 
 PREFIX=/usr/local
 WDIR=/tmp/imagemagick
@@ -17,17 +17,17 @@ WDIR=/tmp/imagemagick
 # Install build deps
 apt -y -q remove imagemagick
 apt -y -q install git make gcc pkg-config autoconf curl g++ yasm cmake \
-    libde265-0 libde265-dev ${LIBJPEGTURBO} x265 libx265-dev libtool \
-    libpng16-16 libpng-dev ${LIBJPEGTURBO} ${LIBWEBP} libwebp-dev libgomp1 \
+    libde265-0 libde265-dev ${LIBJPEGTURBO} ${LIBWEBP} x265 libx265-dev libtool \
+    libpng16-16 libpng-dev libwebp-dev libgomp1 \
     libwebpmux3 libwebpdemux2 ghostscript libxml2-dev libxml2-utils librsvg2-dev \
-    libltdl7-dev libbz2-dev gsfonts libtiff-dev libfreetype6-dev libjpeg-dev
+    libltdl7-dev libbz2-dev gsfonts libtiff-dev libfreetype6-dev libjpeg-dev libheif1 libheif-dev
 
-# Ubuntu doesn't like `bullseye-backports`
-if cat /etc/issue | grep -qi 'Ubuntu 22'; then
-  apt -y install libheif1 libaom-dev libheif-dev
+# Ubuntu doesn't like backports
+if cat /etc/issue | grep -qiE 'Debian GNU/Linux 12|Ubuntu 22'; then
+  apt -y install libaom-dev
 else
   # Use backports instead of compiling it
-  apt -y -q install -t bullseye-backports libheif1 libaom-dev libheif-dev
+  apt -y -q install -t bullseye-backports libaom-dev
 fi
 
 mkdir -p $WDIR

--- a/image/base/slim.Dockerfile
+++ b/image/base/slim.Dockerfile
@@ -19,7 +19,7 @@ ENV PG_MAJOR=13 \
 
 RUN echo 2.0.`date +%Y%m%d` > /VERSION
 
-RUN echo 'deb http://deb.debian.org/debian bullseye-backports main' > /etc/apt/sources.list.d/bullseye-backports.list
+RUN echo "deb http://deb.debian.org/debian ${DEBIAN_RELEASE}-backports main" > "/etc/apt/sources.list.d/${DEBIAN_RELEASE}-backports.list"
 RUN echo "debconf debconf/frontend select Teletype" | debconf-set-selections
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install gnupg sudo curl fping
 RUN sh -c "fping proxy && echo 'Acquire { Retries \"0\"; HTTP { Proxy \"http://proxy:3128\";}; };' > /etc/apt/apt.conf.d/40proxy && apt-get update || true"
@@ -31,9 +31,10 @@ ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8
 
-RUN curl https://apt.postgresql.org/pub/repos/apt/ACCC4CF8.asc | apt-key add -
-RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main" | \
-    tee /etc/apt/sources.list.d/postgres.list
+RUN install -d /usr/share/postgresql-common/pgdg &&\
+    curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc &&\
+    echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt ${DEBIAN_RELEASE}-pgdg main" > /etc/apt/sources.list.d/pgdg.list
+
 RUN curl --silent --location https://deb.nodesource.com/setup_18.x | sudo bash -
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list


### PR DESCRIPTION
We need to upgrade to bookworm because bullseye is EOL. This commit when merged into branch will push the following images to Docker hub:

1. `discourse/base:slim-bookworm`
2. `discourse/base:release-bookworm`
3. `discourse/discourse_test:slim-bookworm`
4. `discourse/discourse_test:slim-browsers-bookworm`
5. `discourse/discourse_test:release-bookworm`
