### PR TITLE
FEATURE: print out compressed image sizes for amd64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   timestamp:
-    if: (github.event_name != 'schedule' || github.event.repo.name == 'discourse/discourse_docker')
+    if: (github.event_name != 'schedule' || github.repository == 'discourse/discourse_docker')
     runs-on: ubuntu-latest
     outputs:
       timestamp: ${{ steps.timestamp.outputs.timestamp }}
@@ -34,7 +34,7 @@ jobs:
           echo "timestamp=$timestamp" >> $GITHUB_OUTPUT
 
   base:
-    if: (github.event_name != 'schedule' || github.event.repo.name == 'discourse/discourse_docker')
+    if: (github.event_name != 'schedule' || github.repository == 'discourse/discourse_docker')
     # `unbuntu-22.04-8core` for arch amd64 non-scheduled builds
     # `unbuntu-22.04` for arch amd64 scheduled builds
     # `unbuntu-22.04-8core-arm` for arch arm64 non-scheduled builds
@@ -123,7 +123,7 @@ jobs:
           echo "current slim: ${CURRENT_SLIM} release: ${CURRENT_RELEASE}. new slim: ${NEW_SLIM} release: ${NEW_RELEASE}"
 
       - name: push to dockerhub
-        if: github.ref == 'refs/heads/main' && github.event.repo.name == 'discourse/discourse_docker'
+        if: github.ref == 'refs/heads/main' && github.repository == 'discourse/discourse_docker'
         env:
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
         run: |
@@ -134,7 +134,7 @@ jobs:
           docker push discourse/discourse_dev:${{ env.TIMESTAMP }}-${{ matrix.arch }}
 
       - name: Push discourse/base:aarch64 image for backwards compatibility
-        if: (github.ref == 'refs/heads/main') && (matrix.arch == 'arm64') && (github.event.repo.name == 'discourse/discourse_docker')
+        if: (github.ref == 'refs/heads/main') && (matrix.arch == 'arm64') && (github.repository == 'discourse/discourse_docker')
         run: |
           docker tag discourse/base:2.0.${{ env.TIMESTAMP }}-main-${{ matrix.arch }} discourse/base:aarch64
           docker push discourse/base:aarch64
@@ -144,7 +144,7 @@ jobs:
     needs: [base, timestamp]
     env:
       TIMESTAMP: ${{ needs.timestamp.outputs.timestamp }}
-    if: github.ref == 'refs/heads/main' && github.event.repo.name == 'discourse/discourse_docker'
+    if: github.ref == 'refs/heads/main' && github.repository == 'discourse/discourse_docker'
     steps:
       - name: create and push multiarch manifests
         run: |
@@ -231,7 +231,7 @@ jobs:
         run: |
           docker images discourse/discourse_test
       - name: push to dockerhub
-        if: success() && (github.ref == 'refs/heads/main') && (github.event.repo.name == 'discourse/discourse_docker')
+        if: success() && (github.ref == 'refs/heads/main') && (github.repository == 'discourse/discourse_docker')
         env:
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,6 @@ env:
 
 jobs:
   timestamp:
-    if: (github.event_name != 'schedule' || github.repository == 'discourse/discourse_docker')
     runs-on: ubuntu-latest
     outputs:
       timestamp: ${{ steps.timestamp.outputs.timestamp }}
@@ -34,7 +33,6 @@ jobs:
           echo "timestamp=$timestamp" >> $GITHUB_OUTPUT
 
   base:
-    if: (github.event_name != 'schedule' || github.repository == 'discourse/discourse_docker')
     # `unbuntu-22.04-8core` for arch amd64 non-scheduled builds
     # `unbuntu-22.04` for arch amd64 scheduled builds
     # `unbuntu-22.04-8core-arm` for arch arm64 non-scheduled builds
@@ -123,7 +121,7 @@ jobs:
           echo "current slim: ${CURRENT_SLIM} release: ${CURRENT_RELEASE}. new slim: ${NEW_SLIM} release: ${NEW_RELEASE}"
 
       - name: push to dockerhub
-        if: github.ref == 'refs/heads/main' && github.repository == 'discourse/discourse_docker'
+        if: github.ref == 'refs/heads/main'
         env:
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
         run: |
@@ -134,7 +132,7 @@ jobs:
           docker push discourse/discourse_dev:${{ env.TIMESTAMP }}-${{ matrix.arch }}
 
       - name: Push discourse/base:aarch64 image for backwards compatibility
-        if: (github.ref == 'refs/heads/main') && (matrix.arch == 'arm64') && (github.repository == 'discourse/discourse_docker')
+        if: (github.ref == 'refs/heads/main') && (matrix.arch == 'arm64')
         run: |
           docker tag discourse/base:2.0.${{ env.TIMESTAMP }}-main-${{ matrix.arch }} discourse/base:aarch64
           docker push discourse/base:aarch64
@@ -144,7 +142,7 @@ jobs:
     needs: [base, timestamp]
     env:
       TIMESTAMP: ${{ needs.timestamp.outputs.timestamp }}
