### PR TITLE
FIX: Setup swap when RAM <= 4GB

### DIFF
--- a/discourse-setup
+++ b/discourse-setup
@@ -193,11 +193,11 @@ check_disk_and_memory() {
     exit 1
   fi
 
-  if [ "$avail_mem" -le 2 ]; then
+  if [ "$avail_mem" -le 4 ]; then
     total_swap=`free -g --si | awk ' /Swap:/  {print $2} '`
 
     if [ "$total_swap" -lt 2 ]; then
-      echo "WARNING: Discourse requires at least 2GB of swap when running with 2GB of RAM"
+      echo "WARNING: Discourse requires at least 2GB of swap when running with 4GB of RAM"
       echo "or less. This system does not appear to have sufficient swap space."
       echo
       echo "Without sufficient swap space, your site may not work properly, and future"


### PR DESCRIPTION
User reports that Discourse needs swap when the server has 4GB ram nowadays

https://meta.discourse.org/t/discourse-launcher-failed-to-bootstrap/362293/5?u=falco