### PR TITLE
FIX: set the Host header on the `upstream` block

### DIFF
--- a/templates/web.template.yml
+++ b/templates/web.template.yml
@@ -146,6 +146,7 @@ run:
       filename: "/etc/nginx/conf.d/discourse.conf"
       from: /upstream[^\}]+\}/m
       to: "upstream discourse {
+        set_header Host $http_host;
         server 127.0.0.1:3000;
       }"
 


### PR DESCRIPTION
Using e.g. `proxy_pass http://discourse` resets the Host header on the upstream
request to `discourse`.

This would break multisites, so we don't want that; the most effetive way to
ensure it's set properly is to `set_header` in the upstream block.
