### PR TITLE
FIX: run clear_stuck_web_upgrades during precompile stage

### DIFF
--- a/templates/web.template.yml
+++ b/templates/web.template.yml
@@ -224,6 +224,7 @@ run:
   - exec:
       cd: $home
       hook: clear_stuck_web_upgrades
+      tag: precompile
       raise_on_fail: false
       cmd:
         - |-


### PR DESCRIPTION
We are not guaranteed to have a database or redis connection during the build stage, but we are during a precompile/configure stage.

Delay a call for clear_stuck_web_upgrades until we can guarantee a connection.