### PR TITLE
letsencrypt updates: renew location for .well-known, add support for multiple hostnames

### DIFF
--- a/templates/web.letsencrypt.ssl.template.yml
+++ b/templates/web.letsencrypt.ssl.template.yml
@@ -40,7 +40,6 @@ run:
 
         events {
           worker_connections 768;
-          # multi_accept on;
         }
 
         http {

--- a/templates/web.letsencrypt.ssl.template.yml
+++ b/templates/web.letsencrypt.ssl.template.yml
@@ -69,7 +69,6 @@ run:
           sed -i 's/listen 80;/listen 80;\nlisten [::]:80;/g' /etc/nginx/letsencrypt.conf
         fi
 
-
         sed -Ei "s/^#?ACCOUNT_EMAIL=.+/ACCOUNT_EMAIL=${LETSENCRYPT_ACCOUNT_EMAIL}/" \
           /shared/letsencrypt/account.conf
 

--- a/templates/web.letsencrypt.ssl.template.yml
+++ b/templates/web.letsencrypt.ssl.template.yml
@@ -90,10 +90,10 @@ run:
         /usr/sbin/nginx -c /etc/nginx/letsencrypt.conf
 
         extra_domains() {
-        if [ -n "$DISCOURSE_HOSTNAME_ALIASES" ]; then
-          domains=$(echo $DISCOURSE_HOSTNAME_ALIASES | sed "s/,/ -d /g")
-          echo "-d $domains"
-        fi
+          if [ -n "$DISCOURSE_HOSTNAME_ALIASES" ]; then
+            domains=$(echo $DISCOURSE_HOSTNAME_ALIASES | sed "s/,/ -d /g")
+            echo "-d $domains"
+          fi
         }
 
         issue_cert() {

--- a/templates/web.letsencrypt.ssl.template.yml
+++ b/templates/web.letsencrypt.ssl.template.yml
@@ -19,6 +19,20 @@ run:
         LE_WORKING_DIR="${LETSENCRYPT_DIR}" ./acme.sh --upgrade --auto-upgrade
         LE_WORKING_DIR="${LETSENCRYPT_DIR}" ./acme.sh --set-default-ca  --server  letsencrypt
 
+        cat << EOF > /etc/nginx/conf.d/outlets/before-server/20-redirect-http-to-https.conf
+        server {
+          listen 80;
+
+          location ~ /.well-known {
+            root /var/www/discourse/public;
+            allow all;
+          }
+          location / {
+            return 301 https://${DISCOURSE_HOSTNAME}$request_uri;
+          }
+        }
+        EOF
+
         cat << EOF > /etc/nginx/letsencrypt.conf
         user www-data;
         worker_processes auto;
@@ -41,7 +55,6 @@ run:
 
           server {
             listen 80;
-            listen [::]:80;
 
             location ~ /.well-known {
               root /var/www/discourse/public;
@@ -50,6 +63,12 @@ run:
           }
         }
         EOF
+
+        if [ -f "/proc/net/if_inet6" ] ; then
+          sed -i 's/listen 80;/listen 80;\nlisten [::]:80;/g' /etc/nginx/conf.d/outlets/before-server/20-redirect-http-to-https.conf
+          sed -i 's/listen 80;/listen 80;\nlisten [::]:80;/g' /etc/nginx/letsencrypt.conf
+        fi
+
 
         sed -Ei "s/^#?ACCOUNT_EMAIL=.+/ACCOUNT_EMAIL=${LETSENCRYPT_ACCOUNT_EMAIL}/" \
           /shared/letsencrypt/account.conf
@@ -71,8 +90,15 @@ run:
         LETSENCRYPT_DIR="/shared/letsencrypt"
         /usr/sbin/nginx -c /etc/nginx/letsencrypt.conf
 
+        extra_domains() {
+        if [ -n "$DISCOURSE_HOSTNAME_ALIASES" ]; then
+          domains=$(echo $DISCOURSE_HOSTNAME_ALIASES | sed "s/,/ -d /g")
+          echo "-d $domains"
+        fi
+        }
+
         issue_cert() {
-          LE_WORKING_DIR="${LETSENCRYPT_DIR}" ${LETSENCRYPT_DIR}/acme.sh --issue $2 -d ${DISCOURSE_HOSTNAME} --keylength $1 -w /var/www/discourse/public
+          LE_WORKING_DIR="${LETSENCRYPT_DIR}" ${LETSENCRYPT_DIR}/acme.sh --issue $2 -d ${DISCOURSE_HOSTNAME} $(extra_domains) --keylength $1 -w /var/www/discourse/public
         }
 
         cert_exists() {

--- a/templates/web.letsencrypt.ssl.template.yml
+++ b/templates/web.letsencrypt.ssl.template.yml
@@ -19,20 +19,6 @@ run:
         LE_WORKING_DIR="${LETSENCRYPT_DIR}" ./acme.sh --upgrade --auto-upgrade
         LE_WORKING_DIR="${LETSENCRYPT_DIR}" ./acme.sh --set-default-ca  --server  letsencrypt
 
-        cat << EOF > /etc/nginx/conf.d/outlets/before-server/20-redirect-http-to-https.conf
-        server {
-          listen 80;
-
-          location ~ /.well-known {
-            root /var/www/discourse/public;
-            allow all;
-          }
-          location / {
-            return 301 https://${DISCOURSE_HOSTNAME}$request_uri;
-          }
-        }
-        EOF
-
         cat << EOF > /etc/nginx/letsencrypt.conf
         user www-data;
         worker_processes auto;
@@ -54,6 +40,7 @@ run:
 
           server {
             listen 80;
+            listen [::]:80;
 
             location ~ /.well-known {
               root /var/www/discourse/public;
@@ -62,11 +49,6 @@ run:
           }
         }
         EOF
-
-        if [ -f "/proc/net/if_inet6" ] ; then
-          sed -i 's/listen 80;/listen 80;\nlisten [::]:80;/g' /etc/nginx/conf.d/outlets/before-server/20-redirect-http-to-https.conf
-          sed -i 's/listen 80;/listen 80;\nlisten [::]:80;/g' /etc/nginx/letsencrypt.conf
-        fi
 
         sed -Ei "s/^#?ACCOUNT_EMAIL=.+/ACCOUNT_EMAIL=${LETSENCRYPT_ACCOUNT_EMAIL}/" \
           /shared/letsencrypt/account.conf

--- a/templates/web.ssl.template.yml
+++ b/templates/web.ssl.template.yml
@@ -27,6 +27,13 @@ run:
         cat << EOF > /etc/nginx/conf.d/outlets/before-server/20-redirect-http-to-https.conf
         server {
           listen 80;
+          listen [::]:80;
+
+          location ~ /.well-known {
+            root /var/www/discourse/public;
+            allow all;
+          }
+
           return 301 https://${DISCOURSE_HOSTNAME}$request_uri;
         }
         EOF
@@ -35,6 +42,7 @@ run:
 
         cat << EOF > /etc/nginx/conf.d/outlets/server/20-https.conf
         listen 443 ssl;
+        listen [::]:443 ssl;
         http2 on;
 
         ssl_protocols TLSv1.2 TLSv1.3;
@@ -58,8 +66,3 @@ run:
         cat << EOF > /etc/nginx/conf.d/outlets/discourse/20-https.conf
         add_header Strict-Transport-Security 'max-age=31536000';
         EOF
-
-        if [ -f "/proc/net/if_inet6" ] ; then
-          sed -i 's/listen 80;/listen 80;\nlisten [::]:80;/g' /etc/nginx/conf.d/outlets/before-server/20-redirect-http-to-https.conf
-          sed -i 's/listen 443 ssl;/listen 443 ssl;\nlisten [::]:443 ssl;/g' /etc/nginx/conf.d/outlets/server/20-https.conf
-        fi


### PR DESCRIPTION
add comma-separated DISCOURSE_HOSTNAME_ALIASES to handle multiple aliases
for letsencrypt domain generation over env vars

FIX: add letsencrypt renew location for .well-known and allow for multi-domain renewal
Do not redirect to https on .well-known location for any domain
so letsencrypt cert renewals can work properly.

FIX: better listening for ipv6 for ipv4 only
Current letsencrypt assumes ipv6 in config. Check for ipv6 before listening