### PR TITLE
Improve node_modules cleanup logic for stable branch

### DIFF
--- a/templates/web.template.yml
+++ b/templates/web.template.yml
@@ -182,11 +182,11 @@ run:
       hook: yarn
       cmd:
         - |-
-          if [ "$version" != "tests-passed" ]; then
-            rm -rf app/assets/javascripts/node_modules
-          fi
-        - |-
           if [ -f yarn.lock ]; then
+            if [ -d node_modules/.pnpm ]; then
+              echo "This version of Discourse uses yarn, but pnpm node_modules are preset. Cleaning up..."
+              find ./node_modules ./app/assets/javascripts/*/node_modules -mindepth 1 -maxdepth 1 -exec rm -rf {} +
+            fi
             su discourse -c 'yarn install --frozen-lockfile && yarn cache clean'
           else
             su discourse -c 'CI=1 pnpm install --frozen-lockfile'


### PR DESCRIPTION
- makes decision based on current state of directory, instead of `$version`
- cleans up the correct directories
- only cleans up the contents. This is important if node_modules directores are mounted volumes (e.g. in devcontainer)