### PR TITLE
DEV: slim image, drop unused packages and use cache mounts

### DIFF
--- a/image/base/Dockerfile
+++ b/image/base/Dockerfile
@@ -29,70 +29,47 @@ RUN --mount=type=cache,target=/var/cache/debconf,sharing=locked \
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   --mount=type=cache,target=/var/cache/debconf,sharing=locked \
   --mount=type=cache,target=/var/lib/apt,sharing=locked \
-  --mount=type=tmpfs,target=/usr/share/doc \
-  --mount=type=tmpfs,target=/usr/share/man \
   --mount=type=tmpfs,target=/var/log \
-  apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install gnupg sudo curl fping
-
-RUN sh -c "fping proxy && echo 'Acquire { Retries \"0\"; HTTP { Proxy \"http://proxy:3128\";}; };' > /etc/apt/apt.conf.d/40proxy && apt-get update || true"
-
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-  --mount=type=cache,target=/var/cache/debconf,sharing=locked \
-  --mount=type=cache,target=/var/lib/apt,sharing=locked \
-  --mount=type=tmpfs,target=/usr/share/doc \
-  --mount=type=tmpfs,target=/usr/share/man \
-  --mount=type=tmpfs,target=/var/log \
-  DEBIAN_FRONTEND=noninteractive apt-get install -y locales
-
-ENV LC_ALL en_US.UTF-8
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US.UTF-8
-RUN sed -i "s/^# $LANG/$LANG/" /etc/locale.gen; \
-    locale-gen
-
-RUN install -d /usr/share/postgresql-common/pgdg &&\
-    curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc &&\
-    echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt ${DEBIAN_RELEASE}-pgdg main" > /etc/apt/sources.list.d/pgdg.list
-
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-  --mount=type=cache,target=/var/cache/debconf,sharing=locked \
-  --mount=type=cache,target=/var/lib/apt,sharing=locked \
-  --mount=type=tmpfs,target=/var/log \
-  --mount=type=tmpfs,target=/usr/share/doc \
-  --mount=type=tmpfs,target=/usr/share/man \
-  curl --silent --location https://deb.nodesource.com/setup_18.x | sudo bash -
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-  --mount=type=cache,target=/var/cache/debconf,sharing=locked \
-  --mount=type=cache,target=/var/lib/apt,sharing=locked \
-  apt-get -y update
+  apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get -y install gnupg sudo curl fping locales \
+    ca-certificates rsync \
+    cmake g++ pkg-config patch \
+    libxslt-dev libcurl4-openssl-dev \
+    libssl-dev libyaml-dev libtool \
+    libpcre3 libpcre3-dev zlib1g zlib1g-dev \
+    libxml2-dev gawk parallel \
+    libpq-dev postgresql-client \
+    libreadline-dev anacron wget \
+    psmisc whois brotli libunwind-dev \
+    libtcmalloc-minimal4 cmake \
+    pngcrush pngquant ripgrep poppler-utils
 
 # install these without recommends to avoid pulling in e.g.
 # X11 libraries, mailutils
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   --mount=type=cache,target=/var/cache/debconf,sharing=locked \
   --mount=type=cache,target=/var/lib/apt,sharing=locked \
-  --mount=type=tmpfs,target=/usr/share/doc \
-  --mount=type=tmpfs,target=/usr/share/man \
+  --mount=type=tmpfs,target=/var/log \
   DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends git rsyslog logrotate cron ssh-client less
+
+RUN install -d /usr/share/postgresql-common/pgdg &&\
+    curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc &&\
+    echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt ${DEBIAN_RELEASE}-pgdg main" > /etc/apt/sources.list.d/pgdg.list
+
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list
+
+ENV LC_ALL=en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US.UTF-8
+RUN sed -i "s/^# $LANG/$LANG/" /etc/locale.gen; \
+    locale-gen
+
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   --mount=type=cache,target=/var/cache/debconf,sharing=locked \
   --mount=type=cache,target=/var/lib/apt,sharing=locked \
