### PR TITLE
Push runtime deps image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,10 +46,15 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: build deps image
+      - name: build runtime deps image
         working-directory: image
         run: |
-          ruby auto_build.rb base_deps_${{ matrix.arch }}
+          ruby auto_build.rb base_runtime_deps_${{ matrix.arch }}
+
+      - name: build the build deps image
+        working-directory: image
+        run: |
+          ruby auto_build.rb base_build_deps_${{ matrix.arch }}
 
       - name: build slim image for `main` branch
         working-directory: image
@@ -87,6 +92,7 @@ jobs:
 
       - name: tag release images
         run: |
+          docker tag discourse/base:build_runtime_deps_${{ matrix.arch }} discourse/base:2.0.${{ env.TIMESTAMP }}-runtime-deps-${{ matrix.arch }}
           docker tag discourse/base:build_web_only_main_${{ matrix.arch }} discourse/base:2.0.${{ env.TIMESTAMP }}-web-only-main-${{ matrix.arch }}
           docker tag discourse/base:build_web_only_stable_${{ matrix.arch }} discourse/base:2.0.${{ env.TIMESTAMP }}-web-only-stable-${{ matrix.arch }}
           docker tag discourse/base:build_release_main_${{ matrix.arch }} discourse/base:2.0.${{ env.TIMESTAMP }}-main-${{ matrix.arch }}
@@ -115,21 +121,6 @@ jobs:
         run: |
           docker history discourse/base:2.0.${{ env.TIMESTAMP }}-main-${{ matrix.arch }}
 
-      - name: Print compressed summary
-        if: github.event_name == 'pull_request' && matrix.arch == 'amd64'
-        run: |
-          # Push to local repo to compare sizes
-          docker tag discourse/base:2.0.${{ env.TIMESTAMP }}-slim-${{ matrix.arch }} localhost:5000/base:2.0.${{ env.TIMESTAMP }}-slim-${{ matrix.arch }}
-          docker tag discourse/base:2.0.${{ env.TIMESTAMP }}-main-${{ matrix.arch }} localhost:5000/base:2.0.${{ env.TIMESTAMP }}-main-${{ matrix.arch }}
-          docker push --quiet localhost:5000/base:2.0.${{ env.TIMESTAMP }}-slim-${{ matrix.arch }}
-          docker push --quiet localhost:5000/base:2.0.${{ env.TIMESTAMP }}-main-${{ matrix.arch }}
-          # multi-arch manifest is an array of schemas - [0] is amd64, [1] is arch64: Compare amd64.
-          CURRENT_SLIM=$(docker manifest inspect -v discourse/base:slim | jq -r '.[0].SchemaV2Manifest.layers[] | .size / 1024 / 1024 | .*100 | round/100' | awk '{print $0; sum+= $0}; END {print sum}' | tail -n 1)
-          CURRENT_RELEASE=$(docker manifest inspect -v discourse/base:release | jq -r '.[0].SchemaV2Manifest.layers[] | .size / 1024 / 1024 | .*100 | round/100' | awk '{print $0; sum+= $0}; END {print sum}' | tail -n 1)
-          NEW_SLIM=$(docker manifest inspect -v --insecure localhost:5000/base:2.0.${{ env.TIMESTAMP }}-slim-${{ matrix.arch }} |  jq -r '.SchemaV2Manifest.layers[] | .size / 1024 / 1024 | .*100 | round/100' | awk '{print $0; sum+= $0}; END {print sum}' | tail -n 1)
-          NEW_RELEASE=$(docker manifest inspect -v --insecure localhost:5000/base:2.0.${{ env.TIMESTAMP }}-main-${{ matrix.arch }} | jq -r '.SchemaV2Manifest.layers[] | .size / 1024 / 1024 | .*100 | round/100' | awk '{print $0; sum+= $0}; END {print sum}' | tail -n 1)
-          echo "current slim: ${CURRENT_SLIM}MB release: ${CURRENT_RELEASE}MB. new slim: ${NEW_SLIM}MB release: ${NEW_RELEASE}MB"
-
       - name: Login to Docker Hub
         if: github.ref == 'refs/heads/main'
         uses: docker/login-action@v3
