### PR TITLE
DEV: Update standalone.yml

### DIFF
--- a/samples/standalone.yml
+++ b/samples/standalone.yml
@@ -61,6 +61,15 @@ env:
   DISCOURSE_DEVELOPER_EMAILS: 'me@example.com,you@example.com'
 
   ## TODO: The SMTP mail server used to validate new accounts and send notifications
+  #
+  # Most SMTP providers will require an authenticated domain or authenticated email
+  # address to send emails.  Please ensure you have authenticated your sending domain
+  # (example.com) or sub-domain (discourse.example.com), and the DISCOURSE_NOTIFICATION_EMAIL
+  # address with your SMTP provider before registering new users to ensure email deliverability.  
+  #
+  # The `discourse-doctor` command can assist with testing your email configuration. 
+  # See: https://meta.discourse.org/t/troubleshoot-email-on-a-new-discourse-install
+  #
   # SMTP ADDRESS, username, and password are required
   # WARNING the char '#' in SMTP password can cause problems!
   DISCOURSE_SMTP_ADDRESS: smtp.example.com


### PR DESCRIPTION
Improve SMTP guidance in the config file

Updated the template advising that the sending domain or sub-domain and DISCOURSE_NOTIFICATION_EMAIL address should be authenticated with SMTP providers to ensure email delivery. 

Also provided a direct link to info on the `discourse-doctor` command that can assist with testing and debugging email configurations.