-    if: github.ref == 'refs/heads/main' && github.repository == 'discourse/discourse_docker'
+    if: github.ref == 'refs/heads/main'
     steps:
       - name: create and push multiarch manifests
         run: |
@@ -231,7 +229,7 @@ jobs:
         run: |
           docker images discourse/discourse_test
       - name: push to dockerhub
-        if: success() && (github.ref == 'refs/heads/main') && (github.repository == 'discourse/discourse_docker')
+        if: success() && (github.ref == 'refs/heads/main')
         env:
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,11 @@ jobs:
     needs: timestamp
     env:
       TIMESTAMP: ${{ needs.timestamp.outputs.timestamp }}
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
     steps:
       - uses: actions/checkout@v3
         with:
@@ -107,18 +112,16 @@ jobs:
         if: github.event_name == 'pull_request' && matrix.arch == 'amd64'
         run: |
           # Push to local repo to compare sizes
-          docker run --quiet -d --rm -p 5002:5000 registry:2
-          sleep 5
-          docker tag discourse/base:2.0.${{ env.TIMESTAMP }}-slim-${{ matrix.arch }} localhost:5002/base:2.0.${{ env.TIMESTAMP }}-slim-${{ matrix.arch }}
-          docker tag discourse/base:2.0.${{ env.TIMESTAMP }}-main-${{ matrix.arch }} localhost:5002/base:2.0.${{ env.TIMESTAMP }}-main-${{ matrix.arch }}
-          docker push --quiet localhost:5002/base:2.0.${{ env.TIMESTAMP }}-slim-${{ matrix.arch }}
-          docker push --quiet localhost:5002/base:2.0.${{ env.TIMESTAMP }}-main-${{ matrix.arch }}
+          docker tag discourse/base:2.0.${{ env.TIMESTAMP }}-slim-${{ matrix.arch }} localhost:5000/base:2.0.${{ env.TIMESTAMP }}-slim-${{ matrix.arch }}
+          docker tag discourse/base:2.0.${{ env.TIMESTAMP }}-main-${{ matrix.arch }} localhost:5000/base:2.0.${{ env.TIMESTAMP }}-main-${{ matrix.arch }}
+          docker push --quiet localhost:5000/base:2.0.${{ env.TIMESTAMP }}-slim-${{ matrix.arch }}
+          docker push --quiet localhost:5000/base:2.0.${{ env.TIMESTAMP }}-main-${{ matrix.arch }}
           # multiarch manifest is an array of schemas - [0] is amd64, [1] is arch64: Compare amd64.
           CURRENT_SLIM=$(docker manifest inspect -v discourse/base:slim | jq -r '.[0].SchemaV2Manifest.layers[] | .size / 1024 / 1024 | .*100 | round/100' | awk '{print $0; sum+= $0}; END {print sum}' | tail -n 1)
           CURRENT_RELEASE=$(docker manifest inspect -v discourse/base:release | jq -r '.[0].SchemaV2Manifest.layers[] | .size / 1024 / 1024 | .*100 | round/100' | awk '{print $0; sum+= $0}; END {print sum}' | tail -n 1)
-          NEW_SLIM=$(docker manifest inspect -v --insecure localhost:5002/base:2.0.${{ env.TIMESTAMP }}-slim-${{ matrix.arch }} |  jq -r '.SchemaV2Manifest.layers[] | .size / 1024 / 1024 | .*100 | round/100' | awk '{print $0; sum+= $0}; END {print sum}' | tail -n 1)
-          NEW_RELEASE=$(docker manifest inspect -v --insecure localhost:5002/base:2.0.${{ env.TIMESTAMP }}-main-${{ matrix.arch }} | jq -r '.SchemaV2Manifest.layers[] | .size / 1024 / 1024 | .*100 | round/100' | awk '{print $0; sum+= $0}; END {print sum}' | tail -n 1)
-          echo "current slim: ${CURRENT_SLIM} release: ${CURRENT_RELEASE}. new slim: ${NEW_SLIM} release: ${NEW_RELEASE}"
+          NEW_SLIM=$(docker manifest inspect -v --insecure localhost:5000/base:2.0.${{ env.TIMESTAMP }}-slim-${{ matrix.arch }} |  jq -r '.SchemaV2Manifest.layers[] | .size / 1024 / 1024 | .*100 | round/100' | awk '{print $0; sum+= $0}; END {print sum}' | tail -n 1)
+          NEW_RELEASE=$(docker manifest inspect -v --insecure localhost:5000/base:2.0.${{ env.TIMESTAMP }}-main-${{ matrix.arch }} | jq -r '.SchemaV2Manifest.layers[] | .size / 1024 / 1024 | .*100 | round/100' | awk '{print $0; sum+= $0}; END {print sum}' | tail -n 1)
+          echo "current slim: ${CURRENT_SLIM}MB release: ${CURRENT_RELEASE}MB. new slim: ${NEW_SLIM}MB release: ${NEW_RELEASE}MB"
 
       - name: push to dockerhub
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,7 @@ env:
 
 jobs:
   timestamp:
