### PR TITLE
Bump Ruby to 3.3.6

### DIFF
--- a/image/base/Dockerfile
+++ b/image/base/Dockerfile
@@ -2,7 +2,7 @@
 # VERSION:  release
 
 ARG DEBIAN_RELEASE=bookworm
-FROM discourse/ruby:3.3.4-${DEBIAN_RELEASE}-slim AS discourse_dependencies
+FROM discourse/ruby:3.3.6-${DEBIAN_RELEASE}-slim AS discourse_dependencies
 
 ARG DEBIAN_RELEASE
 ENV PG_MAJOR=13 \


### PR DESCRIPTION
This is a routine update that includes minor bug fixes.

See https://www.ruby-lang.org/en/news/2024/11/05/ruby-3-3-6-released/
