### PR TITLE
Remove updating of rubygems

### DIFF
--- a/image/base/Dockerfile
+++ b/image/base/Dockerfile
@@ -127,9 +127,6 @@ RUN /tmp/install-redis
 ADD install-oxipng /tmp/install-oxipng
 RUN /tmp/install-oxipng
 
-RUN echo 'gem: --no-document' >> /usr/local/etc/gemrc &&\
-    gem update --system
-
 RUN gem install pups --force &&\
     mkdir -p /pups/bin/ &&\
     ln -s /usr/local/bin/pups /pups/bin/pups


### PR DESCRIPTION
This adds an additional layer of 30mb for no reason. We don't need to be
running the latest version of rubygems all the time.

```
tgxworld ~/work/discourse_docker [skip_updating_ruby_gems] $ docker history --no-trunc discourse/base:release | grep 'gem update --system'
<missing>                                                                 5 hours ago    RUN |1 DEBIAN_RELEASE=bookworm /bin/sh -c echo 'gem: --no-document' >> /usr/local/etc/gemrc &&    gem update --system # buildkit                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                29.8MB    buildkit.dockerfile.v0
```

Even if we need to update rubygems, it should be updated in https://github.com/discourse/docker-ruby