@@ -140,6 +131,7 @@ jobs:
       - name: push to dockerhub
         if: github.ref == 'refs/heads/main'
         run: |
+          docker push discourse/base:2.0.${{ env.TIMESTAMP }}-runtime-deps-${{ matrix.arch }}
           docker push discourse/base:2.0.${{ env.TIMESTAMP }}-slim-${{ matrix.arch }}
           docker push discourse/base:2.0.${{ env.TIMESTAMP }}-web-only-main-${{ matrix.arch }}
           docker push discourse/base:2.0.${{ env.TIMESTAMP }}-web-only-stable-${{ matrix.arch }}
@@ -198,6 +190,16 @@ jobs:
 
       - name: create and push multi-arch manifests
         run: |
+          # Runtime deps timestamped
+          docker buildx imagetools create -t discourse/base:2.0.${{ env.TIMESTAMP }}-runtime-deps \
+            discourse/base:2.0.${{ env.TIMESTAMP }}-runtime-deps-amd64 \
+            discourse/base:2.0.${{ env.TIMESTAMP }}-runtime-deps-arm64
+
+          #Runtime deps release
+          docker buildx imagetools create -t discourse/base:runtime-deps \
+            discourse/base:2.0.${{ env.TIMESTAMP }}-runtime-deps-amd64 \
+            discourse/base:2.0.${{ env.TIMESTAMP }}-runtime-deps-arm64
+
           # Slim timestamped
           docker buildx imagetools create -t discourse/base:2.0.${{ env.TIMESTAMP }}-slim \
             discourse/base:2.0.${{ env.TIMESTAMP }}-slim-amd64 \

--- a/image/auto_build.rb
+++ b/image/auto_build.rb
@@ -2,15 +2,27 @@ require 'pty'
 require 'optparse'
 
 images = {
-  base_deps_amd64: {
+  base_runtime_deps_amd64: {
+    name: 'base',
+    tag: 'discourse/base:build_runtime_deps_amd64',
+    extra_args: '--target discourse-runtime-base'
+  },
+  base_runtime_deps_arm64: {
+    name: 'base',
+    tag: 'discourse/base:build_runtime_deps_arm64',
+    extra_args: '--platform linux/arm64 --target discourse-runtime-base'
+  },
+  base_build_deps_amd64: {
     name: 'base',
     tag: 'discourse/base:build_deps_amd64',
-    extra_args: '--target discourse-build-base'
+    extra_args: '--target discourse-build-base',
+    use_cache: true
   },
-  base_deps_arm64: {
+  base_build_deps_arm64: {
     name: 'base',
     tag: 'discourse/base:build_deps_arm64',
-    extra_args: '--platform linux/arm64 --target discourse-build-base'
+    extra_args: '--platform linux/arm64 --target discourse-build-base',
+    use_cache: true
   },
   base_slim_main_amd64: {
     name: 'base',
@@ -20,7 +32,7 @@ images = {
   },
   base_slim_stable_amd64: {
     name: 'base',
-    tag: 'discourse/base:build_slim_main_amd64',
+    tag: 'discourse/base:build_slim_stable_amd64',
     extra_args: '--target discourse-slim --build-arg="DISCOURSE_BRANCH=stable"',
     use_cache: true
   },


### PR DESCRIPTION
Push an image with only Discourse runtime dependencies. Provides a base image for a finalized image that copies from a build image, resulting in much smaller image sizes.

Rename base_deps to base_build_deps to distinguish from base_runtime_deps*

base_build_deps* depends on base_runtime_deps* builds and can reuse the fresh runtime image build cache. The cache is guaranteed to be fresh as runtime images now handle dropping the docker build cache when built first.

Fix incorrect base_slim_stable_amd64 tag