### PR TITLE
DEV: run pg_createcluster for old postgres version during update

### DIFF
--- a/templates/postgres.template.yml
+++ b/templates/postgres.template.yml
@@ -116,6 +116,7 @@ run:
          install -d -m 0755 -o postgres -g postgres /shared/postgres_data_new && sudo -u postgres /usr/lib/postgresql/15/bin/initdb -D /shared/postgres_data_new || exit 0
          apt-get update
          apt-get install -y postgresql-${PG_MAJOR_OLD} postgresql-${PG_MAJOR_OLD}-pgvector
+         pg_createcluster -u postgres --no-status ${PG_MAJOR_OLD} main
          chown -R postgres:postgres /var/lib/postgresql/15
          /etc/init.d/postgresql stop
          rm -fr /shared/postgres_data/postmaster.pid


### PR DESCRIPTION
We copy default configs for the old PG version during the update.

Upstream changes disabled main cluster creation for old PG versions if a newer one exists so the old configs are no longer generated.

To work around this, we can invoke pg_createcluster.

See https://salsa.debian.org/postgresql/postgresql-common/-/commit/d9139f7777a42a39b5b6fabbffc9f020fad4dce5