### PR TITLE
Fix the broken build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,7 +117,7 @@ jobs:
       - name: Push discourse/base:aarch64 image for backwards compatibility
         if: (github.ref == 'refs/heads/main') && (matrix.arch == 'arm64')
         run: |
-          docker tag discourse/base:2.0.${{ env.TIMESTAMP }}-${{ matrix.arch }} discourse/base:aarch64
+          docker tag discourse/base:2.0.${{ env.TIMESTAMP }}-main-${{ matrix.arch }} discourse/base:aarch64
           docker push discourse/base:aarch64
 
   push_multiarch_manifests:


### PR DESCRIPTION
Follow-up to b47bd562cc03961f3208d09c7e00cbbe40b94092

[Error response from daemon: No such image:
discourse/base:2.0.20240909-1149-arm6](https://github.com/discourse/discourse_docker/actions/runs/10772563422/job/29870473267)