### PR TITLE
Imagemagick enable delegate build and disabled using shared libraries

### DIFF
--- a/image/base/Dockerfile
+++ b/image/base/Dockerfile
@@ -2,6 +2,21 @@
 # VERSION:  release
 
 ARG DEBIAN_RELEASE=bookworm
+FROM discourse/ruby:3.3.6-${DEBIAN_RELEASE}-slim AS builder
+RUN apt update && \
+DEBIAN_FRONTEND=noninteractive apt-get -y install wget \
+    autoconf build-essential \
+    git \
+    cmake \
+    gnupg \
+    libpcre3-dev \
+    libfreetype6-dev \
+    libbrotli-dev
+
+FROM builder AS imagemagick_builder
+ADD install-imagemagick /tmp/install-imagemagick
+RUN /tmp/install-imagemagick
+
 FROM discourse/ruby:3.3.6-${DEBIAN_RELEASE}-slim AS discourse_dependencies
 
 ARG DEBIAN_RELEASE
@@ -36,7 +51,13 @@ RUN --mount=type=tmpfs,target=/var/log \
     libreadline-dev anacron wget \
     psmisc whois brotli libunwind-dev \
     libtcmalloc-minimal4 cmake \
-    pngcrush pngquant ripgrep poppler-utils; \
+    pngcrush pngquant ripgrep poppler-utils \
+# imagemagick runtime dependencies
+    libheif1 libjbig0 libtiff6 libpng16-16 libfontconfig1 \
+    libwebpdemux2 libwebpmux3 libxext6 librsvg2-2 libgomp1 \
+    fonts-urw-base35 \
+# nginx compile dependencies \
+    libfreetype6-dev && \
 # install these without recommends to avoid pulling in e.g.
 # X11 libraries, mailutils
     DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends git rsyslog logrotate cron ssh-client less; \
@@ -70,8 +91,24 @@ RUN sed -i "s/^# $LANG/$LANG/" /etc/locale.gen; \
 RUN --mount=type=tmpfs,target=/root/.npm \
     npm install -g terser uglify-js pnpm
 
-ADD install-imagemagick /tmp/install-imagemagick
-RUN /tmp/install-imagemagick
+# Copy binary and configuration files for magick
+COPY --from=imagemagick_builder /usr/local/bin/magick /usr/local/bin/magick
+COPY --from=imagemagick_builder /usr/local/etc/ImageMagick-7 /usr/local/etc/ImageMagick-7
+COPY --from=imagemagick_builder /usr/local/share/ImageMagick-7 /usr/local/share/ImageMagick-7
+# Create symlinks to imagemagick tools
+RUN ln -s /usr/local/bin/magick /usr/local/bin/animate &&\
+  ln -s /usr/local/bin/magick /usr/local/bin/compare &&\
+  ln -s /usr/local/bin/magick /usr/local/bin/composite &&\
+  ln -s /usr/local/bin/magick /usr/local/bin/conjure &&\
+  ln -s /usr/local/bin/magick /usr/local/bin/convert &&\
+  ln -s /usr/local/bin/magick /usr/local/bin/display &&\
+  ln -s /usr/local/bin/magick /usr/local/bin/identify &&\
+  ln -s /usr/local/bin/magick /usr/local/bin/import &&\
+  ln -s /usr/local/bin/magick /usr/local/bin/magick-script &&\
+  ln -s /usr/local/bin/magick /usr/local/bin/mogrify &&\
+  ln -s /usr/local/bin/magick /usr/local/bin/montage &&\
+  ln -s /usr/local/bin/magick /usr/local/bin/stream &&\
+  test $(magick -version | grep -o -e png -e tiff -e jpeg -e freetype -e heic -e webp | wc -l) -eq 6
 
 ADD install-jemalloc /tmp/install-jemalloc
 RUN /tmp/install-jemalloc

--- a/image/base/install-imagemagick
+++ b/image/base/install-imagemagick
@@ -42,6 +42,8 @@ tar zxf $WDIR/ImageMagick.tar.gz -C $WDIR
 cd $IMDIR
 PKG_CONF_LIBDIR=$PREFIX/lib LDFLAGS=-L$PREFIX/lib CFLAGS='-O2 -I$PREFIX/include' ./configure \
           --prefix=$PREFIX \
+          --disable-shared \
+          --enable-delegate-build \
           --enable-static \
           --enable-bounds-checking \
           --enable-hdri \


### PR DESCRIPTION
compiles to a single portable binary

Create a base builder package with compile time dependencies. Create an imagemagick_builder to build imagemagick.

The base builder can be extended for other builders.

Add imagemagick runtime dependencies to discourse_dependencies image avoid -dev libs

Statically compile as much as possible with --disable-shared and --enable-delegate-build flags.
References:
https://stackoverflow.com/questions/47031789/imagemagick-100-static-build-for-linux https://www.imagemagick.org/discourse-server/viewtopic.php?t=14259

Add fonts-urw-base35 for NimbusSans-Regular, needed for letter avatar generation

Copy over the resulting magick bin, as well as etc and share files from the compilation. etc is needed for magick to run, share is not, but contains translations for errors which Discourse tests are dependent on reading from.

Create symlinks for other magick tooling - imagemagick creates symlink tool names that Discourse uses. These *could* be dropped if Discourse decided to use `magick {toolname}` rather than `{toolname}`.

Add nginx compile dependency - building nginx still needs libfreetype6 This was implicitly installed previously. Removing the imagemagick build from base broke the next nginx build. Add this dependency back in. This dependency can be removed once we build nginx separately as well.