### PR TITLE
Only parse a single line from lscpu to get the Cpu(s) count.

### DIFF
--- a/discourse-setup
+++ b/discourse-setup
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+export LC_ALL=C  # lscpu output is localized.
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd $DIR
 
@@ -258,7 +260,7 @@ scale_ram_and_cpu() {
   else
     avail_gb=$(check_linux_memory)
     threads_per_core=$(lscpu | awk 'BEGIN {FS=":"} /Thread\(s\) per core/ {print $2}')
-    avail_cores=$((`lscpu | awk '/^CPU\(s\)/ {print $2}'`*${threads_per_core}))
+    avail_cores=$((`lscpu | awk '/^CPU\(s\):[[:blank:]]+[0-9]+[[:blank:]]*$/ {print $2; exit}'`*${threads_per_core}))
   fi
   echo "Found ${avail_gb}GB of memory and $avail_cores physical CPU cores"
 


### PR DESCRIPTION
Dear Discourse maintainers,

This is intended to fix an error I was getting with `discourse-setup` on Debian, from line 261:

```stderr
bash: 12
scaling*                   2: syntax error in expression (error token is "scaling*                   2")
```

Caused by the parsing of `lscpu` command retaining *2 lines* instead of just the intended one.

This occurs on my PCs with Debian testing (lscpu from util-linux 2.40.2) and Debian stable (util-linux 2.38.1) because it outputs a line formatted like this (in the "Vendor" section):

    CPU(s) scaling MHz:                   20%

(I also checked on a machine with CentOS, there the format is `CPU MHz:               2700.000`).

To avoid that, I made the regex more specific, but I also added an `exit` statement in `awk`. Probably just one of these fixes could be used.

I believe the script would have worked with the version prior to this commit from a month ago: https://github.com/discourse/discourse_docker/commit/d00c2e75d5884ebefdac3a13f14a7f86b611bda5

Best,

    