### PR TITLE
Bump default base image to discourse/base:2.0.20260706-0040

### DIFF
--- a/launcher
+++ b/launcher
@@ -127,7 +127,7 @@ kernel_min_version='4.4.0'
 config_file=containers/"$config".yml
 cidbootstrap=cids/"$config"_bootstrap.cid
 local_discourse=local_discourse
-image="discourse/base:2.0.20260617-0053"
+image="discourse/base:2.0.20260706-0040"
 docker_path=`which docker.io 2> /dev/null || which docker`
 git_path=`which git`
 

--- a/templates/postgres.template.yml
+++ b/templates/postgres.template.yml
@@ -1,4 +1,4 @@
-base_image: discourse/base:2.0.20260617-0053
+base_image: discourse/base:2.0.20260706-0040
 params:
   db_synchronous_commit: "off"
   db_shared_buffers: "256MB"

--- a/templates/redis.template.yml
+++ b/templates/redis.template.yml
@@ -1,4 +1,4 @@
-base_image: discourse/base:2.0.20260617-0053
+base_image: discourse/base:2.0.20260706-0040
 params:
   redis_io_threads: "1"
 

--- a/templates/web.template.yml
+++ b/templates/web.template.yml
@@ -1,4 +1,4 @@
-base_image: discourse/base:2.0.20260617-0053
+base_image: discourse/base:2.0.20260706-0040
 env:
   # You can have redis on a different box
   RAILS_ENV: 'production'


### PR DESCRIPTION
New image includes both PG15 and PG18 clients.