### PR TITLE
Separate builders for build tools, drop some unused library dependencies

### DIFF
--- a/image/auto_build.rb
+++ b/image/auto_build.rb
@@ -5,12 +5,12 @@ images = {
   base_deps_amd64: {
     name: 'base',
     tag: 'discourse/base:build_deps_amd64',
-    extra_args: '--target discourse-dependencies'
+    extra_args: '--target discourse-build-base'
   },
   base_deps_arm64: {
     name: 'base',
     tag: 'discourse/base:build_deps_arm64',
-    extra_args: '--platform linux/arm64 --target discourse-dependencies'
+    extra_args: '--platform linux/arm64 --target discourse-build-base'
   },
   base_slim_main_amd64: {
     name: 'base',
@@ -21,8 +21,7 @@ images = {
   base_slim_stable_amd64: {
     name: 'base',
     tag: 'discourse/base:build_slim_main_amd64',
-    extra_args:
-      '--target discourse-slim --build-arg="DISCOURSE_BRANCH=stable"',
+    extra_args: '--target discourse-slim --build-arg="DISCOURSE_BRANCH=stable"',
     use_cache: true
   },
   base_slim_main_arm64: {

--- a/image/auto_build.rb
+++ b/image/auto_build.rb
@@ -1,128 +1,134 @@
-require "pty"
-require "optparse"
+require 'pty'
+require 'optparse'
 
 images = {
   base_deps_amd64: {
-    name: "base",
-    tag: "discourse/base:build_deps_amd64",
-    extra_args: "--target discourse_dependencies",
+    name: 'base',
+    tag: 'discourse/base:build_deps_amd64',
+    extra_args: '--target discourse-dependencies'
   },
   base_deps_arm64: {
-    name: "base",
-    tag: "discourse/base:build_deps_arm64",
-    extra_args: "--platform linux/arm64 --target discourse_dependencies",
+    name: 'base',
+    tag: 'discourse/base:build_deps_arm64',
+    extra_args: '--platform linux/arm64 --target discourse-dependencies'
   },
   base_slim_main_amd64: {
-    name: "base",
-    tag: "discourse/base:build_slim_main_amd64",
-    extra_args: "--target discourse_slim",
-    use_cache: true,
+    name: 'base',
+    tag: 'discourse/base:build_slim_main_amd64',
+    extra_args: '--target discourse-slim',
+    use_cache: true
   },
   base_slim_stable_amd64: {
-    name: "base",
-    tag: "discourse/base:build_slim_main_amd64",
-    extra_args: "--target discourse_slim --build-arg=\"DISCOURSE_BRANCH=stable\"",
-    use_cache: true,
+    name: 'base',
+    tag: 'discourse/base:build_slim_main_amd64',
+    extra_args:
+      '--target discourse-slim --build-arg="DISCOURSE_BRANCH=stable"',
+    use_cache: true
   },
   base_slim_main_arm64: {
-    name: "base",
-    tag: "discourse/base:build_slim_main_arm64",
-    extra_args: "--platform linux/arm64 --target discourse_slim",
-    use_cache: true,
+    name: 'base',
+    tag: 'discourse/base:build_slim_main_arm64',
+    extra_args: '--platform linux/arm64 --target discourse-slim',
+    use_cache: true
   },
   base_slim_stable_arm64: {
-    name: "base",
-    tag: "discourse/base:build_slim_stable_arm64",
+    name: 'base',
+    tag: 'discourse/base:build_slim_stable_arm64',
     extra_args:
-      "--platform linux/arm64 --target discourse_slim --build-arg=\"DISCOURSE_BRANCH=stable\"",
-    use_cache: true,
+      '--platform linux/arm64 --target discourse-slim --build-arg="DISCOURSE_BRANCH=stable"',
+    use_cache: true
   },
   base_web_only_main_amd64: {
-    name: "base",
-    tag: "discourse/base:build_web_only_main_amd64",
-    extra_args: "--target discourse_web_only",
-    use_cache: true,
+    name: 'base',
+    tag: 'discourse/base:build_web_only_main_amd64',
+    extra_args: '--target discourse-web-only',
+    use_cache: true
   },
   base_web_only_stable_amd64: {
-    name: "base",
-    tag: "discourse/base:build_web_only_stable_amd64",
-    extra_args: "--target discourse_web_only --build-arg=\"DISCOURSE_BRANCH=stable\"",
-    use_cache: true,
+    name: 'base',
+    tag: 'discourse/base:build_web_only_stable_amd64',
+    extra_args:
+      '--target discourse-web-only --build-arg="DISCOURSE_BRANCH=stable"',
+    use_cache: true
   },
   base_web_only_main_arm64: {
-    name: "base",
-    tag: "discourse/base:build_web_only_main_arm64",
-    extra_args: "--platform linux/arm64 --target discourse_web_only",
-    use_cache: true,
+    name: 'base',
+    tag: 'discourse/base:build_web_only_main_arm64',
+    extra_args: '--platform linux/arm64 --target discourse-web-only',
+    use_cache: true
   },
   base_web_only_stable_arm64: {
-    name: "base",
-    tag: "discourse/base:build_web_only_stable_arm64",
+    name: 'base',
+    tag: 'discourse/base:build_web_only_stable_arm64',
     extra_args:
-      "--platform linux/arm64 --target discourse_web_only --build-arg=\"DISCOURSE_BRANCH=stable\"",
-    use_cache: true,
+      '--platform linux/arm64 --target discourse-web-only --build-arg="DISCOURSE_BRANCH=stable"',
+    use_cache: true
   },
   base_release_main_amd64: {
-    name: "base",
-    tag: "discourse/base:build_release_main_amd64",
-    extra_args: "--build-arg=\"DISCOURSE_BRANCH=main\" --target discourse_release",
-    use_cache: true,
+    name: 'base',
+    tag: 'discourse/base:build_release_main_amd64',
+    extra_args:
+      '--build-arg="DISCOURSE_BRANCH=main" --target discourse-release',
+    use_cache: true
   },
   base_release_main_arm64: {
-    name: "base",
-    tag: "discourse/base:build_release_main_arm64",
+    name: 'base',
+    tag: 'discourse/base:build_release_main_arm64',
     extra_args:
-      "--platform linux/arm64 --build-arg=\"DISCOURSE_BRANCH=main\" --target discourse_release",
-    use_cache: true,
+      '--platform linux/arm64 --build-arg="DISCOURSE_BRANCH=main" --target discourse-release',
+    use_cache: true
   },
   base_release_stable_amd64: {
-    name: "base",
-    tag: "discourse/base:build_release_stable_amd64",
-    extra_args: "--build-arg=\"DISCOURSE_BRANCH=stable\" --target discourse_release",
-    use_cache: true,
+    name: 'base',
+    tag: 'discourse/base:build_release_stable_amd64',
+    extra_args:
+      '--build-arg="DISCOURSE_BRANCH=stable" --target discourse-release',
+    use_cache: true
   },
   base_release_stable_arm64: {
-    name: "base",
-    tag: "discourse/base:build_release_stable_arm64",
+    name: 'base',
+    tag: 'discourse/base:build_release_stable_arm64',
     extra_args:
-      "--platform linux/arm64 --build-arg=\"DISCOURSE_BRANCH=stable\" --target discourse_release",
-    use_cache: true,
+      '--platform linux/arm64 --build-arg="DISCOURSE_BRANCH=stable" --target discourse-release',
+    use_cache: true
   },
   discourse_test_build_amd64: {
-    name: "discourse_test",
-    tag: "discourse/discourse_test:build_amd64",
-    extra_args: "--build-arg=\"from_tag=build_release_main_amd64\"",
+    name: 'discourse_test',
+    tag: 'discourse/discourse_test:build_amd64',
+    extra_args: '--build-arg="from_tag=build_release_main_amd64"'
   },
   discourse_test_build_arm64: {
-    name: "discourse_test",
-    tag: "discourse/discourse_test:build_arm64",
-    extra_args: "--platform linux/arm64 --build-arg=\"from_tag=build_release_main_arm64\"",
+    name: 'discourse_test',
+    tag: 'discourse/discourse_test:build_arm64',
+    extra_args:
+      '--platform linux/arm64 --build-arg="from_tag=build_release_main_arm64"'
   },
   discourse_dev_amd64: {
-    name: "discourse_dev",
-    tag: "discourse/discourse_dev:build_amd64",
-    extra_args: "--build-arg=\"from_tag=build_slim_main_amd64\"",
+    name: 'discourse_dev',
+    tag: 'discourse/discourse_dev:build_amd64',
+    extra_args: '--build-arg="from_tag=build_slim_main_amd64"'
   },
   discourse_dev_arm64: {
-    name: "discourse_dev",
-    tag: "discourse/discourse_dev:build_arm64",
-    extra_args: "--platform linux/arm64 --build-arg=\"from_tag=build_slim_main_arm64\"",
+    name: 'discourse_dev',
+    tag: 'discourse/discourse_dev:build_arm64',
+    extra_args:
+      '--platform linux/arm64 --build-arg="from_tag=build_slim_main_arm64"'
   },
   setup_wizard_amd64: {
-    name: "setup_wizard",
-    tag: "discourse/setup-wizard:build_amd64",
-    extra_args: "",
+    name: 'setup_wizard',
+    tag: 'discourse/setup-wizard:build_amd64',
+    extra_args: ''
   },
   setup_wizard_arm64: {
-    name: "setup_wizard",
-    tag: "discourse/setup-wizard:build_arm64",
-    extra_args: "--platform linux/arm64",
-  },
+    name: 'setup_wizard',
+    tag: 'discourse/setup-wizard:build_arm64',
+    extra_args: '--platform linux/arm64'
+  }
 }
 
 def run(command)
   lines = []
-  PTY.spawn(command) do |stdout, stdin, pid|
+  PTY.spawn(command) do |stdout, _stdin, pid|
     begin
       stdout.each do |line|
         lines << line
@@ -142,19 +148,19 @@ end
 def build(image, cli_args)
   lines =
     run(
-      "cd #{image[:name]} && docker buildx build . --load #{image[:use_cache] == true ? "" : "--no-cache"} --tag #{image[:tag]} #{image[:extra_args] ? image[:extra_args] : ""} #{cli_args}",
+      "cd #{image[:name]} && docker buildx build . --load #{image[:use_cache] == true ? '' : '--no-cache'} --tag #{image[:tag]} #{image[:extra_args] || ''} #{cli_args}"
     )
 
-  if lines[-1] =~ /successfully built/
-    raise "Error building the image for #{image[:name]}: #{lines[-1]}"
-  end
+  return unless lines[-1] =~ /successfully built/
+
+  raise "Error building the image for #{image[:name]}: #{lines[-1]}"
 end
 
-def dev_deps()
+def dev_deps
   run(
-    "sed -e 's/\(db_name: discourse\)/\1_development/' ../templates/postgres.template.yml > discourse_dev/postgres.template.yml",
+    "sed -e 's/\(db_name: discourse\)/\1_development/' ../templates/postgres.template.yml > discourse_dev/postgres.template.yml"
   )
-  run("cp ../templates/redis.template.yml discourse_dev/redis.template.yml")
+  run('cp ../templates/redis.template.yml discourse_dev/redis.template.yml')
 end
 
 if ARGV.length == 0
@@ -163,19 +169,19 @@ if ARGV.length == 0
     ruby auto_build.rb IMAGE
 
     Available images:
-    #{images.keys.join(", ")}
+    #{images.keys.join(', ')}
   TEXT
   exit 1
 else
   image = ARGV[0].to_sym
 
-  if !images.include?(image)
-    $stderr.puts "Image not found"
+  unless images.include?(image)
+    warn 'Image not found'
     exit 1
   end
 
   puts "Building #{images[image]}"
-  dev_deps() if image == :discourse_dev_amd64 || image == :discourse_dev_arm64
+  dev_deps if %i[discourse_dev_amd64 discourse_dev_arm64].include?(image)
 
-  build(images[image], ARGV[1..-1].join(" "))
+  build(images[image], ARGV[1..-1].join(' '))
 end

--- a/image/base/Dockerfile
+++ b/image/base/Dockerfile
@@ -78,13 +78,14 @@ RUN --mount=type=tmpfs,target=/var/log \
     cmake g++ pkg-config patch \
     libxslt-dev libcurl4-openssl-dev \
     libssl-dev libyaml-dev libtool \
-    libpcre3 libpcre3-dev zlib1g zlib1g-dev \
     libxml2-dev gawk \
     libreadline-dev anacron wget \
     psmisc whois brotli libunwind-dev \
     libtcmalloc-minimal4 cmake \
     pngcrush pngquant ripgrep poppler-utils \
     catdoc antiword \
+# nginx runtime dependencies
+    libpcre3 zlib1g \
 # imagemagick runtime dependencies
     ghostscript libjbig0 libtiff6 libpng16-16 libfontconfig1 \
     libwebpdemux2 libwebpmux3 libxext6 librsvg2-2 libgomp1 \

--- a/image/base/Dockerfile
+++ b/image/base/Dockerfile
@@ -77,7 +77,7 @@ RUN --mount=type=tmpfs,target=/var/log \
     libxslt-dev libcurl4-openssl-dev \
     libssl-dev libyaml-dev libtool \
     libpcre3 libpcre3-dev zlib1g zlib1g-dev \
-    libxml2-dev gawk parallel \
+    libxml2-dev gawk \
     libreadline-dev anacron wget \
     psmisc whois brotli libunwind-dev \
     libtcmalloc-minimal4 cmake \

--- a/image/base/Dockerfile
+++ b/image/base/Dockerfile
@@ -81,7 +81,6 @@ RUN --mount=type=tmpfs,target=/var/log \
     libxml2-dev gawk \
     libreadline-dev anacron wget \
     psmisc whois brotli libunwind-dev \
-    libtcmalloc-minimal4 cmake \
     pngcrush pngquant ripgrep poppler-utils \
     catdoc antiword \
 # nginx runtime dependencies

--- a/image/base/Dockerfile
+++ b/image/base/Dockerfile
@@ -73,16 +73,23 @@ RUN --mount=type=tmpfs,target=/var/log \
   --mount=type=tmpfs,target=/var/cache/apt \
   --mount=type=tmpfs,target=/var/lib/apt \
     echo "debconf debconf/frontend select Teletype" | debconf-set-selections; \
-    apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get -y install gnupg sudo curl fping locales \
+    apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
+    gnupg sudo curl fping locales \
     ca-certificates rsync \
-    cmake g++ pkg-config patch \
-    libxslt-dev libcurl4-openssl-dev \
-    libssl-dev libyaml-dev libtool \
-    libxml2-dev gawk \
-    libreadline-dev anacron wget \
-    psmisc whois brotli libunwind-dev \
+    gawk anacron wget \
+    psmisc whois brotli \
     pngcrush pngquant ripgrep poppler-utils \
     catdoc antiword \
+# gem build dependencies
+    cmake g++ pkg-config patch \
+    libtool \
+    libxslt-dev \
+    libcurl4-openssl-dev \
+    libssl-dev \
+    libyaml-dev \
+    libxml2-dev \
+    libreadline-dev \
+    libunwind-dev \
 # nginx runtime dependencies
     libpcre3 zlib1g \
 # imagemagick runtime dependencies

--- a/image/base/Dockerfile
+++ b/image/base/Dockerfile
@@ -70,6 +70,8 @@ RUN echo 2.0.`date +%Y%m%d` > /VERSION
 RUN echo "deb http://deb.debian.org/debian ${DEBIAN_RELEASE}-backports main" > "/etc/apt/sources.list.d/${DEBIAN_RELEASE}-backports.list"
 
 RUN --mount=type=tmpfs,target=/var/log \
+  --mount=type=tmpfs,target=/var/cache/apt \
+  --mount=type=tmpfs,target=/var/lib/apt \
     echo "debconf debconf/frontend select Teletype" | debconf-set-selections; \
     apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get -y install gnupg sudo curl fping locales \
     ca-certificates rsync \

--- a/image/base/Dockerfile
+++ b/image/base/Dockerfile
@@ -28,8 +28,23 @@ FROM builder AS nginx_builder
 ADD nginx_public_keys.key /tmp/nginx_public_keys.key
 ADD install-nginx /tmp/install-nginx
 RUN gpg --import /tmp/nginx_public_keys.key &&\
-    rm /tmp/nginx_public_keys.key &&\
-    /tmp/install-nginx
+  rm /tmp/nginx_public_keys.key &&\
+  /tmp/install-nginx
+
+FROM builder AS thpoff_builder
+# This tool allows us to disable huge page support for our current process
+# since the flag is preserved through forks and execs it can be used on any
+# process
+ADD thpoff.c /src/thpoff.c
+RUN gcc -o /usr/local/sbin/thpoff /src/thpoff.c && rm /src/thpoff.c
+
+FROM builder AS jemalloc_builder
+ADD install-jemalloc /tmp/install-jemalloc
+RUN /tmp/install-jemalloc
+
+FROM builder AS oxipng_builder
+ADD install-oxipng /tmp/install-oxipng
+RUN /tmp/install-oxipng
 
 FROM discourse/ruby:${FROM_DOCKER_IMAGE_TAG} AS discourse_dependencies
 
@@ -72,6 +87,8 @@ RUN --mount=type=tmpfs,target=/var/log \
     ghostscript libjbig0 libtiff6 libpng16-16 libfontconfig1 \
     libwebpdemux2 libwebpmux3 libxext6 librsvg2-2 libgomp1 \
     fonts-urw-base35 libheif1/${DEBIAN_RELEASE}-backports \
+# oxipng dependencies \
+    advancecomp jpegoptim libjpeg-turbo-progs \
 # nginx runtime dependencies \
     nginx-common && \
 # install these without recommends to avoid pulling in e.g.
@@ -127,23 +144,17 @@ RUN ln -s /usr/local/bin/magick /usr/local/bin/animate &&\
   ln -s /usr/local/bin/magick /usr/local/bin/stream &&\
   test $(magick -version | grep -o -e png -e tiff -e jpeg -e freetype -e heic -e webp | wc -l) -eq 6
 
-ADD install-jemalloc /tmp/install-jemalloc
-RUN /tmp/install-jemalloc
+COPY --from=thpoff_builder /usr/local/sbin/thpoff /usr/local/sbin
+COPY --from=jemalloc_builder /usr/lib/libjemalloc.so.2 /usr/lib
+RUN ln -s /usr/lib/libjemalloc.so.2 /usr/lib/libjemalloc.so
+COPY --from=oxipng_builder /usr/local/bin/jhead /usr/local/bin
+COPY --from=oxipng_builder /usr/local/bin/oxipng /usr/local/bin
 
 ADD install-redis /tmp/install-redis
-
-ADD install-oxipng /tmp/install-oxipng
-RUN /tmp/install-oxipng
 
 RUN gem install pups --force &&\
     mkdir -p /pups/bin/ &&\
     ln -s /usr/local/bin/pups /pups/bin/pups
-
-# This tool allows us to disable huge page support for our current process
-# since the flag is preserved through forks and execs it can be used on any
-# process
-ADD thpoff.c /src/thpoff.c
-RUN gcc -o /usr/local/sbin/thpoff /src/thpoff.c && rm /src/thpoff.c
 
 # this is required for aarch64 which uses buildx
 # see https://github.com/docker/buildx/issues/150

--- a/image/base/Dockerfile
+++ b/image/base/Dockerfile
@@ -154,8 +154,7 @@ RUN ln -s /usr/local/bin/magick /usr/local/bin/animate &&\
   test $(magick -version | grep -o -e png -e tiff -e jpeg -e freetype -e heic -e webp | wc -l) -eq 6
 
 COPY --from=thpoff_builder /usr/local/sbin/thpoff /usr/local/sbin
-COPY --from=jemalloc_builder /usr/lib/libjemalloc.so.2 /usr/lib
-RUN ln -s /usr/lib/libjemalloc.so.2 /usr/lib/libjemalloc.so
+COPY --from=jemalloc_builder /usr/lib/libjemalloc.so /usr/lib
 COPY --from=oxipng_builder /usr/local/bin/jhead /usr/local/bin
 COPY --from=oxipng_builder /usr/local/bin/oxipng /usr/local/bin
 

--- a/image/base/Dockerfile
+++ b/image/base/Dockerfile
@@ -46,7 +46,7 @@ FROM builder AS oxipng-builder
 ADD install-oxipng /tmp/install-oxipng
 RUN /tmp/install-oxipng
 
-FROM discourse/ruby:${FROM_DOCKER_IMAGE_TAG} AS discourse-dependencies
+FROM discourse/ruby:${FROM_DOCKER_IMAGE_TAG} AS discourse-runtime-dependencies
 
 ARG DEBIAN_RELEASE
 ARG PG_MAJOR=15
@@ -81,16 +81,6 @@ RUN --mount=type=tmpfs,target=/var/log \
     psmisc whois brotli \
     pngcrush pngquant ripgrep poppler-utils \
     catdoc antiword \
-# gem build dependencies
-    cmake g++ pkg-config patch \
-    libtool \
-    libxslt-dev \
-    libcurl4-openssl-dev \
-    libssl-dev \
-    libyaml-dev \
-    libxml2-dev \
-    libreadline-dev \
-    libunwind-dev \
 # nginx runtime dependencies
     libpcre3 zlib1g \
 # imagemagick runtime dependencies
@@ -171,6 +161,23 @@ RUN rm -f /etc/service
 
 COPY etc/  /etc
 COPY sbin/ /sbin
+
+FROM discourse-runtime-dependencies AS discourse-dependencies
+RUN --mount=type=tmpfs,target=/var/log \
+  --mount=type=tmpfs,target=/var/cache/apt \
+  --mount=type=tmpfs,target=/var/lib/apt \
+    echo "debconf debconf/frontend select Teletype" | debconf-set-selections; \
+    apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
+# gem build dependencies
+    cmake g++ pkg-config patch \
+    libtool \
+    libxslt-dev \
+    libcurl4-openssl-dev \
+    libssl-dev \
+    libyaml-dev \
+    libxml2-dev \
+    libreadline-dev \
+    libunwind-dev
 
 FROM discourse-dependencies AS discourse-slim
 ARG DISCOURSE_BRANCH=main

--- a/image/base/Dockerfile
+++ b/image/base/Dockerfile
@@ -46,7 +46,7 @@ FROM builder AS oxipng-builder
 ADD install-oxipng /tmp/install-oxipng
 RUN /tmp/install-oxipng
 
-FROM discourse/ruby:${FROM_DOCKER_IMAGE_TAG} AS discourse-runtime-dependencies
+FROM discourse/ruby:${FROM_DOCKER_IMAGE_TAG} AS discourse-runtime-base
 
 ARG DEBIAN_RELEASE
 ARG PG_MAJOR=15
@@ -162,7 +162,7 @@ RUN rm -f /etc/service
 COPY etc/  /etc
 COPY sbin/ /sbin
 
-FROM discourse-runtime-dependencies AS discourse-dependencies
+FROM discourse-runtime-base AS discourse-build-base
 RUN --mount=type=tmpfs,target=/var/log \
   --mount=type=tmpfs,target=/var/cache/apt \
   --mount=type=tmpfs,target=/var/lib/apt \
@@ -179,7 +179,7 @@ RUN --mount=type=tmpfs,target=/var/log \
     libreadline-dev \
     libunwind-dev
 
-FROM discourse-dependencies AS discourse-slim
+FROM discourse-build-base AS discourse-slim
 ARG DISCOURSE_BRANCH=main
 
 # Discourse specific bits

--- a/image/base/Dockerfile
+++ b/image/base/Dockerfile
@@ -23,7 +23,7 @@ FROM builder AS imagemagick_builder
 ADD install-imagemagick /tmp/install-imagemagick
 RUN /tmp/install-imagemagick
 
-FROM builder AS nginx_builder
+FROM builder AS nginx-builder
 # From https://nginx.org/en/pgp_keys.html
 ADD nginx_public_keys.key /tmp/nginx_public_keys.key
 ADD install-nginx /tmp/install-nginx
@@ -31,18 +31,18 @@ RUN gpg --import /tmp/nginx_public_keys.key &&\
   rm /tmp/nginx_public_keys.key &&\
   /tmp/install-nginx
 
-FROM builder AS thpoff_builder
+FROM builder AS thpoff-builder
 # This tool allows us to disable huge page support for our current process
 # since the flag is preserved through forks and execs it can be used on any
 # process
 ADD thpoff.c /src/thpoff.c
 RUN gcc -o /usr/local/sbin/thpoff /src/thpoff.c && rm /src/thpoff.c
 
-FROM builder AS jemalloc_builder
+FROM builder AS jemalloc-builder
 ADD install-jemalloc /tmp/install-jemalloc
 RUN /tmp/install-jemalloc
 
-FROM builder AS oxipng_builder
+FROM builder AS oxipng-builder
 ADD install-oxipng /tmp/install-oxipng
 RUN /tmp/install-oxipng
 
@@ -74,8 +74,9 @@ RUN --mount=type=tmpfs,target=/var/log \
   --mount=type=tmpfs,target=/var/lib/apt \
     echo "debconf debconf/frontend select Teletype" | debconf-set-selections; \
     apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
-    gnupg sudo curl fping locales \
-    ca-certificates rsync \
+# discourse runtime requirements
+  gnupg sudo curl fping locales \
+  ca-certificates rsync \
     gawk anacron wget \
     psmisc whois brotli \
     pngcrush pngquant ripgrep poppler-utils \
@@ -132,7 +133,7 @@ RUN sed -i "s/^# $LANG/$LANG/" /etc/locale.gen; \
 RUN --mount=type=tmpfs,target=/root/.npm \
     npm install -g pnpm@10
 
-COPY --from=nginx_builder /usr/sbin/nginx /usr/sbin
+COPY --from=nginx-builder /usr/sbin/nginx /usr/sbin
 
 # Copy binary and configuration files for magick
 COPY --from=imagemagick_builder /usr/local/bin/magick /usr/local/bin/magick
@@ -153,10 +154,10 @@ RUN ln -s /usr/local/bin/magick /usr/local/bin/animate &&\
   ln -s /usr/local/bin/magick /usr/local/bin/stream &&\
   test $(magick -version | grep -o -e png -e tiff -e jpeg -e freetype -e heic -e webp | wc -l) -eq 6
 
-COPY --from=thpoff_builder /usr/local/sbin/thpoff /usr/local/sbin
-COPY --from=jemalloc_builder /usr/lib/libjemalloc.so /usr/lib
-COPY --from=oxipng_builder /usr/local/bin/jhead /usr/local/bin
-COPY --from=oxipng_builder /usr/local/bin/oxipng /usr/local/bin
+COPY --from=thpoff-builder /usr/local/sbin/thpoff /usr/local/sbin
+COPY --from=jemalloc-builder /usr/lib/libjemalloc.so /usr/lib
+COPY --from=oxipng-builder /usr/local/bin/jhead /usr/local/bin
+COPY --from=oxipng-builder /usr/local/bin/oxipng /usr/local/bin
 
 ADD install-redis /tmp/install-redis
 

--- a/image/base/Dockerfile
+++ b/image/base/Dockerfile
@@ -98,11 +98,6 @@ RUN --mount=type=tmpfs,target=/var/log \
     install -d /usr/share/postgresql-common/pgdg &&\
     curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc &&\
     echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt ${DEBIAN_RELEASE}-pgdg main" > /etc/apt/sources.list.d/pgdg.list; \
-# yarn packages
-    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -; \
-    echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list; \
-# node packages
-    curl --silent --location https://deb.nodesource.com/setup_22.x | sudo bash -; \
 # setup anacron, rsyslog, initctl
     sed -i -e 's/start -q anacron/anacron -s/' /etc/cron.d/anacron; \
     sed -i.bak 's/$ModLoad imklog/#$ModLoad imklog/' /etc/rsyslog.conf; \
@@ -110,8 +105,7 @@ RUN --mount=type=tmpfs,target=/var/log \
     dpkg-divert --local --rename --add /sbin/initctl; \
     sh -c "test -f /sbin/initctl || ln -s /bin/true /sbin/initctl"; \
     apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get -y install runit socat \
-    libpq-dev postgresql-client-${PG_MAJOR} \
-    nodejs yarn &&\
+    libpq-dev postgresql-client-${PG_MAJOR} &&\
     mkdir -p /etc/runit/1.d
 
 ENV LC_ALL=en_US.UTF-8
@@ -119,9 +113,6 @@ ENV LANG=en_US.UTF-8
 ENV LANGUAGE=en_US.UTF-8
 RUN sed -i "s/^# $LANG/$LANG/" /etc/locale.gen; \
     locale-gen
-
-RUN --mount=type=tmpfs,target=/root/.npm \
-    npm install -g pnpm@10
 
 COPY --from=nginx-builder /usr/sbin/nginx /usr/sbin
 
@@ -166,6 +157,11 @@ FROM discourse-runtime-base AS discourse-build-base
 RUN --mount=type=tmpfs,target=/var/log \
   --mount=type=tmpfs,target=/var/cache/apt \
   --mount=type=tmpfs,target=/var/lib/apt \
+# yarn packages
+    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -; \
+    echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list; \
+# node packages
+    curl --silent --location https://deb.nodesource.com/setup_22.x | sudo bash -; \
     echo "debconf debconf/frontend select Teletype" | debconf-set-selections; \
     apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
 # gem build dependencies
@@ -177,7 +173,12 @@ RUN --mount=type=tmpfs,target=/var/log \
     libyaml-dev \
     libxml2-dev \
     libreadline-dev \
-    libunwind-dev
+    libunwind-dev \
+# node
+    nodejs yarn
+# pnpm
+RUN --mount=type=tmpfs,target=/root/.npm \
+    npm install -g pnpm@10
 
 FROM discourse-build-base AS discourse-slim
 ARG DISCOURSE_BRANCH=main

--- a/image/base/Dockerfile
+++ b/image/base/Dockerfile
@@ -46,7 +46,7 @@ FROM builder AS oxipng-builder
 ADD install-oxipng /tmp/install-oxipng
 RUN /tmp/install-oxipng
 
-FROM discourse/ruby:${FROM_DOCKER_IMAGE_TAG} AS discourse_dependencies
+FROM discourse/ruby:${FROM_DOCKER_IMAGE_TAG} AS discourse-dependencies
 
 ARG DEBIAN_RELEASE
 ARG PG_MAJOR=15
@@ -172,14 +172,14 @@ RUN rm -f /etc/service
 COPY etc/  /etc
 COPY sbin/ /sbin
 
-FROM discourse_dependencies AS discourse_slim
+FROM discourse-dependencies AS discourse-slim
 ARG DISCOURSE_BRANCH=main
 
 # Discourse specific bits
 RUN install -dm 0755 -o discourse -g discourse /var/www/discourse &&\
     sudo -u discourse git clone --branch $DISCOURSE_BRANCH --filter=tree:0 https://github.com/discourse/discourse.git /var/www/discourse
 
-FROM discourse_slim AS discourse_web_only
+FROM discourse-slim AS discourse-web-only
 ENV RAILS_ENV=production
 
 RUN cd /var/www/discourse &&\
@@ -193,7 +193,7 @@ RUN cd /var/www/discourse &&\
 RUN cd /var/www/discourse &&\
     sudo -u discourse /bin/bash -c 'if [ -f yarn.lock ]; then yarn install --frozen-lockfile && yarn cache clean; else pnpm install --frozen-lockfile; fi'
 
-FROM discourse_web_only AS discourse_release
+FROM discourse-web-only AS discourse-release
 RUN --mount=type=tmpfs,target=/var/log \
   apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
   postgresql-${PG_MAJOR} postgresql-contrib-${PG_MAJOR} postgresql-${PG_MAJOR}-pgvector

--- a/image/base/sbin/boot
+++ b/image/base/sbin/boot
@@ -5,7 +5,7 @@
 shutdown() {
   echo Shutting Down
   /etc/runit/3
-  ls /etc/service | SHELL=/bin/sh parallel sv force-stop {}
+  ls /etc/service | xargs sv force-stop
   kill -HUP $RUNSVDIR
   wait $RUNSVDIR
 
@@ -13,7 +13,10 @@ shutdown() {
   sleep 0.1
 
   ORPHANS=`ps -eo pid | grep -v PID  | tr -d ' ' | grep -v '^1$'`
-  SHELL=/bin/bash parallel 'timeout 5 /bin/bash -c "kill {} && wait {}" || kill -9 {}' ::: $ORPHANS 2> /dev/null
+  for pid in $ORPHANS; do
+    (timeout 5 /bin/bash -c "kill $pid && wait $pid" 2>/dev/null || kill -9 $pid 2>/dev/null) &
+  done
+  wait
   exit
 }
 


### PR DESCRIPTION
Separate out builders for thpoff, jemalloc and oxipng/jhead
Copy over the results of all libraries to reduce dependencies
for base image needing build tools.

drop extra -dev packages from base image as we only need the nginx runtime libs.

refactor parallel stop without parallel package

mount tmpfs for apt caches
remove unreferenced libtcmalloc

reorganize gem dependencies