### PR TITLE
FIX: attempt the postgresql update if a stale socket file exists

### DIFF
--- a/templates/postgres.template.yml
+++ b/templates/postgres.template.yml
@@ -50,6 +50,14 @@ run:
       chmod: "+x"
       contents: |
         #!/bin/bash
+        run_upgrade_postgres() {
+          if [ -f /root/upgrade_postgres ]; then
+            unset RETCODE
+            /root/upgrade_postgres || RETCODE=$?
+            [ -z "${RETCODE}" ] && rm /root/upgrade_postgres || exit $RETCODE
+          fi
+          exit 0
+        }
         sed -i "s/^# $LANG/$LANG/" /etc/locale.gen
         locale-gen && update-locale
         mkdir -p /shared/postgres_run
@@ -58,7 +66,7 @@ run:
         rm -fr /var/run/postgresql
         ln -s /shared/postgres_run /var/run/postgresql
         if [ -e /shared/postgres_run/.s.PGSQL.5432 ]; then
-          socat /dev/null UNIX-CONNECT:/shared/postgres_run/.s.PGSQL.5432 || exit 0 && echo postgres already running stop container ; exit 1
+          socat /dev/null UNIX-CONNECT:/shared/postgres_run/.s.PGSQL.5432 || run_upgrade_postgres && echo postgres already running stop container ; exit 1
         fi
         rm -fr /shared/postgres_run/.s*
         rm -fr /shared/postgres_run/*.pid
@@ -70,11 +78,8 @@ run:
           sudo -E -u postgres /usr/lib/postgresql/15/bin/initdb -D /shared/postgres_data
           chown -R postgres:postgres /shared/postgres_data
           chown -R postgres:postgres /var/run/postgresql
-        elif [ -f /root/upgrade_postgres ]; then
-          unset RETCODE
-          /root/upgrade_postgres || RETCODE=$?
-          [ -z "${RETCODE}" ] && rm /root/upgrade_postgres || exit $RETCODE
         fi
+        run_upgrade_postgres
         # Necessary to enable backups
         install -d -m 0755 -o postgres -g postgres /shared/postgres_backup
 


### PR DESCRIPTION
If there is a stale socket file when bumping the database version, the current workflow throws spurious errors because of [this line](https://github.com/discourse/discourse_docker/blob/ad89eb3b10dbfe14e33558a08722cdca07b3e28c/templates/postgres.template.yml#L61) in the `install_postgres` script:

> socat /dev/null UNIX-CONNECT:/shared/postgres_run/.s.PGSQL.5432 || exit 0 && echo postgres already running stop container ; exit 1

With this change:
* If postgres is still running, the current behaviour remains the same.
* If postgres was not shut down cleanly, pg_upgrade returns that error.
* If it's just a stale file, pg_upgrade should continue to run.