### PR TITLE
DEV: allow for 2 container data services to setup on boot

### DIFF
--- a/samples/data.yml
+++ b/samples/data.yml
@@ -9,8 +9,10 @@ templates:
 # any extra arguments for Docker?
 # docker_args:
 
+# TODO: SOME_SECRET to a password for the discourse user
 params:
   db_default_text_search_config: "pg_catalog.english"
+  db_password: SOME_SECRET
 
   ## Set db_shared_buffers to a max of 25% of the total memory.
   ## will be set automatically by bootstrap based on detected RAM, or you can override
@@ -24,6 +26,7 @@ env:
   LC_ALL: en_US.UTF-8
   LANG: en_US.UTF-8
   LANGUAGE: en_US.UTF-8
+  DISCOURSE_DB_PASSWORD: $db_password
 
 volumes:
   - volume:
@@ -33,12 +36,11 @@ volumes:
         host: /var/discourse/shared/data/log/var-log
         guest: /var/log
 
-# TODO: SOME_SECRET to a password for the discourse user
 hooks:
   after_postgres:
     - exec:
         stdin: |
-          alter user discourse with password 'SOME_SECRET';
+          alter user discourse with password '$db_password';
         cmd: su - postgres -c 'psql discourse'
 
         raise_on_fail: false

--- a/templates/postgres.15.template.yml
+++ b/templates/postgres.15.template.yml
@@ -14,20 +14,35 @@ hooks:
     - replace:
        filename: /etc/service/unicorn/run
        from: "# postgres"
-       to: |
-         if [ -f /root/install_postgres ]; then
-           /root/install_postgres
-           rm /root/install_postgres
-         fi
-         sv start postgres || exit 1
+       to: sv start postgres || exit 1
 
 run:
+  - file:
+     path: /etc/service/config-postgres/run
+     chmod: "+x"
+     contents: |
+       #!/bin/sh
+       if [ -f /usr/local/bin/create_db ] && [ "$CREATE_DB_ON_BOOT" = "1" ]; then
+         sleep 5
+         /usr/local/bin/create_db
+         if [ ! -z "$DISCOURSE_DB_PASSWORD" ]; then
+           echo "alter user discourse with password '$DISCOURSE_DB_PASSWORD';" | su - postgres -c 'psql $db_name'
+         fi
+       fi
+
   - file:
      path: /etc/service/postgres/run
      chmod: "+x"
      contents: |
         #!/bin/sh
         exec 2>&1
+        if [ -f /root/install_postgres ]; then
+          /root/install_postgres
+          rm /root/install_postgres
+        fi
+        if [ "$CREATE_DB_ON_BOOT" = "1" ]; then
+          sv once config-postgres
+        fi
         HOME=/var/lib/postgresql USER=postgres exec thpoff chpst -u postgres:postgres:ssl-cert -U postgres:postgres:ssl-cert /usr/lib/postgresql/15/bin/postmaster -D /etc/postgresql/15/main
 
   - file:

--- a/templates/postgres.template.yml
+++ b/templates/postgres.template.yml
@@ -15,20 +15,35 @@ hooks:
     - replace:
        filename: /etc/service/unicorn/run
        from: "# postgres"
-       to: |
-         if [ -f /root/install_postgres ]; then
-           /root/install_postgres
-           rm /root/install_postgres
-         fi
-         sv start postgres || exit 1
+       to: sv start postgres || exit 1
 
 run:
+  - file:
+     path: /etc/service/config-postgres/run
+     chmod: "+x"
+     contents: |
+       #!/bin/sh
+       if [ -f /usr/local/bin/create_db ] && [ "$CREATE_DB_ON_BOOT" = "1" ]; then
+         sleep 5
+         /usr/local/bin/create_db
+         if [ ! -z "$DISCOURSE_DB_PASSWORD" ]; then
+           echo "alter user discourse with password '$DISCOURSE_DB_PASSWORD';" | su - postgres -c 'psql $db_name'
+         fi
+       fi
+
   - file:
      path: /etc/service/postgres/run
      chmod: "+x"
      contents: |
         #!/bin/sh
         exec 2>&1
+        if [ -f /root/install_postgres ]; then
+          /root/install_postgres
+          rm /root/install_postgres
+        fi
+        if [ "$CREATE_DB_ON_BOOT" = "1" ]; then
+          sv once config-postgres
+        fi
         HOME=/var/lib/postgresql USER=postgres exec thpoff chpst -u postgres:postgres:ssl-cert -U postgres:postgres:ssl-cert /usr/lib/postgresql/15/bin/postmaster -D /etc/postgresql/15/main
 
   - file:

--- a/templates/redis.template.yml
+++ b/templates/redis.template.yml
@@ -9,6 +9,9 @@ run:
      contents: |
         #!/bin/sh
         exec 2>&1
+        if [ ! -d /shared/redis_data ]; then
+          install -d -m 0755 -o redis -g redis /shared/redis_data
+        fi
         exec thpoff chpst -u redis -U redis /usr/bin/redis-server /etc/redis/redis.conf
   - file:
      path: /etc/service/redis/log/run
@@ -87,8 +90,4 @@ hooks:
     - replace:
        filename: /etc/service/unicorn/run
        from: "# redis"
-       to: |
-         if [ ! -d /shared/redis_data ]; then
-           install -d -m 0755 -o redis -g redis /shared/redis_data
-         fi
-         sv start redis || exit 1
+       to: sv start redis || exit 1

--- a/templates/web.template.yml
+++ b/templates/web.template.yml
@@ -61,9 +61,8 @@ run:
         if [[ -z "$PRECOMPILE_ON_BOOT" ]]; then
           PRECOMPILE_ON_BOOT=1
         fi
-        if [ -f /usr/local/bin/create_db ] && [ "$CREATE_DB_ON_BOOT" = "1" ]; then /usr/local/bin/create_db; fi;
-        if [ "$MIGRATE_ON_BOOT" = "1" ]; then su discourse -c 'bundle exec rake db:migrate'; fi
-        if [ "$PRECOMPILE_ON_BOOT" = "1" ]; then SKIP_EMBER_CLI_COMPILE=1 su discourse -c 'bundle exec rake assets:precompile'; fi
+        if [ "$MIGRATE_ON_BOOT" = "1" ]; then su discourse -c 'bundle exec rake db:migrate' || exit 1; fi
+        if [ "$PRECOMPILE_ON_BOOT" = "1" ]; then SKIP_EMBER_CLI_COMPILE=1 su discourse -c 'bundle exec rake assets:precompile' || exit 1; fi
         LD_PRELOAD=$RUBY_ALLOCATOR HOME=/home/discourse USER=discourse exec thpoff chpst -u discourse:www-data -U discourse:www-data bundle exec config/unicorn_launcher -E production -c config/unicorn.conf.rb
 
   - file:


### PR DESCRIPTION
allow postgres templates to assign themselves a DB password allows 2 container setups to be able to create db on boot and setup passwords

move missing folder check to data services when running images without unicorn

standalone unicorn just needs to wait for db to setup via the postgres service start script