### PR TITLE
launcher: use normal image for arm64 installs

### DIFF
--- a/launcher
+++ b/launcher
@@ -233,16 +233,13 @@ check_prereqs() {
     echo "WARNING: Docker version ${test} deprecated, recommend upgrade to ${docker_rec_version} or newer."
   fi
 
-  arm=false
   case $(uname -m) in
     armv7l)
       echo "ERROR: 32bit arm is not supported. Check if your hardware support arm64, which is supported in experimental capacity."
       exit 1
       ;;
     aarch64 | arm64)
-      echo "WARNING: Support for aarch64 is experimental at the moment. Please report any problems at https://meta.discourse.org/tag/arm"
-      image="discourse/base:aarch64"
-      arm=true
+      echo "arm64 arch detected."
       ;;
     x86_64)
       echo "x86_64 arch detected."
@@ -257,8 +254,7 @@ check_prereqs() {
   # 4. discourse docker image is downloaded
   test=`$docker_path images | awk '{print $1 ":" $2 }' | grep "$image"`
 
-  # arm experimental support is on a fixed tag, always pull
-  if [ -z "$test" ] || [ $arm = true ]; then
+  if [ -z "$test" ]; then
     echo
     echo "WARNING: We are about to start downloading the Discourse base image"
     echo "This process may take anywhere between a few minutes to an hour, depending on your network speed"


### PR DESCRIPTION
We now publish images with multi-arch manifests, so no need to use a special tag