### PR TITLE
DEV: Bump minimal Docker version to 24.0.7

### DIFF
--- a/launcher
+++ b/launcher
@@ -83,8 +83,8 @@ fi
 cd "$(dirname "$0")"
 
 pups_version='v1.0.3'
-docker_min_version='17.03.1'
-docker_rec_version='17.06.2'
+docker_min_version='24.0.7'
+docker_rec_version='24.0.7'
 git_min_version='1.8.0'
 git_rec_version='1.8.0'
 kernel_min_version='4.4.0'


### PR DESCRIPTION
When running the newer Debian bookworm based images, we are seeing
`(ThreadError) can't create Thread: Operation not permitted` errors when
trying to spawn a thread in Ruby.

A similar issue was reported in https://github.com/docker-library/ruby/issues/429#issuecomment-1708908819
and the fix here is to upgrade Docker. Either way, we should probably
update because Docker 17 has been EOF for many many years.
