### PR TITLE
FIX: include postgres and redis on test images

### DIFF
--- a/image/discourse_test/Dockerfile
+++ b/image/discourse_test/Dockerfile
@@ -10,6 +10,12 @@ ENV LANG en_US.UTF-8
 RUN sudo -E -u discourse -H git config --global user.email "you@example.com" &&\
     sudo -E -u discourse -H git config --global user.name "Your Name"
 
+# Include postgres and redis on test images
+RUN --mount=type=tmpfs,target=/var/log \
+  apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
+  postgresql-${PG_MAJOR} postgresql-contrib-${PG_MAJOR} postgresql-${PG_MAJOR}-pgvector
+RUN /tmp/install-redis
+
 RUN chown -R discourse . &&\
     chown -R discourse /var/run/postgresql &&\
     bundle config unset deployment &&\


### PR DESCRIPTION
Postgres and redis are no longer included by default on the slim image.
Include an install step on the discourse_test images to install them as well.

Followup from #966