### PR TITLE
DEV: bump nginx to v1.30.1 (CVE-2026-42945)

### DIFF
--- a/image/base/install-nginx
+++ b/image/base/install-nginx
@@ -2,7 +2,7 @@
 set -e
 
 # version check: https://nginx.org/en/download.html
-VERSION=1.28.1
+VERSION=1.30.1
 
 cd /tmp
 wget -q https://nginx.org/download/nginx-$VERSION.tar.gz


### PR DESCRIPTION
Multiple CVEs were reported in nginx prior to version 1.30.1.

These have been fixed in the latest stable.

https://my.f5.com/manage/s/article/K000161019