### PR TITLE
DEV: export default base image

### DIFF
--- a/launcher_go/v2/config/config.go
+++ b/launcher_go/v2/config/config.go
@@ -15,7 +15,6 @@ import (
 )
 
 const defaultBootCommand = "/sbin/boot"
-const defaultBaseImage = "discourse/base:2.0.20240825-0027"
 
 type Config struct {
 	Name            string `yaml:-`
@@ -69,7 +68,7 @@ func LoadConfig(dir string, configName string, includeTemplates bool, templatesD
 	config := &Config{
 		Name:         configName,
 		Boot_Command: defaultBootCommand,
-		Base_Image:   defaultBaseImage,
+		Base_Image:   utils.DefaultBaseImage,
 	}
 
 	matched, _ := regexp.MatchString("[[:upper:]/ !@#$%^&*()+~`=]", configName)

--- a/launcher_go/v2/utils/consts.go
+++ b/launcher_go/v2/utils/consts.go
@@ -10,6 +10,7 @@ import (
 const Version = "v2.0.0"
 
 const DefaultNamespace = "local_discourse"
+const DefaultBaseImage = "discourse/base:2.0.20240825-0027"
 
 // Known secrets, or otherwise not public info from config so we can build public images
 var KnownSecrets = []string{


### PR DESCRIPTION
allows default base image to be public for use as a lib