### PR TITLE
discourse-doctor: support custom app names as CLI arg

### DIFF
--- a/discourse-doctor
+++ b/discourse-doctor
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 LOG_FILE="/tmp/discourse-debug.txt"
 WORKING_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+app_name="$1"
 
 log() {
   if [ "$1" == "-e" ]
@@ -237,8 +238,12 @@ check_email() {
 }
 
 get_yml_file() {
-  app_name=""
-  if [ -f containers/app.yml ]
+  if [ -n "$app_name" ] && [ -f "containers/$app_name.yml" ]
+  then
+    log "Using app name '$app_name' from command argument"
+    web_file="containers/$app_name.yml"
+    log "Found $web_file"
+  elif [ -f containers/app.yml ]
   then
     app_name="app"
     web_file=containers/$app_name.yml


### PR DESCRIPTION
While `launcher` allows to pass any container/app name as CLI argument, `discourse-doctor` does not, but support two hardcoded names only.

This commit adds support for custom names taken from first CLI argument. It is done in a non-breaking change. If the argument is empty, or the related YAML file does not exist, it continues to check for the two hardcoded names like before.

______________

E.g. we use `discourse.yml`, and I was intuitively trying `discourse-doctor discourse`, then `discourse-doctor discourse.yml` and `discourse-doctor container/discourse.yml`, before checking the code, and realizing that it really checks for two hardcoded names only. Maybe others who use custom container names might expect the same, given that `launcher rebuild/enter/...` all take the container name from CLI arg. But of course I can add some help output for documentation purpose if wanted. Also I was thinking about looping through all actually existing `container/*.yml` files, offering a `read -p` selection, or taking the only one automatically (if there is one only). But keeping it simple for now, not adding any functional change as long as the argument does not really match an existing YAML file.