### PR TITLE
FIX: Revert to PG15 in base image

### DIFF
--- a/image/base/Dockerfile
+++ b/image/base/Dockerfile
@@ -57,7 +57,7 @@ RUN /tmp/install-cjpegli
 FROM discourse/ruby:${FROM_DOCKER_IMAGE_TAG} AS discourse-runtime-base
 
 ARG DEBIAN_RELEASE
-ARG PG_MAJOR=18
+ARG PG_MAJOR=15
 ENV PG_MAJOR=${PG_MAJOR} \
     RUBY_ALLOCATOR=/usr/lib/libjemalloc.so \
     LEFTHOOK=0 \
@@ -115,7 +115,7 @@ RUN --mount=type=tmpfs,target=/var/log \
     dpkg-divert --local --rename --add /sbin/initctl; \
     sh -c "test -f /sbin/initctl || ln -s /bin/true /sbin/initctl"; \
     apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get -y install runit socat \
-    libpq-dev postgresql-client-${PG_MAJOR} postgresql-client-15 &&\
+    libpq-dev postgresql-client-${PG_MAJOR} &&\
     mkdir -p /etc/runit/1.d
 
 ENV LC_ALL=en_US.UTF-8


### PR DESCRIPTION
We cannot update the Postgres server before ensuring compatibility in the pups templates. Reverting while this is addressed so the pipeline is not blocked.

This reverts commit cbccdff2812b8efbf6f073b791dc151966cb2a02.