### PR TITLE
FIX: Use bundle config instead of flags removed in Bundler 4.x (phpbb3 import)

### DIFF
--- a/templates/import/phpbb3.template.yml
+++ b/templates/import/phpbb3.template.yml
@@ -114,5 +114,7 @@ hooks:
         cmd:
           - echo "gem 'mysql2'" >> Gemfile
           - echo "gem 'ruby-bbcode-to-md', :github => 'nlalonde/ruby-bbcode-to-md'" >> Gemfile
-          - su discourse -c 'bundle config unset deployment'
-          - su discourse -c 'bundle install --no-deployment --path vendor/bundle --jobs $(($(nproc) - 1)) --without test development'
+          - su discourse -c 'bundle config set --local deployment false'
+          - su discourse -c 'bundle config set --local path vendor/bundle'
+          - su discourse -c 'bundle config set --local without "test development"'
+          - su discourse -c 'bundle install --jobs $(($(nproc) - 1))'


### PR DESCRIPTION
The phpbb3 import template's `after_bundle_exec` hook calls:

```
bundle install --no-deployment --path vendor/bundle --jobs ... --without test development
```

Bundler 4.x has removed the `--path`, `--no-deployment` and `--without` install flags because they relied on being persisted across invocations. With the Bundler version now shipped in the base image (4.0.14), the hook fails with e.g. `The --path flag has been removed ...` and the import container bootstrap aborts (exit 15).

This moves those settings to explicit `bundle config set --local ...` calls and drops the removed flags from `bundle install`, which is the migration path Bundler itself suggests in the error message.

Note: the same pattern exists in the `mssql-dep`, `mysql-dep`, `vanilla` and `mbox` import templates. This PR is scoped to `phpbb3`; happy to extend it to the others if preferred.