### PR TITLE
FEATURE: add autocomplete

### DIFF
--- a/launcher_go/v2/utils/find_config.go
+++ b/launcher_go/v2/utils/find_config.go
@@ -1,0 +1,51 @@
+package utils
+
+import (
+	"bytes"
+	"flag"
+	"io/ioutil"
+	"os"
+	"strings"
+)
+
+// Find config names for autocomplete, given the current --conf-dir argument.
+func FindConfigNames() []string {
+	compLine := os.Getenv("COMP_LINE")
+	flagLine := []string{}
+	found := false
+	// the flag package wants a valid flag first
+	// drop all COMP_LINE args until we find something that starts with --conf-dir
+	for _, s := range strings.Fields(compLine) {
+		if found {
+			flagLine = append(flagLine, s)
+		}
+		if strings.HasPrefix(s, "--conf-dir") {
+			flagLine = append(flagLine, s)
+			found = true
+		}
+	}
+	flags := flag.NewFlagSet("f", flag.ContinueOnError)
+	//squelch helptext
+	flags.SetOutput(&bytes.Buffer{})
+	confDirArg := flags.String("conf-dir", "./containers", "conf dir")
+	flags.Parse(flagLine)
+
+	// search in the current conf dir for any files
+	confDir := strings.TrimRight(*confDirArg, "/") + "/"
+	confFiles := []string{}
+	files, err := ioutil.ReadDir(confDir)
+	if err == nil {
+		for _, file := range files {
+			if !file.IsDir() {
+				if strings.HasSuffix(file.Name(), ".yml") {
+					confName, _ := strings.CutSuffix(file.Name(), ".yml")
+					confFiles = append(confFiles, confName)
+				} else if strings.HasSuffix(file.Name(), ".yaml") {
+					confName, _ := strings.CutSuffix(file.Name(), ".yaml")
+					confFiles = append(confFiles, confName)
+				}
+			}
+		}
+	}
+	return confFiles
+}

--- a/launcher_go/v2/utils/find_config_test.go
+++ b/launcher_go/v2/utils/find_config_test.go
@@ -1,0 +1,39 @@
+package utils_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/discourse/discourse_docker/launcher_go/v2/utils"
+	"os"
+)
+
+var _ = Describe("FindConfig", func() {
+
+	It("Parses and returns yml or yaml files", func() {
+		os.Setenv("COMP_LINE", "launcher2 build --conf-dir ../test/containers")
+		Expect(utils.FindConfigNames()).To(ContainElements("test", "test2"))
+	})
+
+	It("Parses and returns yml or yaml files with trailing slash", func() {
+		os.Setenv("COMP_LINE", "launcher2 build --conf-dir ../test/containers/")
+		Expect(utils.FindConfigNames()).To(ContainElements("test", "test2"))
+	})
+
+	It("Parses and returns yml or yaml files on equals", func() {
+		os.Setenv("COMP_LINE", "launcher2 --conf-dir=../test/containers other args")
+		Expect(utils.FindConfigNames()).To(ContainElements("test", "test2"))
+	})
+
+	It("doesn't error when dir does not exist when set", func() {
+		os.Setenv("COMP_LINE", "launcher2 --conf-dir=./does-not-exist")
+		Expect(utils.FindConfigNames()).To(BeEmpty())
+	})
+
+	It("doesn't error when dir does not exist", func() {
+		//by default it look is in ./containers directory, which does not exist
+		// in this directory
+		os.Setenv("COMP_LINE", "launcher2")
+		Expect(utils.FindConfigNames()).To(BeEmpty())
+	})
+})


### PR DESCRIPTION
Add autocomplete features via `install-completions` command (aliased to `sh`) using https://github.com/WillAbides/kongplete to add complete compatibility with the kong CLI parser.