### PR TITLE
DEV: Bump rust version to 1.82.0

### DIFF
--- a/image/base/install-rust
+++ b/image/base/install-rust
@@ -5,7 +5,7 @@ set -e
 export RUSTUP_HOME=/usr/local/rustup
 export CARGO_HOME=/usr/local/cargo
 export PATH=/usr/local/cargo/bin:$PATH
-export RUST_VERSION=1.75.0
+export RUST_VERSION=1.82.0
 export RUSTUP_VERSION=1.25.2
 
 dpkgArch="$(dpkg --print-architecture)"


### PR DESCRIPTION
This is to resolve an error we are seeing in our arm64 dev builds

```
24 49.46 error: package `apple-xar v0.20.0` cannot be built because it requires rustc 1.81 or newer, while the currently active rustc version is 1.75.0
24 49.46 Either upgrade to rustc 1.81 or newer, or use
```
