### PR TITLE
FIX: fastly template should be teaching nginx what to trust

### DIFF
--- a/templates/fastly.template.yml
+++ b/templates/fastly.template.yml
@@ -1,6 +1,11 @@
 run:
-  - replace:
-     filename: "/etc/nginx/conf.d/discourse.conf"
-     from: "$proxy_add_x_forwarded_for"
-     to: "$http_fastly_client_ip"
-     global: true
+  - file:
+      path: /etc/nginx/conf.d/outlets/server/real-ip-header.conf
+      chmod: 644
+      contents: |
+        real_ip_header fastly-client-ip;
+  - exec:
+      cmd:
+        - apt-get update && apt-get install -y jq && apt-get clean
+        # print sprintf looks dubious at first, but avoids the problem of "how many times do you backslash a \\\\n"
+        - curl -s https://api.fastly.com/public-ip-list | jq -r '.addresses[], .ipv6_addresses[]' | awk '{print sprintf("set_real_ip_from %s;", $0)}' > /etc/nginx/conf.d/outlets/server/real-ip-fastly.conf


### PR DESCRIPTION
The idea of replacing proxy_add_x_forwarded_for is ghastly - we have the
ability to teach nginx how to discern the correct values for the actual end
user IP instead of telling it to pass through the header to Discourse.

This means the server-side nginx logs will be correct, plus allows for more
complex setups.
