### PR TITLE
dev: add user-installed gems to PATH

### DIFF
--- a/image/discourse_dev/Dockerfile
+++ b/image/discourse_dev/Dockerfile
@@ -12,6 +12,9 @@ ADD sudoers.discourse /etc/sudoers.d/discourse
 
 RUN sudo -u discourse bundle config set --global path /home/discourse/.bundle/gems
 
+# Add user-install ruby gems to PATH
+RUN echo 'PATH="$(ruby -r rubygems -e "puts Gem.user_dir")/bin:$PATH"' >>/home/discourse/.profile
+
 # get redis going
 ADD redis.template.yml /pups/redis.yml
 RUN /pups/bin/pups /pups/redis.yml

--- a/image/discourse_dev/Dockerfile
+++ b/image/discourse_dev/Dockerfile
@@ -13,7 +13,7 @@ ADD sudoers.discourse /etc/sudoers.d/discourse
 RUN sudo -u discourse bundle config set --global path /home/discourse/.bundle/gems
 
 # Add user-install ruby gems to PATH
-RUN echo 'PATH="$(ruby -r rubygems -e "puts Gem.user_dir")/bin:$PATH"' >>/home/discourse/.profile
+RUN echo 'PATH="$(ruby -r rubygems -e "puts Gem.user_dir")/bin:$PATH"' >> /home/discourse/.profile
 
 # get redis going
 ADD redis.template.yml /pups/redis.yml


### PR DESCRIPTION
This is important for usability of things like discourse_theme, and editor tooling (e.g. ruby-lsp)