### PR TITLE
Drop ghostscript dependency

### DIFF
--- a/image/base/Dockerfile
+++ b/image/base/Dockerfile
@@ -84,7 +84,7 @@ RUN --mount=type=tmpfs,target=/var/log \
 # nginx runtime dependencies
     libpcre3 zlib1g \
 # imagemagick runtime dependencies
-    ghostscript libjbig0 libtiff6 libpng16-16 libfontconfig1 \
+    libjbig0 libtiff6 libpng16-16 libfontconfig1 \
     libwebpdemux2 libwebpmux3 libxext6 librsvg2-2 libgomp1 \
     fonts-urw-base35 libheif1/${DEBIAN_RELEASE}-backports \
 # oxipng dependencies \

--- a/image/base/install-imagemagick
+++ b/image/base/install-imagemagick
@@ -15,7 +15,7 @@ apt -y -q remove imagemagick
 apt -y -q install git make gcc pkg-config autoconf curl g++ yasm cmake \
     libde265-0 libde265-dev ${LIBJPEGTURBO} libwebp7 x265 libx265-dev libtool \
     libpng16-16 libpng-dev libwebp-dev libgomp1 libaom-dev \
-    libwebpmux3 libwebpdemux2 ghostscript libxml2-dev libxml2-utils librsvg2-dev \
+    libwebpmux3 libwebpdemux2 libxml2-dev libxml2-utils librsvg2-dev \
     libltdl7-dev libbz2-dev gsfonts libtiff-dev libfreetype6-dev libjpeg-dev
 
 if cat /etc/issue | grep -qi Debian; then


### PR DESCRIPTION
We don't need this, and it adds unnecessary vulnerability surface-area