### PR TITLE
Reduce min docker version to 20.10.0

### DIFF
--- a/launcher
+++ b/launcher
@@ -83,7 +83,7 @@ fi
 cd "$(dirname "$0")"
 
 pups_version='v1.0.3'
-docker_min_version='24.0.7'
+docker_min_version='20.10.0'
 docker_rec_version='24.0.7'
 git_min_version='1.8.0'
 git_rec_version='1.8.0'


### PR DESCRIPTION
Follow up to 31931deae8fc05b4d4c0ab8489596179f4ae3421

Docker 20.10.0 works for now so be less aggressive in forcing people to
upgrade.
