### PR TITLE
DEV: reduce image size by using web-only image for discourse/discourse images

### DIFF
--- a/.github/workflows/push-web-only.yml
+++ b/.github/workflows/push-web-only.yml
@@ -76,10 +76,7 @@ jobs:
           # Then we can do something like:
           # bin/launcher build --params="version=stable" --conf-dir=./samples web_only
           cp ./samples/web_only.yml ./containers/web_only.yml
-          # TODO: Uncomment when PR 966 is merged
-          # allowing us to build from web-only images
-          # https://github.com/discourse/discourse_docker/pull/966
-          #echo $(grep base_image: ./templates/web.template.yml)-web-only >> ./containers/web_only.yml
+          echo $(grep base_image: ./templates/web.template.yml)-web-only >> ./containers/web_only.yml
           sed -Ei 's/^ *+#?version:.*/  version: ${{ matrix.version }}/' ./containers/web_only.yml
           sed -Ei '/^ *+- "templates\/web.template.yml"/a\  - "templates/offline-page.template.yml"' ./containers/web_only.yml
           sed -Ei 's/^ *+#- "templates\/web.ssl.template.yml"/  - "templates\/web.ssl.template.yml"/' ./containers/web_only.yml


### PR DESCRIPTION
Take advantage of web-only images to build discourse/discourse without postgres and redis invovled.

Now that the base image bump is in, we have a matching web-only version to build from