### PR TITLE
Print docker history summary in build actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,6 +102,10 @@ jobs:
         run: |
           docker images discourse/base
 
+      - name: Print `docker history` summary for main branch image
+        run: |
+          docker history discourse/base:2.0.${{ env.TIMESTAMP }}-main-${{ matrix.arch }}
+
       - name: Print compressed summary
         if: github.event_name == 'pull_request' && matrix.arch == 'amd64'
         run: |


### PR DESCRIPTION
It is useful to know what the size of each layer is after the image has
been built.
