### PR TITLE
Revert "DEV: Pin playwright browser cache path in discourse_test image (#1058)"

### DIFF
--- a/image/discourse_test/Dockerfile
+++ b/image/discourse_test/Dockerfile
@@ -35,12 +35,6 @@ RUN /tmp/install-chrome &&\
 
 FROM with_browsers AS release
 
-# Pin playwright's browser cache to a fixed path so consumers that run the
-# container as a different user (e.g. GitHub Actions runs as root with
-# HOME=/github/home) still find the pre-installed chromium binary instead
-# of re-downloading it.
-ENV PLAYWRIGHT_BROWSERS_PATH=/home/discourse/.cache/ms-playwright
-
 RUN cd /var/www/discourse &&\
     sudo -u discourse bundle install --jobs $(($(nproc) - 1)) &&\
     sudo -E -u discourse -H /bin/bash -c 'CI=1 pnpm install'


### PR DESCRIPTION
Reverts #1058. The image build failed because the subsequent `pnpm playwright install ffmpeg` step still ran as root and created `/home/discourse/.cache/ms-playwright` owned by root, breaking the chromium install that ran as the discourse user with `EACCES: permission denied`. See https://github.com/discourse/discourse_docker/actions/runs/26201953575.

Reverting so `discourse_test:release` returns to a known-good state. A combined re-introduction PR will follow with the ffmpeg install also running as the discourse user.