### PR TITLE
Reapply "DEV: re-split build vs compile (#878)" (#990)

### DIFF
--- a/templates/web.template.yml
+++ b/templates/web.template.yml
@@ -234,13 +234,13 @@ run:
       tag: build
       hook: assets_precompile_build
       cmd:
-        - su discourse -c 'bundle exec rake assets:precompile:build'
+        - su discourse -c 'SKIP_DB_AND_REDIS=1 bundle exec rake assets:precompile'
   - exec:
       cd: $home
       tag: precompile
       hook: assets_precompile
       cmd:
-        - su discourse -c 'SKIP_EMBER_CLI_COMPILE=1 bundle exec rake themes:update assets:precompile'
+        - su discourse -c 'bundle exec rake themes:update maxminddb:refresh assets:precompile:css'
 
   - replace:
       tag: precompile


### PR DESCRIPTION
Allow for assets to be precompiled fully in a build image.

The only remaining things for configure is update themes, maxmind download, and css compiling.

This reverts commit 661f61a0d3359262e79c657784a3b45abb9f72d0.