### PR TITLE
Bump default base image to 2.0.20250226-0128

### DIFF
--- a/launcher
+++ b/launcher
@@ -92,7 +92,7 @@ kernel_min_version='4.4.0'
 config_file=containers/"$config".yml
 cidbootstrap=cids/"$config"_bootstrap.cid
 local_discourse=local_discourse
-image="discourse/base:2.0.20250129-0720"
+image="discourse/base:2.0.20250226-0128"
 docker_path=`which docker.io 2> /dev/null || which docker`
 git_path=`which git`
 


### PR DESCRIPTION
Tag is from latest passing build at 
https://hub.docker.com/r/discourse/base/tags