### PR TITLE
PERF: remove bundle cache on bundle install

### DIFF
--- a/templates/web.template.yml
+++ b/templates/web.template.yml
@@ -213,6 +213,8 @@ run:
       cmd:
         - su discourse -c 'bundle install --jobs $(($(nproc) - 1)) --retry 3'
         - su discourse -c 'bundle clean'
+        - su discourse -c 'find /var/www/discourse/vendor/bundle -name cache -not -path "*/gems/*" -type d -exec rm -rf {} +'
+        - su discourse -c 'find /var/www/discourse/vendor/bundle -name tmp -type d -exec rm -rf {} +'
 
   - exec:
       cd: $home


### PR DESCRIPTION
Mirror the way we're cleaning bundle cache from base build:

https://github.com/discourse/discourse_docker/blob/9ebce86fda3d9787d752de6311df15dcab9700f1/image/base/Dockerfile#L179-L180

This similarly removes the cache files in the web template.