### PR TITLE
FIX: improve postgres upgrade reliability

### DIFF
--- a/templates/postgres.15.template.yml
+++ b/templates/postgres.15.template.yml
@@ -132,8 +132,10 @@ run:
            exit 1
          fi
 
-         mv /shared/postgres_data /shared/postgres_data_old
-         mv /shared/postgres_data_new /shared/postgres_data
+         mkdir /shared/postgres_data_old
+         mv /shared/postgres_data/* /shared/postgres_data_old
+         mv /shared/postgres_data_new/* /shared/postgres_data
+         rmdir /shared/postgres_data_new
 
          echo -------------------------------------------------------------------------------------
          echo UPGRADE OF POSTGRES COMPLETE

--- a/templates/postgres.template.yml
+++ b/templates/postgres.template.yml
@@ -139,8 +139,10 @@ run:
            exit 1
          fi
 
-         mv /shared/postgres_data /shared/postgres_data_old
-         mv /shared/postgres_data_new /shared/postgres_data
+         mkdir /shared/postgres_data_old
+         mv /shared/postgres_data/* /shared/postgres_data_old
+         mv /shared/postgres_data_new/* /shared/postgres_data
+         rmdir /shared/postgres_data_new
 
          echo -------------------------------------------------------------------------------------
          echo UPGRADE OF POSTGRES COMPLETE


### PR DESCRIPTION
On some systems the /shared/postgres_data directory might be a mount point, so in order to avoid failure in this scenario, move the postgres data files directly instead of manipulating the data directory.

see https://meta.discourse.org/t/infinite-loop-during-postgres-upgrade/91767/8?u=lavamind