### PR TITLE
discourse-doctor: prevent others from reading sensitive log content

### DIFF
--- a/discourse-doctor
+++ b/discourse-doctor
@@ -307,6 +307,8 @@ clean_up_log_file() {
     echo "Replacing: $VAR"
     sed -i -e 's/'"$VAR"'\([=: ]\)\S*/'"$VAR"'\1REDACTED /g' $LOG_FILE
   done
+  # allow others to read the log for convenience, now that sensitive content has been redacted
+  chmod 0644 $LOG_FILE
 }
 
 print_done() {
@@ -348,6 +350,8 @@ print_done() {
 initialize_log_file() {
   rm -f $LOG_FILE
   touch $LOG_FILE
+  # prevent others from reading sensitive content from the log
+  chmod 0600 $LOG_FILE
   log DISCOURSE DOCTOR $(date)
   log -e "OS: $(uname -a)\n\n"
 }


### PR DESCRIPTION
The log file is world-readable until the script finished, while sensitive settings are written to it at the very start. If the container is not running, a rebuild is done, which can leave the file with sensitive content world-readable for quite a long time.

This commit makes the log file readable to root only, while the script is running, and applies default mode only after sensitive content has been reducted, for convenience and to remain a non-breaking change.

An alternative would be to redact sensitive content right after it was written, in the `get_discourse_config()` function, but it would require more code and sensitive content might be printed later as well if a rebuild is done.