### PR TITLE
FIX: Clear stuck web upgrade flags after a full rebuild

### DIFF
--- a/templates/web.template.yml
+++ b/templates/web.template.yml
@@ -223,6 +223,15 @@ run:
         - su discourse -c 'bundle exec rake db:migrate'
   - exec:
       cd: $home
+      hook: clear_stuck_web_upgrades
+      raise_on_fail: false
+      cmd:
+        - |-
+          if [ -f plugins/docker_manager/lib/tasks/docker_manager.rake ]; then
+            su discourse -c 'bundle exec rake docker_manager:stop_all_upgrades'
+          fi
+  - exec:
+      cd: $home
       tag: build
       hook: assets_precompile_build
       cmd:


### PR DESCRIPTION
**Previously**, a failed web update via the `docker_manager` plugin left Redis flags set that kept the admin UI showing "Updating..." even after the user recovered with `./launcher rebuild app`.

**In this update**, `web.template.yml` invokes `docker_manager:stop_all_upgrades` right after `db_migrate` to clear those flags. Guarded by a file-existence check on the rake task and `raise_on_fail: false` so instances without `docker_manager`, or with an older plugin version that predates the task, are unaffected.

Paired with https://github.com/discourse/docker_manager/pull/319.