### PR TITLE
Update firefox tar format

### DIFF
--- a/image/discourse_test/Dockerfile
+++ b/image/discourse_test/Dockerfile
@@ -23,7 +23,7 @@ RUN /tmp/install-chrome &&\
     apt update &&\
     apt install -y libgconf-2-4 libxss1 firefox-esr &&\
     cd /tmp && wget -q "https://download.mozilla.org/?product=firefox-latest-ssl&os=linux64&lang=en-US" -O firefox.tar.xz &&\
-    tar xjvf firefox.tar.xz && mv /tmp/firefox /opt/firefox-evergreen &&\
+    tar xJvf firefox.tar.xz && mv /tmp/firefox /opt/firefox-evergreen &&\
     apt clean &&\
     rm /tmp/firefox.tar.xz
 

--- a/image/discourse_test/Dockerfile
+++ b/image/discourse_test/Dockerfile
@@ -22,10 +22,10 @@ ADD install-chrome /tmp/install-chrome
 RUN /tmp/install-chrome &&\
     apt update &&\
     apt install -y libgconf-2-4 libxss1 firefox-esr &&\
-    cd /tmp && wget -q "https://download.mozilla.org/?product=firefox-latest-ssl&os=linux64&lang=en-US" -O firefox.tar.bz2 &&\
-    tar xjvf firefox.tar.bz2 && mv /tmp/firefox /opt/firefox-evergreen &&\
+    cd /tmp && wget -q "https://download.mozilla.org/?product=firefox-latest-ssl&os=linux64&lang=en-US" -O firefox.tar.xz &&\
+    tar xjvf firefox.tar.xz && mv /tmp/firefox /opt/firefox-evergreen &&\
     apt clean &&\
-    rm /tmp/firefox.tar.bz2
+    rm /tmp/firefox.tar.xz
 
 FROM with_browsers AS release
 


### PR DESCRIPTION
Firefox started distributing `.tar.xz` instead of `.tar.bz2`