### PR TITLE
Increase timeout for scheduled build job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       matrix:
         arch: [amd64, arm64]
-    timeout-minutes: ${{ (github.event_name == 'schedule' && 60) || ((matrix.arch == 'arm64' && 45) || 30) }}
+    timeout-minutes: ${{ (github.event_name == 'schedule' && 90) || ((matrix.arch == 'arm64' && 45) || 30) }}
     needs: timestamp
     env:
       ARCH: ${{matrix.arch}}


### PR DESCRIPTION
Now that base & dev images are built in the same job, we need a little more time