### PR TITLE
Use flaky-test-retry system

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ concurrency:
 
 env:
   BUILDKIT_PROGRESS: plain
+  DISCOURSE_TURBO_RSPEC_RETRY_AND_LOG_FLAKY_TESTS: true
 
 jobs:
   base:


### PR DESCRIPTION
We use this on the main core repository, so it makes sense to use it here as well. It should reduce the overall flakiness of the discourse_docker build.