### PR TITLE
FEATURE: Update base image to Postgres 18

### DIFF
--- a/image/base/Dockerfile
+++ b/image/base/Dockerfile
@@ -57,7 +57,7 @@ RUN /tmp/install-cjpegli
 FROM discourse/ruby:${FROM_DOCKER_IMAGE_TAG} AS discourse-runtime-base
 
 ARG DEBIAN_RELEASE
-ARG PG_MAJOR=15
+ARG PG_MAJOR=18
 ENV PG_MAJOR=${PG_MAJOR} \
     RUBY_ALLOCATOR=/usr/lib/libjemalloc.so \
     LEFTHOOK=0 \
@@ -115,7 +115,7 @@ RUN --mount=type=tmpfs,target=/var/log \
     dpkg-divert --local --rename --add /sbin/initctl; \
     sh -c "test -f /sbin/initctl || ln -s /bin/true /sbin/initctl"; \
     apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get -y install runit socat \
-    libpq-dev postgresql-client-${PG_MAJOR} &&\
+    libpq-dev postgresql-client-${PG_MAJOR} postgresql-client-15 &&\
     mkdir -p /etc/runit/1.d
 
 ENV LC_ALL=en_US.UTF-8


### PR DESCRIPTION
As part of the PG18 upgrade we need both PG15 and PG18 clients in the base image for in-app backups to work.

Once the new image is baked I'll update the templates to use it and formalise the PG18 update for self-hosters.