### PR TITLE
DEV: Move `RETRY_AND_LOG_FLAKY_TESTS` to correct location

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,6 @@ concurrency:
 
 env:
   BUILDKIT_PROGRESS: plain
-  DISCOURSE_TURBO_RSPEC_RETRY_AND_LOG_FLAKY_TESTS: true
 
 jobs:
   timestamp:
@@ -95,7 +94,7 @@ jobs:
 
       - name: run specs for `main` branch
         run: |
-          docker run --rm -e RUBY_ONLY=1 -e USE_TURBO=1 -e SKIP_PLUGINS=1 -e SKIP_LINT=1 discourse/discourse_test:build_${{ matrix.arch }}
+          docker run --rm -e RUBY_ONLY=1 -e USE_TURBO=1 -e SKIP_PLUGINS=1 -e SKIP_LINT=1 -e DISCOURSE_TURBO_RSPEC_RETRY_AND_LOG_FLAKY_TESTS=1 discourse/discourse_test:build_${{ matrix.arch }}
 
       - name: build & tag dev image for `main` branch
         working-directory: image


### PR DESCRIPTION
We need to set the env inside the docker container, not in the github runner