### PR TITLE
Fix Warnung: the "listen ... http2" directive is deprecated

### DIFF
--- a/templates/web.ssl.template.yml
+++ b/templates/web.ssl.template.yml
@@ -15,14 +15,16 @@ run:
      filename: "/etc/nginx/conf.d/discourse.conf"
      from: /listen 80;\s+gzip on;/m
      to: |
-       listen 443 ssl http2;
+       listen 443 ssl;
+       http2;
        SSL_TEMPLATE_SSL_BLOCK
   - replace:
      filename: "/etc/nginx/conf.d/discourse.conf"
      from: /listen 80;\s+listen \[::\]:80;\s+gzip on;/m
      to: |
-       listen 443 ssl http2;
-       listen [::]:443 ssl http2;
+       listen 443 ssl;
+       listen [::]:443 ssl;
+       http2;
        SSL_TEMPLATE_SSL_BLOCK
   - replace:
      hook: ssl

--- a/templates/web.ssl.template.yml
+++ b/templates/web.ssl.template.yml
@@ -24,7 +24,7 @@ run:
      to: |
        listen 443 ssl;
        listen [::]:443 ssl;
-       http2;
+       http2 on;
        SSL_TEMPLATE_SSL_BLOCK
   - replace:
      hook: ssl

--- a/templates/web.ssl.template.yml
+++ b/templates/web.ssl.template.yml
@@ -16,7 +16,7 @@ run:
      from: /listen 80;\s+gzip on;/m
      to: |
        listen 443 ssl;
-       http2;
+       http2 on;
        SSL_TEMPLATE_SSL_BLOCK
   - replace:
      filename: "/etc/nginx/conf.d/discourse.conf"


### PR DESCRIPTION
this small fix fixes the warning message in nginx