### PR TITLE
Remove use of `discourse/base:aarch64` in launcher2

### DIFF
--- a/launcher_go/v2/config/config.go
+++ b/launcher_go/v2/config/config.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"regexp"
-	"runtime"
 	"slices"
 	"strings"
 
@@ -16,13 +15,7 @@ import (
 )
 
 const defaultBootCommand = "/sbin/boot"
-
-func DefaultBaseImage() string {
-	if runtime.GOARCH == "arm64" {
-		return "discourse/base:aarch64"
-	}
-	return "discourse/base:2.0.20231121-0024"
-}
+const defaultBaseImage = "discourse/base:2.0.20231121-0024"
 
 type Config struct {
 	Name            string `yaml:-`
@@ -76,7 +69,7 @@ func LoadConfig(dir string, configName string, includeTemplates bool, templatesD
 	config := &Config{
 		Name:         configName,
 		Boot_Command: defaultBootCommand,
-		Base_Image:   DefaultBaseImage(),
+		Base_Image:   defaultBaseImage,
 	}
 
 	matched, _ := regexp.MatchString("[[:upper:]/ !@#$%^&*()+~`=]", configName)


### PR DESCRIPTION
Since fc61b8a850e0a7f8c1ef0852a13d735121b4d862, we started shipping
manifests for the `discourse/base` images so we don't have to
specifically pull the tag for arm64.
