### PR TITLE
Add Postgres 18 client to base image

### DIFF
--- a/image/base/Dockerfile
+++ b/image/base/Dockerfile
@@ -115,7 +115,7 @@ RUN --mount=type=tmpfs,target=/var/log \
     dpkg-divert --local --rename --add /sbin/initctl; \
     sh -c "test -f /sbin/initctl || ln -s /bin/true /sbin/initctl"; \
     apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get -y install runit socat \
-    libpq-dev postgresql-client-${PG_MAJOR} &&\
+    libpq-dev postgresql-client-${PG_MAJOR} postgresql-client-18 &&\
     mkdir -p /etc/runit/1.d
 
 ENV LC_ALL=en_US.UTF-8


### PR DESCRIPTION
This will allow backup/restore against a PG18 server. The PG15 client continues to be installed and `pg_wrapper` will automatically select a suitable version as needed.

The `postgresql-client-18` package was chosen over the generic `postgresql-client` equivalent in order to convey intent and bring a little bit of order to the versioning situation.