### PR TITLE
Remove deprecated sshd and web.ipv6 templates

### DIFF
--- a/templates/sshd.template.yml
+++ b/templates/sshd.template.yml
@@ -1,6 +1,0 @@
-# This file is deprecated; you can remove it from your app.yml
-# TODO(2026-01-01): Remove this file
-run: 
-  - exec: |-
-      echo "Deprecation warning: sshd is no longer supported"
-      echo "Remove templates/sshd.template.yml from your containers/*.yml files"

--- a/templates/web.ipv6.template.yml
+++ b/templates/web.ipv6.template.yml
@@ -1,6 +1,0 @@
-# This file is deprecated; you can remove it from your app.yml
-# TODO(2026-01-01): Remove this file
-run:
-  - exec: |-
-      echo "Deprecation warning: IPv6 is enabled by default when possible"
-      echo "Remove templates/web.ipv6.template.yml from your containers/*.yml files"


### PR DESCRIPTION
Both files were marked `# TODO(2026-01-01): Remove this file` for over five months. They emit deprecation warnings when included but no longer provide any functionality:

- sshd was removed as a supported feature
- IPv6 is now enabled by default when available