### PR TITLE
Move amd64 arch builds to self hosted runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,11 +27,10 @@ jobs:
           echo "timestamp=$timestamp" >> $GITHUB_OUTPUT
 
   base:
-    # `unbuntu-22.04-8core` for arch amd64 non-scheduled builds
-    # `unbuntu-22.04` for arch amd64 scheduled builds
+    # `debian-12` for amd64 builds
     # `unbuntu-22.04-8core-arm` for arch arm64 non-scheduled builds
     # `unbuntu-22.04-2core-arm` for arch arm64 scheduled builds
-    runs-on: ubuntu-22.04${{ ((github.event_name != 'schedule') && '-8core') || (( matrix.arch == 'arm64' && '-2core' ) || '') }}${{ (matrix.arch == 'arm64') && '-arm' || '' }}
+    runs-on: ${{ (matrix.arch == 'amd64' && 'debian-12') || (github.event_name == 'schedule' && 'ubuntu-22.04-2core-arm') || 'ubuntu-22.04-8core-arm' }}
     strategy:
       matrix:
         arch: [amd64, arm64]
@@ -48,6 +47,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 1
+
+      - name: Install Ruby
+        run: |
+          apt-get update && apt-get install -y ruby
 
       - name: build deps image
         working-directory: image


### PR DESCRIPTION
Our self hosted runners are cheaper and faster so we want to move to
them. Unfortunately, we do not have arm based runners so keep those on
Github hosted runners.
