### PR TITLE
FIX: Run playwright ffmpeg install as the discourse user

### DIFF
--- a/image/discourse_test/Dockerfile
+++ b/image/discourse_test/Dockerfile
@@ -50,7 +50,7 @@ RUN cd /var/www/discourse && sudo -E -u discourse -H bundle exec rake plugin:ins
     sudo -E -u discourse -H bundle exec ruby script/install_minio_binaries.rb
 
 RUN cd /var/www/discourse && \
-    pnpm playwright install ffmpeg
+    sudo -E -u discourse -H pnpm playwright install ffmpeg
 
 RUN cd /var/www/discourse && \
     sudo -E -u discourse -H pnpm playwright install --no-shell chromium


### PR DESCRIPTION
Previously, after #1058 set `ENV PLAYWRIGHT_BROWSERS_PATH=/home/discourse/.cache/ms-playwright` in the `release` stage, the build broke because the `pnpm playwright install ffmpeg` step still ran as root. It created `/home/discourse/.cache/ms-playwright` owned by root, then the subsequent chromium install (run as the discourse user) failed with `EACCES: permission denied, mkdir '__dirlock'`.

This change runs the ffmpeg install with `sudo -E -u discourse -H` so the cache directory is owned by the discourse user from the start. Both playwright installs now share the same cache path with the right ownership.

Failing build: https://github.com/discourse/discourse_docker/actions/runs/26201953575

Paired change: discourse/discourse#40214 (drops the now-redundant `Install playwright` step from the test workflow).