### PR TITLE
Restore GNU parallel in the base image

### DIFF
--- a/image/base/Dockerfile
+++ b/image/base/Dockerfile
@@ -80,7 +80,7 @@ RUN --mount=type=tmpfs,target=/var/log \
     gawk anacron wget \
     psmisc whois brotli \
     pngcrush pngquant ripgrep poppler-utils \
-    catdoc antiword \
+    catdoc antiword parallel \
 # nginx runtime dependencies
     libpcre3 zlib1g \
 # imagemagick runtime dependencies

--- a/image/discourse_test/Dockerfile
+++ b/image/discourse_test/Dockerfile
@@ -13,7 +13,8 @@ RUN sudo -E -u discourse -H git config --global user.email "you@example.com" &&\
 # Include postgres and redis on test images
 RUN --mount=type=tmpfs,target=/var/log \
   apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
-  postgresql-${PG_MAJOR} postgresql-contrib-${PG_MAJOR} postgresql-${PG_MAJOR}-pgvector
+  postgresql-${PG_MAJOR} postgresql-contrib-${PG_MAJOR} postgresql-${PG_MAJOR}-pgvector \
+  parallel
 RUN /tmp/install-redis
 
 RUN chown -R discourse . &&\

--- a/image/discourse_test/Dockerfile
+++ b/image/discourse_test/Dockerfile
@@ -13,8 +13,7 @@ RUN sudo -E -u discourse -H git config --global user.email "you@example.com" &&\
 # Include postgres and redis on test images
 RUN --mount=type=tmpfs,target=/var/log \
   apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
-  postgresql-${PG_MAJOR} postgresql-contrib-${PG_MAJOR} postgresql-${PG_MAJOR}-pgvector \
-  parallel
+  postgresql-${PG_MAJOR} postgresql-contrib-${PG_MAJOR} postgresql-${PG_MAJOR}-pgvector
 RUN /tmp/install-redis
 
 RUN chown -R discourse . &&\


### PR DESCRIPTION
Restores the `parallel` package, which was removed in #994 ("drop some unused library dependencies") as part of the build-tool cleanup.

