### PR TITLE
Remove `git reset --hard` command in web template to reduce layer size

### DIFF
--- a/templates/web.template.yml
+++ b/templates/web.template.yml
@@ -91,7 +91,6 @@ run:
       cd: $home
       hook: code
       cmd:
-        - sudo -H -E -u discourse git reset --hard
         - sudo -H -E -u discourse git clean -f
         # TODO Remove the special handling of shallow clones when everyone uses images without that clone type
         - |-


### PR DESCRIPTION
I noticed that use running `git reset --hard` results in ~133MB being
added to the final layer generated by `launcher bootstrap`. However, I
can not figure out why we would need to run `git reset --hard` at all.

Even if there is a reason to run `git reset --hard`, it should not be
the default. If someone for whatever reason needs to run `git reset
--hard`, they should do so using the `before_code` hook.

To replicate the problem, one can run the following steps:

1. In the `discourse_docker` repository, create a file named `containers/test.yml` with the following contents:

```
base_image: discourse/base:2.0.20241223-0016

run:
  - exec: sudo -H -E -u discourse bash -c "cd /var/www/discourse && git reset --hard"
```

2. Run `./launcher bootstrap test`
3. Run `docker history local_discourse/test` and see that the new layer created by `./launcher bootstrap` is roughly 133MB.

```
IMAGE          CREATED         CREATED BY                                      SIZE      COMMENT
012471f3c5e4   2 minutes ago   /bin/bash -c /usr/local/bin/pups --stdin        133MB
```