### PR TITLE
Drop `pry` as default runtime console.

### DIFF
--- a/templates/web.template.yml
+++ b/templates/web.template.yml
@@ -240,13 +240,7 @@ run:
      chmod: +x
      contents: |
        #!/bin/bash
-       # If they requested a console, load pry instead
-       if [ "$*" == "c" -o "$*" == "console" ]
-       then
-        (cd /var/www/discourse && RAILS_ENV=production sudo -H -E -u discourse bundle exec pry -r ./config/environment)
-       else
-        (cd /var/www/discourse && RAILS_ENV=production sudo -H -E -u discourse bundle exec script/rails "$@")
-       fi
+       (cd /var/www/discourse && RAILS_ENV=production sudo -H -E -u discourse bundle exec script/rails "$@")
 
   - file:
      path: /usr/local/bin/rake


### PR DESCRIPTION
Using `pry` as the default runtime console in the production environment
is forcing us to account for it in Discourse core's codebase. In order
to avoid the additional complexity in Discourse core's codebase, we have
decided to drop `pry` as the default runtime console and rely on IRB
which is just as good these days. We will however be keeping the
dependency on `pry` around so those that would like to use it can start
it manually.
