### PR TITLE
Build images with PG 15 installed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,6 +73,12 @@ jobs:
         run: |
           ruby auto_build.rb base_release_main_${{ matrix.arch }}
 
+      # Temporarily build images with PG 15 so that we can ship the changes to the postgres templates in the same PR.
+      - name: build release images for `main` branch with PG 15
+        working-directory: image
+        run: |
+          ruby auto_build.rb base_release_main_${{ matrix.arch }}_pg_15
+
       - name: build release images for `stable` branch
         working-directory: image
         run: |
@@ -81,6 +87,7 @@ jobs:
       - name: tag release images
         run: |
           docker tag discourse/base:build_release_main_${{ matrix.arch }} discourse/base:2.0.${{ env.TIMESTAMP }}-main-${{ matrix.arch }}
+          docker tag discourse/base:build_release_main_${{ matrix.arch }}_pg_15 discourse/base:2.0.${{ env.TIMESTAMP }}-main-${{ matrix.arch }}-pg-15
           docker tag discourse/base:build_release_stable_${{ matrix.arch }} discourse/base:2.0.${{ env.TIMESTAMP }}-stable-${{ matrix.arch }}
 
       - name: build test_build image for `main` branch
@@ -129,6 +136,7 @@ jobs:
           docker login --username discoursebuild --password $DOCKERHUB_PASSWORD
           docker push discourse/base:2.0.${{ env.TIMESTAMP }}-slim-${{ matrix.arch }}
           docker push discourse/base:2.0.${{ env.TIMESTAMP }}-main-${{ matrix.arch }}
+          docker push discourse/base:2.0.${{ env.TIMESTAMP }}-main-${{ matrix.arch }}-pg-15
           docker push discourse/base:2.0.${{ env.TIMESTAMP }}-stable-${{ matrix.arch }}
           docker push discourse/discourse_dev:${{ env.TIMESTAMP }}-${{ matrix.arch }}
 
@@ -137,7 +145,6 @@ jobs:
         run: |
           docker tag discourse/base:2.0.${{ env.TIMESTAMP }}-main-${{ matrix.arch }} discourse/base:aarch64
           docker push discourse/base:aarch64
-
   push_multi_arch_manifests:
     runs-on: ubuntu-latest
     needs: [base, timestamp]
@@ -163,6 +170,11 @@ jobs:
           docker manifest create discourse/base:2.0.${{ env.TIMESTAMP }} \
             -a discourse/base:2.0.${{ env.TIMESTAMP }}-main-amd64 \
             -a discourse/base:2.0.${{ env.TIMESTAMP }}-main-arm64
+
+          # Full Discourse `main` branch timestamped with PG 15
+          docker manifest create discourse/base:2.0.${{ env.TIMESTAMP }}-15 \
+            -a discourse/base:2.0.${{ env.TIMESTAMP }}-main-amd64-pg-15 \
+            -a discourse/base:2.0.${{ env.TIMESTAMP }}-main-arm64-pg-15
 
           # Full Discourse `stable` branch timestamped
           docker manifest create discourse/base:2.0.${{ env.TIMESTAMP }}-stable \

--- a/image/auto_build.rb
+++ b/image/auto_build.rb
@@ -43,11 +43,25 @@ images = {
     extra_args: "--build-arg=\"DISCOURSE_BRANCH=main\" --target discourse_release",
     use_cache: true,
   },
+  base_release_main_amd64_pg_15: {
+    name: "base",
+    tag: "discourse/base:build_release_main_amd64_pg_15",
+    extra_args:
+      "--build-arg=\"DISCOURSE_BRANCH=main\" --target discourse_release --build-arg PG_MAJOR=15",
+    use_cache: true,
+  },
   base_release_main_arm64: {
     name: "base",
     tag: "discourse/base:build_release_main_arm64",
     extra_args:
       "--platform linux/arm64 --build-arg=\"DISCOURSE_BRANCH=main\" --target discourse_release",
+    use_cache: true,
+  },
+  base_release_main_arm64_pg_15: {
+    name: "base",
+    tag: "discourse/base:build_release_main_arm64_pg_15",
+    extra_args:
+      "--build-arg=\"DISCOURSE_BRANCH=main\" --target discourse_release --build-arg PG_MAJOR=15",
     use_cache: true,
   },
   base_release_stable_amd64: {

--- a/image/base/Dockerfile
+++ b/image/base/Dockerfile
@@ -28,7 +28,8 @@ RUN gpg --import /tmp/nginx_public_keys.key &&\
 FROM discourse/ruby:3.3.6-${DEBIAN_RELEASE}-slim AS discourse_dependencies
 
 ARG DEBIAN_RELEASE
-ENV PG_MAJOR=13 \
+ARG PG_MAJOR=13
+ENV PG_MAJOR=${PG_MAJOR} \
     RUBY_ALLOCATOR=/usr/lib/libjemalloc.so \
     LEFTHOOK=0 \
     DEBIAN_RELEASE=${DEBIAN_RELEASE}


### PR DESCRIPTION
This commit updates the build workflow to build and push an extra base Docker
image with PG 15 installed. The tag is not meant to be permanent and is
just meant to help us update our postgres templates to support PG 15
within the same commit.

The changes in this PR will be removed once our `discourse/base:release` ships with PG
15 by default.
