### PR TITLE
Base image in launcher

### DIFF
--- a/launcher
+++ b/launcher
@@ -92,7 +92,7 @@ kernel_min_version='4.4.0'
 config_file=containers/"$config".yml
 cidbootstrap=cids/"$config"_bootstrap.cid
 local_discourse=local_discourse
-image="discourse/base:2.0.20240708-0023"
+image="discourse/base:2.0.20240825-0027"
 docker_path=`which docker.io 2> /dev/null || which docker`
 git_path=`which git`
 


### PR DESCRIPTION
This pulls in the [Nginx 1.26.1 update](https://github.com/discourse/discourse_docker/commit/6f8c17dbf4def3c991626b51eb9e33ccd92b2296), [Ruby 3.3.4 update](https://github.com/discourse/discourse_docker/commit/84644fcbea88a3c54a59dfab5f54a4b2ee5719f5) and [Debian
bookworm update](https://github.com/discourse/discourse_docker/commit/4c58e2b75bb341f362ff0d4d29af350b785cdee0).
