### PR TITLE
Revert "DEV: generate only en_us locales"

### DIFF
--- a/image/base/Dockerfile
+++ b/image/base/Dockerfile
@@ -50,7 +50,7 @@ RUN echo "deb http://deb.debian.org/debian ${DEBIAN_RELEASE}-backports main" > "
 
 RUN --mount=type=tmpfs,target=/var/log \
     echo "debconf debconf/frontend select Teletype" | debconf-set-selections; \
-    apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get -y install gnupg sudo curl fping locales \
+    apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get -y install gnupg sudo curl fping locales locales-all \
     ca-certificates rsync \
     cmake g++ pkg-config patch \
     libxslt-dev libcurl4-openssl-dev \
@@ -94,8 +94,6 @@ RUN --mount=type=tmpfs,target=/var/log \
 ENV LC_ALL=en_US.UTF-8
 ENV LANG=en_US.UTF-8
 ENV LANGUAGE=en_US.UTF-8
-RUN sed -i "s/^# $LANG/$LANG/" /etc/locale.gen; \
-    locale-gen
 
 RUN --mount=type=tmpfs,target=/root/.npm \
     npm install -g terser uglify-js pnpm

--- a/templates/postgres.13.template.yml
+++ b/templates/postgres.13.template.yml
@@ -53,7 +53,6 @@ run:
       contents: |
         #!/bin/bash -x
         sed -i "s/^# $LANG/$LANG/" /etc/locale.gen
-        locale-gen && update-locale
         mkdir -p /shared/postgres_run
         chown postgres:postgres /shared/postgres_run
         chmod 775 /shared/postgres_run

--- a/templates/postgres.15.template.yml
+++ b/templates/postgres.15.template.yml
@@ -51,7 +51,6 @@ run:
       contents: |
         #!/bin/bash
         sed -i "s/^# $LANG/$LANG/" /etc/locale.gen
-        locale-gen && update-locale
         mkdir -p /shared/postgres_run
         chown postgres:postgres /shared/postgres_run
         chmod 775 /shared/postgres_run

--- a/templates/postgres.template.yml
+++ b/templates/postgres.template.yml
@@ -51,7 +51,6 @@ run:
       contents: |
         #!/bin/bash
         sed -i "s/^# $LANG/$LANG/" /etc/locale.gen
-        locale-gen && update-locale
         mkdir -p /shared/postgres_run
         chown postgres:postgres /shared/postgres_run
         chmod 775 /shared/postgres_run


### PR DESCRIPTION
This commit reverts a1d8d0bbcb5a17f878573a154024a71c009a4fb9

There are too many reports of rebuilds breaking due to this change so
revert for now at the expense of a 10% larger compressed Docker image.
