### PR TITLE
Bump default base image to discourse/base:2.0.20250129-0720

### DIFF
--- a/launcher
+++ b/launcher
@@ -92,7 +92,7 @@ kernel_min_version='4.4.0'
 config_file=containers/"$config".yml
 cidbootstrap=cids/"$config"_bootstrap.cid
 local_discourse=local_discourse
-image="discourse/base:2.0.20250127-0958-pg-15"
+image="discourse/base:2.0.20250129-0720"
 docker_path=`which docker.io 2> /dev/null || which docker`
 git_path=`which git`
 


### PR DESCRIPTION
Follow-up to d9c837c783b06ae33d949f9dc50db187ba3d6337