+    if: (github.event_name != 'schedule' || github.event.repo.name == 'discourse/discourse_docker')
     runs-on: ubuntu-latest
     outputs:
       timestamp: ${{ steps.timestamp.outputs.timestamp }}
@@ -33,6 +34,7 @@ jobs:
           echo "timestamp=$timestamp" >> $GITHUB_OUTPUT
 
   base:
+    if: (github.event_name != 'schedule' || github.event.repo.name == 'discourse/discourse_docker')
     # `unbuntu-22.04-8core` for arch amd64 non-scheduled builds
     # `unbuntu-22.04` for arch amd64 scheduled builds
     # `unbuntu-22.04-8core-arm` for arch arm64 non-scheduled builds
@@ -103,8 +105,25 @@ jobs:
         run: |
           docker images discourse/base
 
+      - name: Print compressed summary
+        if: github.event_name == 'pull_request' && matrix.arch == 'amd64'
+        run: |
+          # Push to local repo to compare sizes
+          docker run --quiet -d --rm -p 5002:5000 registry:2
+          sleep 5
+          docker tag discourse/base:2.0.${{ env.TIMESTAMP }}-slim-${{ matrix.arch }} localhost:5002/base:2.0.${{ env.TIMESTAMP }}-slim-${{ matrix.arch }}
+          docker tag discourse/base:2.0.${{ env.TIMESTAMP }}-main-${{ matrix.arch }} localhost:5002/base:2.0.${{ env.TIMESTAMP }}-main-${{ matrix.arch }}
+          docker push --quiet localhost:5002/base:2.0.${{ env.TIMESTAMP }}-slim-${{ matrix.arch }}
+          docker push --quiet localhost:5002/base:2.0.${{ env.TIMESTAMP }}-main-${{ matrix.arch }}
+          # multiarch manifest is an array of schemas - [0] is amd64, [1] is arch64: Compare amd64.
+          CURRENT_SLIM=$(docker manifest inspect -v discourse/base:slim | jq -r '.[0].SchemaV2Manifest.layers[] | .size / 1024 / 1024 | .*100 | round/100' | awk '{print $0; sum+= $0}; END {print sum}' | tail -n 1)
+          CURRENT_RELEASE=$(docker manifest inspect -v discourse/base:release | jq -r '.[0].SchemaV2Manifest.layers[] | .size / 1024 / 1024 | .*100 | round/100' | awk '{print $0; sum+= $0}; END {print sum}' | tail -n 1)
+          NEW_SLIM=$(docker manifest inspect -v --insecure localhost:5002/base:2.0.${{ env.TIMESTAMP }}-slim-${{ matrix.arch }} |  jq -r '.SchemaV2Manifest.layers[] | .size / 1024 / 1024 | .*100 | round/100' | awk '{print $0; sum+= $0}; END {print sum}' | tail -n 1)
+          NEW_RELEASE=$(docker manifest inspect -v --insecure localhost:5002/base:2.0.${{ env.TIMESTAMP }}-main-${{ matrix.arch }} | jq -r '.SchemaV2Manifest.layers[] | .size / 1024 / 1024 | .*100 | round/100' | awk '{print $0; sum+= $0}; END {print sum}' | tail -n 1)
+          echo "current slim: ${CURRENT_SLIM} release: ${CURRENT_RELEASE}. new slim: ${NEW_SLIM} release: ${NEW_RELEASE}"
+
       - name: push to dockerhub
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' && github.event.repo.name == 'discourse/discourse_docker'
         env:
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
         run: |
@@ -115,7 +134,7 @@ jobs:
           docker push discourse/discourse_dev:${{ env.TIMESTAMP }}-${{ matrix.arch }}
 
       - name: Push discourse/base:aarch64 image for backwards compatibility
-        if: (github.ref == 'refs/heads/main') && (matrix.arch == 'arm64')
+        if: (github.ref == 'refs/heads/main') && (matrix.arch == 'arm64') && (github.event.repo.name == 'discourse/discourse_docker')
         run: |
           docker tag discourse/base:2.0.${{ env.TIMESTAMP }}-main-${{ matrix.arch }} discourse/base:aarch64
           docker push discourse/base:aarch64
@@ -125,7 +144,7 @@ jobs:
     needs: [base, timestamp]
     env:
       TIMESTAMP: ${{ needs.timestamp.outputs.timestamp }}
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' && github.event.repo.name == 'discourse/discourse_docker'
     steps:
       - name: create and push multiarch manifests
         run: |
@@ -212,7 +231,7 @@ jobs:
         run: |
           docker images discourse/discourse_test
       - name: push to dockerhub
-        if: success() && (github.ref == 'refs/heads/main')
+        if: success() && (github.ref == 'refs/heads/main') && (github.event.repo.name == 'discourse/discourse_docker')
         env:
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
         run: |


### PR DESCRIPTION
Print out compressed image sizes for amd64 images, in PRs, adds a step that prints a line such as:

`current slim: 676.45 release: 1007.99. new slim: 676.46 release: 1008.04`

making it easier to compare image sizes.

remove jobs from pushing on forks.

Remove jobs from scheduled jobs from running on forks