### PR TITLE
Fix web.socketed.template with outlets

### DIFF
--- a/templates/web.socketed.template.yml
+++ b/templates/web.socketed.template.yml
@@ -11,15 +11,19 @@ run:
      contents: |
         #!/bin/bash
         rm -rf /shared/nginx.http*.sock
-  - replace:
-     filename: "/etc/nginx/conf.d/outlets/server/10-http.conf"
-     from: /listen 80;(\nlisten \[::\]:80;)?/
-     to: |
-       listen unix:/shared/nginx.http.sock;
-       set_real_ip_from unix:;
-  - replace:
-     filename: "/etc/nginx/conf.d/outlets/server/20-https.conf"
-     from: /listen 443 ssl;(\nlisten \[::\]:443 ssl;)?/
-     to: |
-       listen unix:/shared/nginx.https.sock ssl;
-       set_real_ip_from unix:;
+
+hooks:
+  after_web:
+    - replace:
+       filename: "/etc/nginx/conf.d/outlets/server/10-http.conf"
+       from: /listen 80;(\nlisten \[::\]:80;)?/
+       to: |
+         listen unix:/shared/nginx.http.sock;
+         set_real_ip_from unix:;
+  after_ssl:
+    - replace:
+       filename: "/etc/nginx/conf.d/outlets/server/20-https.conf"
+       from: /listen 443 ssl;(\nlisten \[::\]:443 ssl;)?/
+       to: |
+         listen unix:/shared/nginx.https.sock ssl;
+         set_real_ip_from unix:;


### PR DESCRIPTION
The web.template creates `10-http.conf`. The web.ssl.template creates `20-https.conf` and removes `10-http.conf`. Hence only one of them exists which makes web.socketed.template fail trying to alter both. Use web and ssl hooks to alter `10-http.conf` and `20-https.conf` both only after they were created, and in case before they were removed.

~I did not test it yet, will do later today, but open the PR for general review already. The alternative would be to just use conditional or wildcard `sed` via `exec` block. But the benefit of the hooks is that the order in which templates are loaded does not matter, right?~ EDIT: Works perfectly