-  --mount=type=tmpfs,target=/usr/share/doc \
-  --mount=type=tmpfs,target=/usr/share/man \
-  DEBIAN_FRONTEND=noninteractive apt-get -y install ca-certificates rsync \
-    cmake g++ pkg-config patch \
-    libxslt-dev libcurl4-openssl-dev \
-    libssl-dev libyaml-dev libtool \
-    libpcre3 libpcre3-dev zlib1g zlib1g-dev \
-    libxml2-dev gawk parallel \
-    postgresql-${PG_MAJOR} postgresql-client \
-    postgresql-contrib-${PG_MAJOR} libpq-dev postgresql-${PG_MAJOR}-pgvector \
-    libreadline-dev anacron wget \
-    psmisc whois brotli libunwind-dev \
-    libtcmalloc-minimal4 cmake \
-    pngcrush pngquant ripgrep poppler-utils
+  --mount=type=tmpfs,target=/var/log \
+  curl --silent --location https://deb.nodesource.com/setup_18.x | sudo bash -
+
 RUN sed -i -e 's/start -q anacron/anacron -s/' /etc/cron.d/anacron
 RUN sed -i.bak 's/$ModLoad imklog/#$ModLoad imklog/' /etc/rsyslog.conf
 RUN sed -i.bak 's/module(load="imklog")/#module(load="imklog")/' /etc/rsyslog.conf
@@ -101,14 +78,11 @@ RUN sh -c "test -f /sbin/initctl || ln -s /bin/true /sbin/initctl"
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   --mount=type=cache,target=/var/cache/debconf,sharing=locked \
   --mount=type=cache,target=/var/lib/apt,sharing=locked \
-  --mount=type=tmpfs,target=/usr/share/doc \
-  --mount=type=tmpfs,target=/usr/share/man \
   --mount=type=tmpfs,target=/root/.npm \
   cd / &&\
-    DEBIAN_FRONTEND=noninteractive apt-get -y install runit socat &&\
+    apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get -y install runit socat \
+    postgresql-${PG_MAJOR} postgresql-contrib-${PG_MAJOR} postgresql-${PG_MAJOR}-pgvector &&\
     mkdir -p /etc/runit/1.d &&\
-    apt-get clean &&\
-    rm -f /etc/apt/apt.conf.d/40proxy &&\
     DEBIAN_FRONTEND=noninteractive apt-get install -y nodejs yarn &&\
     npm install -g terser uglify-js pnpm
 
@@ -116,8 +90,6 @@ ADD install-imagemagick /tmp/install-imagemagick
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   --mount=type=cache,target=/var/cache/debconf,sharing=locked \
   --mount=type=cache,target=/var/lib/apt,sharing=locked \
-  --mount=type=tmpfs,target=/usr/share/doc \
-  --mount=type=tmpfs,target=/usr/share/man \
   /tmp/install-imagemagick
 
 ADD install-jemalloc /tmp/install-jemalloc
@@ -157,9 +129,7 @@ ADD thpoff.c /src/thpoff.c
 RUN gcc -o /usr/local/sbin/thpoff /src/thpoff.c && rm /src/thpoff.c
 
 # clean up for docker squash
