### PR TITLE
DEV: remove create_db after running

### DIFF
--- a/templates/postgres.template.yml
+++ b/templates/postgres.template.yml
@@ -265,5 +265,5 @@ run:
       cmd:
         # give db a few secs to start up
         - "sleep 5"
-        - /usr/local/bin/create_db
+        - /usr/local/bin/create_db && rm /usr/local/bin/create_db
         - "echo postgres installed!"


### PR DESCRIPTION
allows for standalone image to know to begin immediately without awaiting database in unicorn startup script