### PR TITLE
DEV: Force PNPM v9 to be installed.

### DIFF
--- a/image/base/Dockerfile
+++ b/image/base/Dockerfile
@@ -98,7 +98,7 @@ RUN sed -i "s/^# $LANG/$LANG/" /etc/locale.gen; \
     locale-gen
 
 RUN --mount=type=tmpfs,target=/root/.npm \
-    npm install -g terser uglify-js pnpm
+    npm install -g terser uglify-js pnpm@9
 
 COPY --from=nginx_builder /usr/sbin/nginx /usr/sbin
 


### PR DESCRIPTION
## ✨ What's This?

See: discourse/discourse#31156

Before upgrading PNPM to v10, we need to get Docker builds running again, so this PR forces PNPM v9 to be installed.