### PR TITLE
DEV: Simplify discourse_dev postgres setup

### DIFF
--- a/image/discourse_dev/postgres_dev.template.yml
+++ b/image/discourse_dev/postgres_dev.template.yml
@@ -23,36 +23,4 @@ run:
   # give db a few secs to start up
   - exec: "sleep 5"
 
-  - exec: su postgres -c 'createdb discourse_development' || true
-  - exec: su postgres -c 'psql discourse_development -c "grant all privileges on database discourse_development to discourse;"' || true
-  - exec: su postgres -c 'psql discourse_development -c "alter schema public owner to discourse;"'
-  - exec: su postgres -c 'psql discourse_development -c "create extension if not exists hstore;"'
-  - exec: su postgres -c 'psql discourse_development -c "create extension if not exists pg_trgm;"'
-  - exec: su postgres -c 'psql discourse_development -c "create extension if not exists vector;"'
-  - exec: su postgres -c 'psql discourse_development -c "alter extension vector update;"' || true
-
-  - exec: su postgres -c 'createdb discourse_test' || true
-  - exec: su postgres -c 'psql discourse_test -c "grant all privileges on database discourse_test to discourse;"' || true
-  - exec: su postgres -c 'psql discourse_test -c "alter schema public owner to discourse;"'
-  - exec: su postgres -c 'psql discourse_test -c "create extension if not exists hstore;"'
-  - exec: su postgres -c 'psql discourse_test -c "create extension if not exists pg_trgm;"'
-  - exec: su postgres -c 'psql discourse_test -c "create extension if not exists vector;"'
-  - exec: su postgres -c 'psql discourse_test -c "alter extension vector update;"' || true
-
-  - exec: su postgres -c 'createdb discourse_test_multisite' || true
-  - exec: su postgres -c 'psql discourse_test_multisite -c "grant all privileges on database discourse_test_multisite to discourse;"' || true
-  - exec: su postgres -c 'psql discourse_test_multisite -c "alter schema public owner to discourse;"'
-  - exec: su postgres -c 'psql discourse_test_multisite -c "create extension if not exists hstore;"'
-  - exec: su postgres -c 'psql discourse_test_multisite -c "create extension if not exists pg_trgm;"'
-  - exec: su postgres -c 'psql discourse_test_multisite -c "create extension if not exists vector;"'
-  - exec: su postgres -c 'psql discourse_test_multisite -c "alter extension vector update;"' || true
-
-  - exec: cd tmp && git clone https://github.com/discourse/discourse.git --depth=1
-  - exec: chown -R discourse /tmp/discourse
-  - exec: cd /tmp/discourse && sudo -u discourse bundle config --local path ./vendor/bundle
-  - exec: cd /tmp/discourse && sudo -u discourse bundle install --jobs $(($(nproc) - 1))
-  - exec: cd /tmp/discourse && sudo -u discourse yarn install
-  - exec: cd /tmp/discourse && sudo -u discourse yarn cache clean
-  - exec: cd /tmp/discourse && sudo -u discourse bundle exec rake db:migrate
-  - exec: cd /tmp/discourse && sudo -u discourse RAILS_ENV=test bundle exec rake db:migrate
-  - exec: rm -fr /tmp/discourse
+  - exec: su postgres -c 'psql -c "ALTER USER discourse WITH SUPERUSER;"'


### PR DESCRIPTION
- Remove manual database creation, and instead promote discourse user to postgres SUPERUSER. This means that `db:drop` and `db:create` commands can be run in the dev image, just like in other local development environments. As well as simplifying things, it fixes turbo_rspec, which was previously impossible in the docker dev environment (because `discourse` didn't have permissions to create the parallel databases)

- Stop pre-migrating test database in dev image. It adds additional build time & image size, and doesn't actually help because core's `bin/docker/boot_dev` script overwrites the container's postgres directory with a volume mount