### PR TITLE
Drop macOS tests for launcher_go

### DIFF
--- a/.github/workflows/launcher_go.yml
+++ b/.github/workflows/launcher_go.yml
@@ -31,12 +31,10 @@ jobs:
           fi
 
   test:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     strategy:
       fail-fast: true
-      matrix:
-        os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5


### PR DESCRIPTION
The runners cost 10 times more and there are no macOS specific tests
which we are running.
