### PR TITLE
DEV: Pin playwright browser cache path in discourse_test image

### DIFF
--- a/image/discourse_test/Dockerfile
+++ b/image/discourse_test/Dockerfile
@@ -35,6 +35,12 @@ RUN /tmp/install-chrome &&\
 
 FROM with_browsers AS release
 
+# Pin playwright's browser cache to a fixed path so consumers that run the
+# container as a different user (e.g. GitHub Actions runs as root with
+# HOME=/github/home) still find the pre-installed chromium binary instead
+# of re-downloading it.
+ENV PLAYWRIGHT_BROWSERS_PATH=/home/discourse/.cache/ms-playwright
+
 RUN cd /var/www/discourse &&\
     sudo -u discourse bundle install --jobs $(($(nproc) - 1)) &&\
     sudo -E -u discourse -H /bin/bash -c 'CI=1 pnpm install'


### PR DESCRIPTION
Previously, the `discourse_test` image installed playwright's chromium browser under the discourse user (`/home/discourse/.cache/ms-playwright`). Consumers that run the container as a different user, such as GitHub Actions which uses `HOME=/github/home`, missed the cache via the default `~/.cache/ms-playwright` lookup and re-downloaded chromium (~170 MB) on every system test job.

This change pins `PLAYWRIGHT_BROWSERS_PATH` to the installed path in the image's `release` stage so consumers inherit it regardless of which user runs the container.

Paired change: discourse/discourse#40214 (drops the now-redundant `Install playwright` step from the test workflow once this image change ships).