### PR TITLE
Revert "FIX: Set the Host header in the nginx.conf upstream block"

### DIFF
--- a/templates/web.template.yml
+++ b/templates/web.template.yml
@@ -146,7 +146,6 @@ run:
       filename: "/etc/nginx/conf.d/discourse.conf"
       from: /upstream[^\}]+\}/m
       to: "upstream discourse {
-        set_header Host $http_host;
         server 127.0.0.1:3000;
       }"
 


### PR DESCRIPTION
This reverts commit d8a363b60e92fff3ba2338daa6cdb1b04bff3680.

Support for this was removed in nginx - I was unintentionally testing on an old version
