### PR TITLE
DEV: always change postgres permissions on existing data directory

### DIFF
--- a/templates/postgres.template.yml
+++ b/templates/postgres.template.yml
@@ -77,9 +77,9 @@ run:
         if [ ! -e /shared/postgres_data ]; then
           install -d -m 0755 -o postgres -g postgres /shared/postgres_data
           sudo -E -u postgres /usr/lib/postgresql/15/bin/initdb -D /shared/postgres_data
-          chown -R postgres:postgres /shared/postgres_data
-          chown -R postgres:postgres /var/run/postgresql
         fi
+        find /shared/postgres_data \! -user postgres -exec chown postgres '{}' +
+        find /var/run/postgresql \! -user postgres -exec chown postgres '{}' +
         run_upgrade_postgres
         # Necessary to enable backups
         install -d -m 0755 -o postgres -g postgres /shared/postgres_backup


### PR DESCRIPTION
If permissions of the initial data directory get changed, the install script is unable to reset the permissions to the expected user.

The intent of the chown command is to ensure the permissions of the database and run directory are consistent and known. This allows it to do that on an existing data directory where this is more likely to occur.

This uses a more consistent find command by moving chown command under exec Do not rely on a file glob which can error on too many files.