### PR TITLE
FEATURE: add an option for custom namespaces

### DIFF
--- a/launcher_go/v2/config/config.go
+++ b/launcher_go/v2/config/config.go
@@ -15,7 +15,7 @@ import (
 )
 
 const defaultBootCommand = "/sbin/boot"
-const defaultBaseImage = "discourse/base:2.0.20231121-0024"
+const defaultBaseImage = "discourse/base:2.0.20240825-0027"
 
 type Config struct {
 	Name            string `yaml:-`
@@ -217,7 +217,7 @@ func (config *Config) RunImage() string {
 	if len(config.Run_Image) > 0 {
 		return config.Run_Image
 	}
-	return utils.BaseImageName + config.Name
+	return "local_discourse/" + config.Name
 }
 
 func (config *Config) DockerHostname(defaultHostname string) string {

--- a/launcher_go/v2/docker/commands.go
+++ b/launcher_go/v2/docker/commands.go
@@ -19,11 +19,12 @@ import (
 )
 
 type DockerBuilder struct {
-	Config   *config.Config
-	Ctx      *context.Context
-	Stdin    io.Reader
-	Dir      string
-	ImageTag string
+	Config    *config.Config
+	Ctx       *context.Context
+	Stdin     io.Reader
+	Dir       string
+	Namespace string
+	ImageTag  string
 }
 
 func (r *DockerBuilder) Run() error {
@@ -46,7 +47,7 @@ func (r *DockerBuilder) Run() error {
 	cmd.Args = append(cmd.Args, "--pull")
 	cmd.Args = append(cmd.Args, "--force-rm")
 	cmd.Args = append(cmd.Args, "-t")
-	cmd.Args = append(cmd.Args, utils.BaseImageName+r.Config.Name+":"+r.ImageTag)
+	cmd.Args = append(cmd.Args, r.Namespace+"/"+r.Config.Name+":"+r.ImageTag)
 	cmd.Args = append(cmd.Args, "--shm-size=512m")
 	cmd.Args = append(cmd.Args, "-f")
 	cmd.Args = append(cmd.Args, "-")
@@ -219,6 +220,7 @@ func (r *DockerRunner) Run() error {
 type DockerPupsRunner struct {
 	Config         *config.Config
 	PupsArgs       string
+	FromImageName  string
 	SavedImageName string
 	ExtraEnv       []string
 	Ctx            *context.Context
@@ -254,6 +256,7 @@ func (r *DockerPupsRunner) Run() error {
 		Ctx:         r.Ctx,
 		ExtraEnv:    r.ExtraEnv,
 		Rm:          rm,
+		CustomImage: r.FromImageName,
 		ContainerId: r.ContainerId,
 		Cmd:         commands,
 		Stdin:       strings.NewReader(r.Config.Yaml()),

--- a/launcher_go/v2/main.go
+++ b/launcher_go/v2/main.go
@@ -18,6 +18,7 @@ type Cli struct {
 	ConfDir      string             `default:"./containers" hidden:"" help:"Discourse pups config directory." predictor:"dir"`
 	TemplatesDir string             `default:"." hidden:"" help:"Home project directory containing a templates/ directory which in turn contains pups yaml templates." predictor:"dir"`
 	BuildDir     string             `default:"./tmp" hidden:"" help:"Temporary build folder for building images." predictor:"dir"`
+	Namespace    string             `default:"local_discourse" env:"DISCOURSE_NAMESPACE" help:"image namespace."`
 	BuildCmd     DockerBuildCmd     `cmd:"" name:"build" help:"Build a base image. This command does not need a running database. Saves resulting container."`
 	ConfigureCmd DockerConfigureCmd `cmd:"" name:"configure" help:"Configure and save an image with all dependencies and environment baked in. Updates themes and precompiles all assets. Saves resulting container."`
 	MigrateCmd   DockerMigrateCmd   `cmd:"" name:"migrate" help:"Run migration tasks for a site. Running container is temporary and is not saved."`

--- a/launcher_go/v2/utils/consts.go
+++ b/launcher_go/v2/utils/consts.go
@@ -9,7 +9,7 @@ import (
 
 const Version = "v2.0.0"
 
-const BaseImageName = "local_discourse/"
+const DefaultNamespace = "local_discourse"
 
 // Known secrets, or otherwise not public info from config so we can build public images
 var KnownSecrets = []string{


### PR DESCRIPTION
Implements #685 into launcher2.
Add an option to select a targeted namespace, env var DISCOURSE_NAMESPACE.

Configure:
Add `source-tag` to select which image to configure from.
Rename old `tag` option to `target-tag` to differentiate from `source-tag` option