### PR TITLE
Clarified SMTP-related comments in samples/standalone.yml

### DIFF
--- a/samples/standalone.yml
+++ b/samples/standalone.yml
@@ -61,15 +61,17 @@ env:
   DISCOURSE_DEVELOPER_EMAILS: 'me@example.com,you@example.com'
 
   ## TODO: The SMTP mail server used to validate new accounts and send notifications
-  # SMTP ADDRESS, username, and password are required
-  # WARNING the char '#' in SMTP password can cause problems!
+  # SMTP ADDRESS is required
+  # WARNING: SMTP password should be wrapped in quotes to avoid problems
   DISCOURSE_SMTP_ADDRESS: smtp.example.com
   #DISCOURSE_SMTP_PORT: 587
   DISCOURSE_SMTP_USER_NAME: user@example.com
-  DISCOURSE_SMTP_PASSWORD: pa$$word
-  #DISCOURSE_SMTP_ENABLE_START_TLS: true           # (optional, default true)
+  DISCOURSE_SMTP_PASSWORD: "pa$$word"
+  #DISCOURSE_SMTP_ENABLE_START_TLS: true           # (optional, default: true)
   #DISCOURSE_SMTP_DOMAIN: discourse.example.com    # (required by some providers)
   #DISCOURSE_NOTIFICATION_EMAIL: noreply@discourse.example.com    # (address to send notifications from)
+  #DISCOURSE_SMTP_OPENSSL_VERIFY_MODE: peer        # (optional, default: peer, valid values: none, peer, client_once, fail_if_no_peer_cert)
+  #DISCOURSE_SMTP_AUTHENTICATION: plain            # (default: plain, valid values: plain, login, cram_md5)
 
   ## If you added the Lets Encrypt template, uncomment below to get a free SSL certificate
   #LETSENCRYPT_ACCOUNT_EMAIL: me@example.com


### PR DESCRIPTION
The comments about SMTP config options were ambiguous and didn't cover all of the available options, so I added them and listed the defaults and valid options. This is just a small change and goes along with changes to the troubleshooting docs at [on Discourse Meta](https://meta.discourse.org/t/troubleshoot-email-on-a-new-discourse-install/16326) because I noticed some inconsistencies while setting up Discourse for the first time.