-RUN rm -fr /usr/share/man &&\
-    rm -fr /usr/share/doc &&\
-    rm -fr /usr/local/share/doc &&\
+RUN rm -fr /usr/local/share/doc &&\
     rm -fr /usr/local/share/ri &&\
     rm -fr /var/lib/apt/lists/* &&\
     rm -fr /root/.gem &&\

--- a/image/base/Dockerfile
+++ b/image/base/Dockerfile
@@ -36,7 +36,6 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     libssl-dev libyaml-dev libtool \
     libpcre3 libpcre3-dev zlib1g zlib1g-dev \
     libxml2-dev gawk parallel \
-    libpq-dev postgresql-client \
     libreadline-dev anacron wget \
     psmisc whois brotli libunwind-dev \
     libtcmalloc-minimal4 cmake \
@@ -61,6 +60,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     dpkg-divert --local --rename --add /sbin/initctl; \
     sh -c "test -f /sbin/initctl || ln -s /bin/true /sbin/initctl"; \
     apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get -y install runit socat \
+    libpq-dev postgresql-client \
     postgresql-${PG_MAJOR} postgresql-contrib-${PG_MAJOR} postgresql-${PG_MAJOR}-pgvector \
     nodejs yarn &&\
     mkdir -p /etc/runit/1.d

--- a/image/base/Dockerfile
+++ b/image/base/Dockerfile
@@ -23,13 +23,12 @@ RUN groupadd --gid 104 postgres &&\
 
 RUN echo 2.0.`date +%Y%m%d` > /VERSION
 RUN echo "deb http://deb.debian.org/debian ${DEBIAN_RELEASE}-backports main" > "/etc/apt/sources.list.d/${DEBIAN_RELEASE}-backports.list"
-RUN --mount=type=cache,target=/var/cache/debconf,sharing=locked \
-  echo "debconf debconf/frontend select Teletype" | debconf-set-selections
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   --mount=type=cache,target=/var/cache/debconf,sharing=locked \
   --mount=type=cache,target=/var/lib/apt,sharing=locked \
   --mount=type=tmpfs,target=/var/log \
+  echo "debconf debconf/frontend select Teletype" | debconf-set-selections; \
   apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get -y install gnupg sudo curl fping locales \
     ca-certificates rsync \
     cmake g++ pkg-config patch \
@@ -41,22 +40,30 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     libreadline-dev anacron wget \
     psmisc whois brotli libunwind-dev \
     libtcmalloc-minimal4 cmake \
-    pngcrush pngquant ripgrep poppler-utils
+    pngcrush pngquant ripgrep poppler-utils; \
 
 # install these without recommends to avoid pulling in e.g.
 # X11 libraries, mailutils
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-  --mount=type=cache,target=/var/cache/debconf,sharing=locked \
-  --mount=type=cache,target=/var/lib/apt,sharing=locked \
-  --mount=type=tmpfs,target=/var/log \
-  DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends git rsyslog logrotate cron ssh-client less
+    DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends git rsyslog logrotate cron ssh-client less; \
 
-RUN install -d /usr/share/postgresql-common/pgdg &&\
+    install -d /usr/share/postgresql-common/pgdg &&\
     curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc &&\
-    echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt ${DEBIAN_RELEASE}-pgdg main" > /etc/apt/sources.list.d/pgdg.list
+    echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt ${DEBIAN_RELEASE}-pgdg main" > /etc/apt/sources.list.d/pgdg.list; \
 
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list
+    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -; \
+    echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list; \
+
+    curl --silent --location https://deb.nodesource.com/setup_18.x | sudo bash -; \
+
+    sed -i -e 's/start -q anacron/anacron -s/' /etc/cron.d/anacron; \
+    sed -i.bak 's/$ModLoad imklog/#$ModLoad imklog/' /etc/rsyslog.conf; \
+    sed -i.bak 's/module(load="imklog")/#module(load="imklog")/' /etc/rsyslog.conf; \
+    dpkg-divert --local --rename --add /sbin/initctl; \
+    sh -c "test -f /sbin/initctl || ln -s /bin/true /sbin/initctl"; \
+    apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get -y install runit socat \
+    postgresql-${PG_MAJOR} postgresql-contrib-${PG_MAJOR} postgresql-${PG_MAJOR}-pgvector \
+    nodejs yarn &&\
+    mkdir -p /etc/runit/1.d
 
 ENV LC_ALL=en_US.UTF-8
 ENV LANG=en_US.UTF-8
@@ -64,26 +71,7 @@ ENV LANGUAGE=en_US.UTF-8
 RUN sed -i "s/^# $LANG/$LANG/" /etc/locale.gen; \
     locale-gen
 
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-  --mount=type=cache,target=/var/cache/debconf,sharing=locked \
-  --mount=type=cache,target=/var/lib/apt,sharing=locked \
-  --mount=type=tmpfs,target=/var/log \
-  curl --silent --location https://deb.nodesource.com/setup_18.x | sudo bash -
-
-RUN sed -i -e 's/start -q anacron/anacron -s/' /etc/cron.d/anacron
-RUN sed -i.bak 's/$ModLoad imklog/#$ModLoad imklog/' /etc/rsyslog.conf
-RUN sed -i.bak 's/module(load="imklog")/#module(load="imklog")/' /etc/rsyslog.conf
-RUN dpkg-divert --local --rename --add /sbin/initctl
-RUN sh -c "test -f /sbin/initctl || ln -s /bin/true /sbin/initctl"
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-  --mount=type=cache,target=/var/cache/debconf,sharing=locked \
-  --mount=type=cache,target=/var/lib/apt,sharing=locked \
-  --mount=type=tmpfs,target=/root/.npm \
-  cd / &&\
-    apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get -y install runit socat \
-    postgresql-${PG_MAJOR} postgresql-contrib-${PG_MAJOR} postgresql-${PG_MAJOR}-pgvector &&\
-    mkdir -p /etc/runit/1.d &&\
-    DEBIAN_FRONTEND=noninteractive apt-get install -y nodejs yarn &&\
+RUN --mount=type=tmpfs,target=/root/.npm \
     npm install -g terser uglify-js pnpm
 
 ADD install-imagemagick /tmp/install-imagemagick

--- a/image/base/Dockerfile
+++ b/image/base/Dockerfile
@@ -40,20 +40,19 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     psmisc whois brotli libunwind-dev \
     libtcmalloc-minimal4 cmake \
     pngcrush pngquant ripgrep poppler-utils; \
-
 # install these without recommends to avoid pulling in e.g.
 # X11 libraries, mailutils
     DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends git rsyslog logrotate cron ssh-client less; \
-
+# postgres packages
     install -d /usr/share/postgresql-common/pgdg &&\
     curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc &&\
     echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt ${DEBIAN_RELEASE}-pgdg main" > /etc/apt/sources.list.d/pgdg.list; \
-
+# yarn packages
     curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -; \
     echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list; \
-
+# node packages
     curl --silent --location https://deb.nodesource.com/setup_18.x | sudo bash -; \
-
+# setup anacron, rsyslog, initctl
     sed -i -e 's/start -q anacron/anacron -s/' /etc/cron.d/anacron; \
     sed -i.bak 's/$ModLoad imklog/#$ModLoad imklog/' /etc/rsyslog.conf; \
     sed -i.bak 's/module(load="imklog")/#module(load="imklog")/' /etc/rsyslog.conf; \

--- a/image/base/Dockerfile
+++ b/image/base/Dockerfile
@@ -23,13 +23,27 @@ RUN groupadd --gid 104 postgres &&\
 
 RUN echo 2.0.`date +%Y%m%d` > /VERSION
 RUN echo "deb http://deb.debian.org/debian ${DEBIAN_RELEASE}-backports main" > "/etc/apt/sources.list.d/${DEBIAN_RELEASE}-backports.list"
-RUN echo "debconf debconf/frontend select Teletype" | debconf-set-selections
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install gnupg sudo curl fping
-RUN sh -c "fping proxy && echo 'Acquire { Retries \"0\"; HTTP { Proxy \"http://proxy:3128\";}; };' > /etc/apt/apt.conf.d/40proxy && apt-get update || true"
-RUN apt-mark hold initscripts
-RUN apt-get -y upgrade
+RUN --mount=type=cache,target=/var/cache/debconf,sharing=locked \
+  echo "debconf debconf/frontend select Teletype" | debconf-set-selections
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y locales
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  --mount=type=cache,target=/var/cache/debconf,sharing=locked \
+  --mount=type=cache,target=/var/lib/apt,sharing=locked \
+  --mount=type=tmpfs,target=/usr/share/doc \
+  --mount=type=tmpfs,target=/usr/share/man \
+  --mount=type=tmpfs,target=/var/log \
+  apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install gnupg sudo curl fping
+
+RUN sh -c "fping proxy && echo 'Acquire { Retries \"0\"; HTTP { Proxy \"http://proxy:3128\";}; };' > /etc/apt/apt.conf.d/40proxy && apt-get update || true"
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  --mount=type=cache,target=/var/cache/debconf,sharing=locked \
+  --mount=type=cache,target=/var/lib/apt,sharing=locked \
+  --mount=type=tmpfs,target=/usr/share/doc \
+  --mount=type=tmpfs,target=/usr/share/man \
+  --mount=type=tmpfs,target=/var/log \
+  DEBIAN_FRONTEND=noninteractive apt-get install -y locales
+
 ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8
@@ -40,14 +54,35 @@ RUN install -d /usr/share/postgresql-common/pgdg &&\
     curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc &&\
     echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt ${DEBIAN_RELEASE}-pgdg main" > /etc/apt/sources.list.d/pgdg.list
 
-RUN curl --silent --location https://deb.nodesource.com/setup_18.x | sudo bash -
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  --mount=type=cache,target=/var/cache/debconf,sharing=locked \
+  --mount=type=cache,target=/var/lib/apt,sharing=locked \
+  --mount=type=tmpfs,target=/var/log \
+  --mount=type=tmpfs,target=/usr/share/doc \
+  --mount=type=tmpfs,target=/usr/share/man \
+  curl --silent --location https://deb.nodesource.com/setup_18.x | sudo bash -
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list
-RUN apt-get -y update
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  --mount=type=cache,target=/var/cache/debconf,sharing=locked \
+  --mount=type=cache,target=/var/lib/apt,sharing=locked \
+  apt-get -y update
+
 # install these without recommends to avoid pulling in e.g.
 # X11 libraries, mailutils
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends git rsyslog logrotate cron ssh-client less
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y install autoconf build-essential ca-certificates rsync \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  --mount=type=cache,target=/var/cache/debconf,sharing=locked \
+  --mount=type=cache,target=/var/lib/apt,sharing=locked \
+  --mount=type=tmpfs,target=/usr/share/doc \
+  --mount=type=tmpfs,target=/usr/share/man \
+  DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends git rsyslog logrotate cron ssh-client less
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  --mount=type=cache,target=/var/cache/debconf,sharing=locked \
+  --mount=type=cache,target=/var/lib/apt,sharing=locked \
+  --mount=type=tmpfs,target=/usr/share/doc \
+  --mount=type=tmpfs,target=/usr/share/man \
+  DEBIAN_FRONTEND=noninteractive apt-get -y install ca-certificates rsync \
+    cmake g++ pkg-config patch \
     libxslt-dev libcurl4-openssl-dev \
     libssl-dev libyaml-dev libtool \
     libpcre3 libpcre3-dev zlib1g zlib1g-dev \
@@ -63,7 +98,13 @@ RUN sed -i.bak 's/$ModLoad imklog/#$ModLoad imklog/' /etc/rsyslog.conf
 RUN sed -i.bak 's/module(load="imklog")/#module(load="imklog")/' /etc/rsyslog.conf
 RUN dpkg-divert --local --rename --add /sbin/initctl
 RUN sh -c "test -f /sbin/initctl || ln -s /bin/true /sbin/initctl"
-RUN cd / &&\
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  --mount=type=cache,target=/var/cache/debconf,sharing=locked \
+  --mount=type=cache,target=/var/lib/apt,sharing=locked \
+  --mount=type=tmpfs,target=/usr/share/doc \
+  --mount=type=tmpfs,target=/usr/share/man \
+  --mount=type=tmpfs,target=/root/.npm \
+  cd / &&\
     DEBIAN_FRONTEND=noninteractive apt-get -y install runit socat &&\
     mkdir -p /etc/runit/1.d &&\
     apt-get clean &&\
@@ -72,7 +113,12 @@ RUN cd / &&\
     npm install -g terser uglify-js pnpm
 
 ADD install-imagemagick /tmp/install-imagemagick
-RUN /tmp/install-imagemagick
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  --mount=type=cache,target=/var/cache/debconf,sharing=locked \
+  --mount=type=cache,target=/var/lib/apt,sharing=locked \
+  --mount=type=tmpfs,target=/usr/share/doc \
+  --mount=type=tmpfs,target=/usr/share/man \
+  /tmp/install-imagemagick
 
 ADD install-jemalloc /tmp/install-jemalloc
 RUN /tmp/install-jemalloc
@@ -81,7 +127,10 @@ RUN /tmp/install-jemalloc
 ADD nginx_public_keys.key /tmp/nginx_public_keys.key
 ADD install-nginx /tmp/install-nginx
 
-RUN gpg --import /tmp/nginx_public_keys.key &&\
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/cache/debconf,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    gpg --import /tmp/nginx_public_keys.key &&\
     rm /tmp/nginx_public_keys.key &&\
     /tmp/install-nginx
 
@@ -89,7 +138,10 @@ ADD install-redis /tmp/install-redis
 RUN /tmp/install-redis
 
 ADD install-oxipng /tmp/install-oxipng
-RUN /tmp/install-oxipng
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/cache/debconf,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    /tmp/install-oxipng
 
 RUN echo 'gem: --no-document' >> /usr/local/etc/gemrc &&\
     gem update --system
@@ -107,19 +159,12 @@ RUN gcc -o /usr/local/sbin/thpoff /src/thpoff.c && rm /src/thpoff.c
 # clean up for docker squash
 RUN rm -fr /usr/share/man &&\
     rm -fr /usr/share/doc &&\
-    rm -fr /usr/share/vim/vim74/doc &&\
-    rm -fr /usr/share/vim/vim74/lang &&\
-    rm -fr /usr/share/vim/vim74/spell/en* &&\
-    rm -fr /usr/share/vim/vim74/tutor &&\
     rm -fr /usr/local/share/doc &&\
     rm -fr /usr/local/share/ri &&\
     rm -fr /var/lib/apt/lists/* &&\
     rm -fr /root/.gem &&\
     rm -fr /root/.npm &&\
     rm -fr /tmp/*
-
-# this can probably be done, but I worry that people changing PG locales will have issues
-# cd /usr/share/locale && rm -fr `ls -d */ | grep -v en`
 
 # this is required for aarch64 which uses buildx
 # see https://github.com/docker/buildx/issues/150


### PR DESCRIPTION
apt using caches for /var/cache/apt, /var/cache/debconf, and var/lib/apt.

Ensure /usr/share/doc and /usr/share/man do not get saved to the image by mounting temporary folders to paths.

Drop build-essential from installs, in favor of selective cmake, g++, pkg-config, and patch packages.

drop apt-get -y upgrade in dockerfile. We should inherit upgrades from base images. No need to apt-mark hold initscripts now that we're not running `upgrade`

Remove calls to vim as we no longer install vim here. Remove comment for slimming locales as we have now done so.