### PR TITLE
DEV: bump timeout for non-scheduled builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       matrix:
         arch: [amd64, arm64]
-    timeout-minutes: ${{ (github.event_name == 'schedule' && 90) || ((matrix.arch == 'arm64' && 45) || 30) }}
+    timeout-minutes: ${{ (github.event_name == 'schedule' && 90) || 45 }}
     needs: timestamp
     env:
       TIMESTAMP: ${{ needs.timestamp.outputs.timestamp }}


### PR DESCRIPTION
The most recent build timed out at 30 minutes. Bump timeout temporarily to get a gauge on how long self-hosted builds take (push to Dockerhub looks to be slower than Github-hosted runners).