### PR TITLE
FEATURE: add generate docker compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ image/discourse_dev/postgres.template.yml
 image/discourse_dev/redis.template.yml
 .gc-state/*
 .vagrant/
+tmp/*

--- a/launcher_go/v2/cli_build.go
+++ b/launcher_go/v2/cli_build.go
@@ -142,7 +142,10 @@ type CleanCmd struct {
 
 func (r *CleanCmd) Run(cli *Cli) error {
 	dir := cli.BuildDir + "/" + r.Config
+	os.Remove(dir + "/docker-compose.yaml")
 	os.Remove(dir + "/config.yaml")
+	os.Remove(dir + "/.envrc")
+	os.Remove(dir + "/" + "Dockerfile")
 	if err := os.Remove(dir); err != nil {
 		return err
 	}

--- a/launcher_go/v2/cli_generate.go
+++ b/launcher_go/v2/cli_generate.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"github.com/discourse/discourse_docker/launcher_go/v2/config"
+	"os"
+)
+
+/*
+ * raw-yaml
+ * compose
+ * args (args, run-image, boot-command, hostname)
+ */
+
+type CliGenerate struct {
+	DockerCompose DockerComposeCmd `cmd:"" name:"compose" help:"Create docker compose setup in the output {output-directory}/{config}/. The builder generates a docker-compose.yaml, Dockerfile, config.yaml, and an env file for you to source .envrc. Run with 'source .envrc; docker compose up'."`
+}
+
+type DockerComposeCmd struct {
+	OutputDir string `name:"output dir" default:"./compose" short:"o" help:"Output dir for docker compose files." predictor:"dir"`
+	BakeEnv   bool   `short:"e" help:"Bake in the configured environment to image after build."`
+
+	Config string `arg:"" name:"config" help:"config" predictor:"config"`
+}
+
+func (r *DockerComposeCmd) Run(cli *Cli, ctx *context.Context) error {
+	config, err := config.LoadConfig(cli.ConfDir, r.Config, true, cli.TemplatesDir)
+	if err != nil {
+		return errors.New("YAML syntax error. Please check your containers/*.yml config files.")
+	}
+	dir := r.OutputDir + "/" + r.Config
+	if err := os.MkdirAll(dir, 0755); err != nil && !os.IsExist(err) {
+		return err
+	}
+	if err := config.WriteDockerCompose(dir, r.BakeEnv); err != nil {
+		return err
+	}
+	return nil
+}

--- a/launcher_go/v2/cli_generate_test.go
+++ b/launcher_go/v2/cli_generate_test.go
@@ -1,0 +1,57 @@
+package main_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"bytes"
+	"context"
+	ddocker "github.com/discourse/discourse_docker/launcher_go/v2"
+	"github.com/discourse/discourse_docker/launcher_go/v2/utils"
+	"os"
+)
+
+var _ = Describe("Generate", func() {
+	var testDir string
+	var out *bytes.Buffer
+	var cli *ddocker.Cli
+	var ctx context.Context
+
+	BeforeEach(func() {
+		utils.DockerPath = "docker"
+		out = &bytes.Buffer{}
+		utils.Out = out
+		testDir, _ = os.MkdirTemp("", "ddocker-test")
+
+		ctx = context.Background()
+
+		cli = &ddocker.Cli{
+			ConfDir:      "./test/containers",
+			TemplatesDir: "./test",
+			BuildDir:     testDir,
+		}
+	})
+	AfterEach(func() {
+		os.RemoveAll(testDir)
+	})
+
+	It("should output docker compose cmd to config name's subdir", func() {
+		runner := ddocker.DockerComposeCmd{Config: "test",
+			OutputDir: testDir}
+		err := runner.Run(cli, &ctx)
+		Expect(err).To(BeNil())
+		out, err := os.ReadFile(testDir + "/test/config.yaml")
+		Expect(err).To(BeNil())
+		Expect(string(out[:])).To(ContainSubstring("DISCOURSE_DEVELOPER_EMAILS: 'me@example.com,you@example.com'"))
+	})
+
+	It("should force create output parent folders", func() {
+		runner := ddocker.DockerComposeCmd{Config: "test",
+			OutputDir: testDir + "/subfolder/sub-subfolder"}
+		err := runner.Run(cli, &ctx)
+		Expect(err).To(BeNil())
+		out, err := os.ReadFile(testDir + "/subfolder/sub-subfolder/test/config.yaml")
+		Expect(err).To(BeNil())
+		Expect(string(out[:])).To(ContainSubstring("DISCOURSE_DEVELOPER_EMAILS: 'me@example.com,you@example.com'"))
+	})
+})

