### PR TITLE
DEV: image: fix bundle invocation for deployment mode (bug)

### DIFF
--- a/image/discourse_dev/Dockerfile
+++ b/image/discourse_dev/Dockerfile
@@ -66,7 +66,7 @@ USER discourse
 # Warm global bundle cache, then delete the compressed `cache/` versions (`/gem/` are enough)
 RUN --mount=type=bind,src=/repo,from=repo-fetcher,target=/tmp/discourse-clone,readwrite \
     cd /tmp/discourse-clone \
-    && bundle install --deployment \
+    && env BUNDLE_DEPLOYMENT=true bundle install \
     && rm -rf /home/discourse/.bundle/gems/ruby/*/cache/*
 
 # Warm global yarn cache


### PR DESCRIPTION
bundler 4 removed the --deployment flag (which was deprecated long ago).