### PR TITLE
DEV: Update ImageMagick to 7.1.1-43

### DIFF
--- a/image/base/install-imagemagick
+++ b/image/base/install-imagemagick
@@ -2,8 +2,8 @@
 set -e
 
 # version check: https://github.com/ImageMagick/ImageMagick/releases
-IMAGE_MAGICK_VERSION="7.1.0-62"
-IMAGE_MAGICK_HASH="d282117bc6d0e91ad1ad685d096623b96ed8e229f911c891d83277b350ef884a"
+IMAGE_MAGICK_VERSION="7.1.1-43"
+IMAGE_MAGICK_HASH="ceb972266b23dc7c1cfce0da5a7f0c9acfb4dc81f40eb542a49476fedbc2618f"
 
 LIBJPEGTURBO=$(cat /etc/issue | grep -qi Debian && echo 'libjpeg62-turbo libjpeg62-turbo-dev' || echo 'libjpeg-turbo8 libjpeg-turbo8-dev')
 


### PR DESCRIPTION
We could use a bump, after two years since the last one.