### PR TITLE
Fix TLS in socketed template

### DIFF
--- a/templates/web.socketed.template.yml
+++ b/templates/web.socketed.template.yml
@@ -19,7 +19,7 @@ run:
        set_real_ip_from unix:;
   - replace:
      filename: "/etc/nginx/conf.d/discourse.conf"
-     from: /listen 443 ssl http2;/
+     from: /listen 443 ssl;/
      to: |
-       listen unix:/shared/nginx.https.sock ssl http2;
+       listen unix:/shared/nginx.https.sock ssl;
        set_real_ip_from unix:;


### PR DESCRIPTION
After 7d548ad4ae3022863262f485505a32df13df1983, the replacement pattern in web.socketed.template.yml no longer matches, making nginx.https.sock not exist.

As such, remove the `http2` field from the `listen` directive to match aforementioned commit.