### PR TITLE
Update Discourse installation support in China (pnpm)

### DIFF
--- a/templates/web.china.template.yml
+++ b/templates/web.china.template.yml
@@ -12,8 +12,7 @@ hooks:
   before_yarn:
     - exec:
         cmd:
-          - su discourse -c 'yarn config set registry https://registry.npmmirror.com --global'
-          - su discourse -c 'cd $home && sed -i "s#https://registry.yarnpkg.com#https://registry.npmmirror.com#g" yarn.lock'
+          - su discourse -c 'pnpm config set registry https://registry.npmmirror.com --global'
 
   before_bundle_exec:
     - exec:


### PR DESCRIPTION
This commit updates 2 things.
1. Updates the yarn hook to replace the npm mirror before `pnpm install`.
2. Removes the `yarn.lock` patch as pnpm is now used.

After applying these modifications, I successfully installed Discourse on the Tencent Cloud China server. No more network problems.