### PR TITLE
FIX: accept pasted text in setup wizard inputs

### DIFF
--- a/image/setup_wizard/lib/discourse_setup/tui_components.rb
+++ b/image/setup_wizard/lib/discourse_setup/tui_components.rb
@@ -75,6 +75,9 @@ module DiscourseSetup
               break @value
             elsif event.backspace?
               @value = @value.chop
+            elsif event.paste?
+              # Bracketed paste arrives as one atomic event, not per-key events
+              @value += event.content.gsub(/[^[:print:]]/, "")
             elsif event.key?
               char = event.to_s
               @value += char if char.length == 1 && char.match?(/[[:print:]]/)


### PR DESCRIPTION
## Problem

Pasting into the new setup wizard TUI does nothing — domains and SMTP passwords have to be typed character by character.

## Cause

`ratatui_ruby` enables bracketed paste by default, so a paste arrives as a single atomic `Event::Paste` instead of a stream of key events. The `TextInput` event loop only handled `enter?`/`backspace?`/`key?`, so paste events fell through silently.

## Fix

Handle `event.paste?` by appending the pasted content, stripped of non-printable characters so stray newlines/tabs in the clipboard don't corrupt the single-line field or auto-submit it.

## Verification

Drove the real `TextInput` component in a live PTY, sending genuine bracketed-paste byte sequences (`ESC[200~…ESC[201~`):

- Pre-fix control: pasting `forum.example.com` + Enter → `""` (bug reproduced)
- With fix: same paste → `"forum.example.com"`
- Paste containing `\r\n\t` → control chars stripped, no accidental submit
- Paste then backspace then typing → composes correctly
- Password field paste → value correct, display stays masked
- Plain per-key typing → unaffected

Note: users get this once the `discourse/setup-wizard:release` image is rebuilt and pushed.