### PR TITLE
Provide hint for discourse-staff-notes

### DIFF
--- a/launcher
+++ b/launcher
@@ -40,6 +40,7 @@ BUNDLED_PLUGINS=(
   "discourse-data-explorer"
   "discourse-post-voting"
   "discourse-user-notes"
+  "discourse-staff-notes" # old name for discourse-user-notes
   "discourse-assign"
   "discourse-subscriptions"
   "discourse-hcaptcha"


### PR DESCRIPTION
This is the old name for user-notes, so people might still have it in their app.yml