### PR TITLE
FEATURE: add image handling libraries

### DIFF
--- a/image/base/Dockerfile
+++ b/image/base/Dockerfile
@@ -46,6 +46,10 @@ FROM builder AS oxipng-builder
 ADD install-oxipng /tmp/install-oxipng
 RUN /tmp/install-oxipng
 
+FROM builder AS cjpegli-builder
+ADD install-cjpegli /tmp/install-cjpegli
+RUN /tmp/install-cjpegli
+
 FROM discourse/ruby:${FROM_DOCKER_IMAGE_TAG} AS discourse-runtime-base
 
 ARG DEBIAN_RELEASE
@@ -54,8 +58,6 @@ ENV PG_MAJOR=${PG_MAJOR} \
     RUBY_ALLOCATOR=/usr/lib/libjemalloc.so \
     LEFTHOOK=0 \
     DEBIAN_RELEASE=${DEBIAN_RELEASE}
-
-#LABEL maintainer="Sam Saffron \"https://twitter.com/samsaffron\""
 
 # Ensures that the gid and uid of the following users are consistent to avoid permission issues on directories in the
 # mounted volumes.
@@ -89,6 +91,8 @@ RUN --mount=type=tmpfs,target=/var/log \
     fonts-urw-base35 libheif1/${DEBIAN_RELEASE}-backports \
 # oxipng dependencies \
     advancecomp jpegoptim libjpeg-turbo-progs \
+# safe_image dependency
+    libvips42 \
 # nginx runtime dependencies \
     nginx-common && \
 # install these without recommends to avoid pulling in e.g.
@@ -139,6 +143,7 @@ COPY --from=thpoff-builder /usr/local/sbin/thpoff /usr/local/sbin
 COPY --from=jemalloc-builder /usr/lib/libjemalloc.so /usr/lib
 COPY --from=oxipng-builder /usr/local/bin/jhead /usr/local/bin
 COPY --from=oxipng-builder /usr/local/bin/oxipng /usr/local/bin
+COPY --from=cjpegli-builder /usr/local/bin/cjpegli /usr/local/bin
 
 ADD install-redis /tmp/install-redis
 

--- a/image/base/install-cjpegli
+++ b/image/base/install-cjpegli
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -e
+
+# cjpegli is safe_image's preferred encoder for generated JPEGs. It ships
+# with libjxl >= 0.9, which has no bookworm package, so build just the tool
+# from source with vendored dependencies (the binary stays self-contained;
+# no libjxl shared libraries are installed).
+# version check: https://github.com/libjxl/libjxl/releases
+LIBJXL_VERSION="0.11.2"
+LIBJXL_HASH="ab38928f7f6248e2a98cc184956021acb927b16a0dee71b4d260dc040a4320ea"
+
+WDIR=/tmp/libjxl
+
+# Install build deps (deps.sh fetches the pinned third_party trees via curl)
+apt -y -q install git cmake build-essential pkg-config wget curl ca-certificates
+
+mkdir -p $WDIR
+cd $WDIR
+
+wget -q -O $WDIR/libjxl.tar.gz "https://github.com/libjxl/libjxl/archive/refs/tags/v$LIBJXL_VERSION.tar.gz"
+sha256sum $WDIR/libjxl.tar.gz
+echo "$LIBJXL_HASH $WDIR/libjxl.tar.gz" | sha256sum -c
+tar zxf $WDIR/libjxl.tar.gz -C $WDIR
+cd $WDIR/libjxl-$LIBJXL_VERSION
+
+# Third-party deps (highway, brotli, skcms, libjpeg-turbo headers) are
+# fetched by deps.sh at the exact commit hashes recorded inside the
+# checksum-verified tarball, so the whole tree is integrity-pinned.
+./deps.sh
+
+cmake -B build \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DBUILD_SHARED_LIBS=OFF \
+  -DBUILD_TESTING=OFF \
+  -DJPEGXL_ENABLE_BENCHMARK=OFF \
+  -DJPEGXL_ENABLE_EXAMPLES=OFF \
+  -DJPEGXL_ENABLE_MANPAGES=OFF \
+  -DJPEGXL_ENABLE_DOXYGEN=OFF \
+  -DJPEGXL_ENABLE_JNI=OFF \
+  -DJPEGXL_ENABLE_SJPEG=OFF \
+  -DJPEGXL_ENABLE_OPENEXR=OFF \
+  -DJPEGXL_ENABLE_PLUGINS=OFF
+cmake --build build -j"$(nproc)" --target cjpegli
+
+cp build/tools/cjpegli /usr/local/bin/cjpegli
+
+cd $HOME
+rm -rf $WDIR
+
+# Validate (cjpegli has no --version flag)
+cjpegli -h 2>&1 | grep -q "Usage: cjpegli"


### PR DESCRIPTION
Discourse is looking to port to using libvips, and cjpegli for image compression
Both result in both better compression ratios and faster performance