--- a/launcher_go/v2/config/config_test.go
+++ b/launcher_go/v2/config/config_test.go
@@ -44,6 +44,42 @@ var _ = Describe("Config", func() {
 		Expect(dockerfile).To(ContainSubstring("EXPOSE 80"))
 	})
 
+	It("can write env file", func() {
+		conf.WriteEnvConfig(testDir)
+		out, err := os.ReadFile(testDir + "/.envrc")
+		Expect(err).To(BeNil())
+		Expect(string(out[:])).To(ContainSubstring("export DISCOURSE_HOSTNAME"))
+	})
+
+	It("can write a dockerfile", func() {
+		conf.WriteDockerfile(testDir, "", false)
+		out, err := os.ReadFile(testDir + "/config.yaml")
+		Expect(err).To(BeNil())
+		Expect(string(out[:])).To(ContainSubstring("DISCOURSE_DEVELOPER_EMAILS: 'me@example.com,you@example.com'"))
+		out, err = os.ReadFile(testDir + "/Dockerfile")
+		Expect(err).To(BeNil())
+		Expect(string(out[:])).To(ContainSubstring("RUN cat /temp-config.yaml"))
+		Expect(string(out[:])).To(ContainSubstring("EXPOSE 80"))
+	})
+
+	It("can write a docker compose setup", func() {
+		conf.WriteDockerCompose(testDir, false)
+		out, err := os.ReadFile(testDir + "/.envrc")
+		Expect(err).To(BeNil())
+		Expect(string(out[:])).To(ContainSubstring("export DISCOURSE_HOSTNAME"))
+		out, err = os.ReadFile(testDir + "/config.yaml")
+		Expect(err).To(BeNil())
+		Expect(string(out[:])).To(ContainSubstring("DISCOURSE_DEVELOPER_EMAILS: 'me@example.com,you@example.com'"))
+		out, err = os.ReadFile(testDir + "/Dockerfile")
+		Expect(err).To(BeNil())
+		Expect(string(out[:])).To(ContainSubstring("RUN cat /temp-config.yaml"))
+
+		out, err = os.ReadFile(testDir + "/docker-compose.yaml")
+		Expect(err).To(BeNil())
+		Expect(string(out[:])).To(ContainSubstring("build:"))
+		Expect(string(out[:])).To(ContainSubstring("image: local_discourse/test"))
+	})
+
 	Context("hostname tests", func() {
 		It("replaces hostname", func() {
 			config := config.Config{Env: map[string]string{"DOCKER_USE_HOSTNAME": "true", "DISCOURSE_HOSTNAME": "asdfASDF"}}

--- a/launcher_go/v2/main.go
+++ b/launcher_go/v2/main.go
@@ -18,6 +18,7 @@ type Cli struct {
 	ConfDir      string             `default:"./containers" hidden:"" help:"Discourse pups config directory." predictor:"dir"`
 	TemplatesDir string             `default:"." hidden:"" help:"Home project directory containing a templates/ directory which in turn contains pups yaml templates." predictor:"dir"`
 	BuildDir     string             `default:"./tmp" hidden:"" help:"Temporary build folder for building images." predictor:"dir"`
+	CliGenerate  CliGenerate        `cmd:"" name:"generate" help:"Generate commands, used to generate Discourse pups, and other Discourse configuration for external tools."`
 	BuildCmd     DockerBuildCmd     `cmd:"" name:"build" help:"Build a base image. This command does not need a running database. Saves resulting container."`
 	ConfigureCmd DockerConfigureCmd `cmd:"" name:"configure" help:"Configure and save an image with all dependencies and environment baked in. Updates themes and precompiles all assets. Saves resulting container."`
 	MigrateCmd   DockerMigrateCmd   `cmd:"" name:"migrate" help:"Run migration tasks for a site. Running container is temporary and is not saved."`


### PR DESCRIPTION
Adds the ability to generate a docker-compose setup from a discourse pups config.

This is an optional feature, and not required for launcher2's runtime lifecycle. If it's deemed launcher shouldn't be responsible for this, I can probably figure out a good way to do this outside the project separately.