### PR TITLE
DEV: allow multiple configure runs

### DIFF
--- a/templates/postgres.15.template.yml
+++ b/templates/postgres.15.template.yml
@@ -220,7 +220,12 @@ run:
 
   - exec:
       tag: db
-      cmd: "[ -f /root/install_postgres ] && /root/install_postgres && rm -f /root/install_postgres"
+      cmd: |
+        if [ -f /root/install_postgres ]; then
+          /root/install_postgres && rm -f /root/install_postgres
+        elif [ -e /shared/postgres_run/.s.PGSQL.5432 ]; then
+          socat /dev/null UNIX-CONNECT:/shared/postgres_run/.s.PGSQL.5432 || exit 0 && echo postgres already running stop container ; exit 1
+        fi
 
   - exec:
       tag: db

--- a/templates/postgres.template.yml
+++ b/templates/postgres.template.yml
@@ -208,7 +208,12 @@ run:
 
   - exec:
       tag: db
-      cmd: "[ -f /root/install_postgres ] && /root/install_postgres && rm -f /root/install_postgres"
+      cmd: |
+        if [ -f /root/install_postgres ]; then
+          /root/install_postgres && rm -f /root/install_postgres
+        elif [ -e /shared/postgres_run/.s.PGSQL.5432 ]; then
+          socat /dev/null UNIX-CONNECT:/shared/postgres_run/.s.PGSQL.5432 || exit 0 && echo postgres already running stop container ; exit 1
+        fi
 
   - exec:
       tag: db


### PR DESCRIPTION
(launcher2 related improvement)

when we have already run an initial setup, fall back to just checking for socket, rather than outright failing if the init script has already been run.

This allows 'configure' steps to be re-run in standalone cases.

eg: `launcher2 configure app && launcher2 configure app`

current version: fails as it's missing the install_postgres file
with PR: checks for psql socket, and builds.

doing something like `launcher2 start app && launcher2 configure app` would also print out a more correct error message, "postgres already running stop container"