### PR TITLE
Build cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
           echo "datestamp=$datestamp" >> $GITHUB_OUTPUT
 
   # run all targets individually for cache, otherwise this may break caching
-  # possibley related to https://github.com/docker/buildx/issues/414
+  # possibly related to https://github.com/docker/buildx/issues/414
   base:
     # `cdck-linux-8-core` for amd64 builds
     # `ubuntu-24.04-8core-arm` for arm64 builds

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,13 +22,19 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       timestamp: ${{ steps.timestamp.outputs.timestamp }}
+      datestamp: ${{ steps.timestamp.outputs.datestamp }}
     steps:
       - id: timestamp
         run: |
           timestamp=$(date +%Y%m%d-%H%M)
+          datestamp=$(echo $timestamp | sed -e 's/-.*$//')
           echo "timestamp=$timestamp"
+          echo "datestamp=$datestamp"
           echo "timestamp=$timestamp" >> $GITHUB_OUTPUT
+          echo "datestamp=$datestamp" >> $GITHUB_OUTPUT
 
+  # run all targets individually for cache, otherwise this may break caching
+  # possibley related to https://github.com/docker/buildx/issues/414
   base:
     # `cdck-linux-8-core` for amd64 builds
     # `ubuntu-24.04-8core-arm` for arm64 builds
@@ -43,53 +49,66 @@ jobs:
         working-directory: image
     env:
       TIMESTAMP: ${{ needs.timestamp.outputs.timestamp }}
+      DATESTAMP: ${{ needs.timestamp.outputs.datestamp }}
       ARCH: ${{ matrix.arch }}
+      CACHE_IMAGE: ghcr.io/${{ github.repository }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
       - uses: docker/setup-buildx-action@v3
+      - name: Login to cache registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Login to Docker Hub
         if: ${{ github.event_name == 'schedule' || github.event_name == 'push' }}
         uses: docker/login-action@v3
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
-      - name: Build runtime deps
+      - name: Build deps
         run: |
-          docker buildx bake base-runtime-deps --no-cache --load
+          docker buildx bake base-runtime-deps -f docker-bake.hcl -f docker-bake.cache.hcl --load
 
       - name: Build slim image
         run: |
-          docker buildx bake base-slim --load
+          docker buildx bake base-slim-main -f docker-bake.hcl -f docker-bake.cache.hcl
+          docker buildx bake base-slim-stable -f docker-bake.hcl -f docker-bake.cache.hcl
 
       - name: Build web only image
         run: |
-          docker buildx bake base-web-only --load
+          docker buildx bake base-web-only-main -f docker-bake.hcl -f docker-bake.cache.hcl --load
+          docker buildx bake base-web-only-stable -f docker-bake.hcl -f docker-bake.cache.hcl --load
 
       - name: Build release image
         run: |
-          docker buildx bake base-release --load
+          docker buildx bake base-release-main -f docker-bake.hcl -f docker-bake.cache.hcl --load
+          docker buildx bake base-release-stable -f docker-bake.hcl -f docker-bake.cache.hcl --load
 
       - name: Build test images
         run: |
-          docker buildx bake test-release-${{ matrix.arch }} --load
+          docker buildx bake test-release -f docker-bake.hcl -f docker-bake.cache.hcl --load
 
       - name: run specs for `main` branch
         if: vars.SKIP_TESTS != '1'
         run: |
-          docker run --rm -e RUBY_ONLY=1 -e USE_TURBO=1 -e SKIP_PLUGINS=1 -e SKIP_LINT=1 -e DISCOURSE_TURBO_RSPEC_RETRY_AND_LOG_FLAKY_TESTS=1 ${TEST_IMAGE}:release-${{ matrix.arch }}
+          docker run --rm -e RUBY_ONLY=1 -e USE_TURBO=1 -e SKIP_PLUGINS=1 -e SKIP_LINT=1 -e DISCOURSE_TURBO_RSPEC_RETRY_AND_LOG_FLAKY_TESTS=1 ${TEST_IMAGE}:release
 
       - name: Build and push test image
         if: ${{ github.event_name == 'schedule' || github.event_name == 'push' }}
         run: |
-          docker buildx bake test --set="*.tags=${TEST_IMAGE}" --set="*.output=type=registry,push-by-digest=true" --metadata-file=/tmp/test.json
+          docker buildx bake test-slim -f docker-bake.hcl -f docker-bake.push.hcl -f docker-bake.cache.hcl -f docker-bake.cache-write.hcl --metadata-file=/tmp/test-slim.json
+          docker buildx bake test-slim-browsers -f docker-bake.hcl -f docker-bake.push.hcl -f docker-bake.cache.hcl -f docker-bake.cache-write.hcl --metadata-file=/tmp/test-slim-browsers.json
+          docker buildx bake test-release -f docker-bake.hcl -f docker-bake.push.hcl -f docker-bake.cache.hcl -f docker-bake.cache-write.hcl --metadata-file=/tmp/test-release.json
 
       - name: Build and push dev image
         if: ${{ github.event_name == 'schedule' || github.event_name == 'push' }}
         run: |
-          docker buildx bake dev --set="*.tags=${DEV_IMAGE}" --set="*.output=type=registry,push-by-digest=true" --allow=fs.read=../templates --metadata-file=/tmp/dev.json
+          docker buildx bake --allow=fs.read=../templates dev -f docker-bake.hcl -f docker-bake.push.hcl -f docker-bake.cache.hcl -f docker-bake.cache-write.hcl --metadata-file=/tmp/dev.json
 
       - name: Print summary
         run: |
@@ -97,57 +116,69 @@ jobs:
 
       - name: Print `docker history` summary for main branch image
         run: |
-          docker history ${BASE_IMAGE}:release-main-${{ matrix.arch }}
+          docker history ${BASE_IMAGE}:release-main
 
       - name: push to dockerhub
         if: ${{ github.event_name == 'schedule' || github.event_name == 'push' }}
         run: |
-          docker buildx bake base --set="*.tags=${BASE_IMAGE}" --set="*.output=type=registry,push-by-digest=true" --metadata-file=/tmp/base.json
+          docker buildx bake base-runtime-deps -f docker-bake.hcl -f docker-bake.push.hcl -f docker-bake.cache.hcl -f docker-bake.cache-write.hcl --metadata-file=/tmp/base-runtime-deps.json
+          docker buildx bake base-slim-main -f docker-bake.hcl -f docker-bake.push.hcl -f docker-bake.cache.hcl -f docker-bake.cache-write.hcl --metadata-file=/tmp/base-slim-main.json
+          docker buildx bake base-slim-stable -f docker-bake.hcl -f docker-bake.push.hcl -f docker-bake.cache.hcl -f docker-bake.cache-write.hcl --metadata-file=/tmp/base-slim-stable.json
+          docker buildx bake base-web-only-main -f docker-bake.hcl -f docker-bake.push.hcl -f docker-bake.cache.hcl -f docker-bake.cache-write.hcl --metadata-file=/tmp/base-web-only-main.json
+          docker buildx bake base-web-only-stable -f docker-bake.hcl -f docker-bake.push.hcl -f docker-bake.cache.hcl -f docker-bake.cache-write.hcl --metadata-file=/tmp/base-web-only-stable.json
+          docker buildx bake base-release-main -f docker-bake.hcl -f docker-bake.push.hcl -f docker-bake.cache.hcl -f docker-bake.cache-write.hcl --metadata-file=/tmp/base-release-main.json
+          docker buildx bake base-release-stable -f docker-bake.hcl -f docker-bake.push.hcl -f docker-bake.cache.hcl -f docker-bake.cache-write.hcl --metadata-file=/tmp/base-release-stable.json
 
       - name: save image digests
         if: ${{ github.event_name == 'schedule' || github.event_name == 'push' }}
         id: metadata
         run: |
-          test_slim_${{ matrix.arch }}=$(jq -r '."test-slim-${{ matrix.arch }}"["containerimage.digest"]' /tmp/test.json)
+          test_slim_${{ matrix.arch }}=$(jq -r '."test-slim"["containerimage.digest"]' /tmp/test-slim.json)
           echo "test_slim_${{ matrix.arch }}=$test_slim_${{ matrix.arch }}"
           echo "test_slim_${{ matrix.arch }}=$test_slim_${{ matrix.arch }}" >> $GITHUB_OUTPUT
 
-          test_slim_browsers_${{ matrix.arch }}=$(jq -r '."test-slim-browsers-${{ matrix.arch }}"["containerimage.digest"]' /tmp/test.json)
+          test_slim_browsers_${{ matrix.arch }}=$(jq -r '."test-slim-browsers"["containerimage.digest"]' /tmp/test-slim-browsers.json)
           echo "test_slim_browsers_${{ matrix.arch }}=$test_slim_browsers_${{ matrix.arch }}"
           echo "test_slim_browsers_${{ matrix.arch }}=$test_slim_browsers_${{ matrix.arch }}" >> $GITHUB_OUTPUT
 
-          test_release_${{ matrix.arch }}=$(jq -r '."test-release-${{ matrix.arch }}"["containerimage.digest"]' /tmp/test.json)
+          test_release_${{ matrix.arch }}=$(jq -r '."test-release"["containerimage.digest"]' /tmp/test-release.json)
           echo "test_release_${{ matrix.arch }}=$test_release_${{ matrix.arch }}"
           echo "test_release_${{ matrix.arch }}=$test_release_${{ matrix.arch }}" >> $GITHUB_OUTPUT
 
-          dev_${{ matrix.arch }}=$(jq -r '."dev-${{ matrix.arch }}"["containerimage.digest"]' /tmp/dev.json)
+          dev_${{ matrix.arch }}=$(jq -r '."dev"["containerimage.digest"]' /tmp/dev.json)
           echo "dev_${{ matrix.arch }}=$dev_${{ matrix.arch }}"
           echo "dev_${{ matrix.arch }}=$dev_${{ matrix.arch }}" >> $GITHUB_OUTPUT
 
-          base_slim_main_${{ matrix.arch }}=$(jq -r '."base-slim-main-${{ matrix.arch }}"["containerimage.digest"]' /tmp/base.json)
+          base_runtime_deps_${{ matrix.arch }}=$(jq -r '."base-runtime-deps"["containerimage.digest"]' /tmp/base-runtime-deps.json)
+          echo "base_runtime_deps_${{ matrix.arch }}=$base_runtime_deps_${{ matrix.arch }}"
+          echo "base_runtime_deps_${{ matrix.arch }}=$base_runtime_deps_${{ matrix.arch }}" >> $GITHUB_OUTPUT
+
+          base_slim_main_${{ matrix.arch }}=$(jq -r '."base-slim-main"["containerimage.digest"]' /tmp/base-slim-main.json)
           echo "base_slim_main_${{ matrix.arch }}=$base_slim_main_${{ matrix.arch }}"
           echo "base_slim_main_${{ matrix.arch }}=$base_slim_main_${{ matrix.arch }}" >> $GITHUB_OUTPUT
 
-          base_slim_stable_${{ matrix.arch }}=$(jq -r '."base-slim-stable-${{ matrix.arch }}"["containerimage.digest"]' /tmp/base.json)
+          base_slim_stable_${{ matrix.arch }}=$(jq -r '."base-slim-stable"["containerimage.digest"]' /tmp/base-slim-stable.json)
           echo "base_slim_stable_${{ matrix.arch }}=$base_slim_stable_${{ matrix.arch }}"
           echo "base_slim_stable_${{ matrix.arch }}=$base_slim_stable_${{ matrix.arch }}" >> $GITHUB_OUTPUT
 
-          base_web_only_main_${{ matrix.arch }}=$(jq -r '."base-web-only-main-${{ matrix.arch }}"["containerimage.digest"]' /tmp/base.json)
+          base_web_only_main_${{ matrix.arch }}=$(jq -r '."base-web-only-main"["containerimage.digest"]' /tmp/base-web-only-main.json)
           echo "base_web_only_main_${{ matrix.arch }}=$base_web_only_main_${{ matrix.arch }}"
           echo "base_web_only_main_${{ matrix.arch }}=$base_web_only_main_${{ matrix.arch }}" >> $GITHUB_OUTPUT
 
-          base_web_only_stable_${{ matrix.arch }}=$(jq -r '."base-web-only-stable-${{ matrix.arch }}"["containerimage.digest"]' /tmp/base.json)
+          base_web_only_stable_${{ matrix.arch }}=$(jq -r '."base-web-only-stable"["containerimage.digest"]' /tmp/base-web-only-stable.json)
           echo "base_web_only_stable_${{ matrix.arch }}=$base_web_only_stable_${{ matrix.arch }}"
           echo "base_web_only_stable_${{ matrix.arch }}=$base_web_only_stable_${{ matrix.arch }}" >> $GITHUB_OUTPUT
 
-          base_release_main_${{ matrix.arch }}=$(jq -r '."base-release-main-${{ matrix.arch }}"["containerimage.digest"]' /tmp/base.json)
+          base_release_main_${{ matrix.arch }}=$(jq -r '."base-release-main"["containerimage.digest"]' /tmp/base-release-main.json)
           echo "base_release_main_${{ matrix.arch }}=$base_release_main_${{ matrix.arch }}"
           echo "base_release_main_${{ matrix.arch }}=$base_release_main_${{ matrix.arch }}" >> $GITHUB_OUTPUT
 
-          base_release_stable_${{ matrix.arch }}=$(jq -r '."base-release-stable-${{ matrix.arch }}"["containerimage.digest"]' /tmp/base.json)
+          base_release_stable_${{ matrix.arch }}=$(jq -r '."base-release-stable"["containerimage.digest"]' /tmp/base-release-stable.json)
           echo "base_release_stable_${{ matrix.arch }}=$base_release_stable_${{ matrix.arch }}"
           echo "base_release_stable_${{ matrix.arch }}=$base_release_stable_${{ matrix.arch }}" >> $GITHUB_OUTPUT
     outputs:
+      base_runtime_deps_amd64: ${{ steps.metadata.outputs.base_runtime_deps_amd64 }}
+      base_runtime_deps_arm64: ${{ steps.metadata.outputs.base_runtime_deps_arm64 }}
       base_slim_main_amd64: ${{ steps.metadata.outputs.base_slim_main_amd64 }}
       base_slim_main_arm64: ${{ steps.metadata.outputs.base_slim_main_arm64 }}
       base_slim_stable_amd64: ${{ steps.metadata.outputs.base_slim_stable_amd64 }}
@@ -195,11 +226,12 @@ jobs:
 
       - name: build and push to dockerhub
         run: |
-          docker buildx bake setup-wizard --set="*.tags=${SETUP_WIZARD_IMAGE}" --set="*.output=type=registry,push-by-digest=true" --metadata-file=/tmp/setup-wizard.json
+          docker buildx bake setup-wizard -f docker-bake.hcl -f docker-bake.push.hcl --metadata-file=/tmp/setup-wizard.json
+
       - name: save image digests
         id: metadata
         run: |
-          ${{ matrix.arch }}=$(jq -r '."setup-wizard-${{ matrix.arch }}"["containerimage.digest"]' /tmp/setup-wizard.json)
+          ${{ matrix.arch }}=$(jq -r '."setup-wizard"["containerimage.digest"]' /tmp/setup-wizard.json)
           echo "${{ matrix.arch }}=$${{ matrix.arch }}"
           echo "${{ matrix.arch }}=$${{ matrix.arch }}" >> $GITHUB_OUTPUT
     outputs:
@@ -231,6 +263,16 @@ jobs:
           docker buildx imagetools create -t ${BASE_IMAGE}:slim \
             ${{ needs.base.outputs.base_slim_main_amd64 }} \
             ${{ needs.base.outputs.base_slim_main_arm64 }}
+
+          # runtime-deps timestamped
+          docker buildx imagetools create -t ${BASE_IMAGE}:2.0.${{ env.TIMESTAMP }}-runtime-deps \
+            ${{ needs.base.outputs.base_runtime_deps_amd64 }} \
+            ${{ needs.base.outputs.base_runtime_deps_arm64 }}
+
+          # runtime-deps release
+          docker buildx imagetools create -t ${BASE_IMAGE}:runtime-deps \
+            ${{ needs.base.outputs.base_runtime_deps_amd64 }} \
+            ${{ needs.base.outputs.base_runtime_deps_arm64 }}
 
           # Web-Only `main` timestamped
           docker buildx imagetools create -t ${BASE_IMAGE}:2.0.${{ env.TIMESTAMP }}-web-only \

--- a/.github/workflows/cleanup-cache.yml
+++ b/.github/workflows/cleanup-cache.yml
@@ -1,0 +1,39 @@
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  cleanup_cache:
+    runs-on: ubuntu-latest
+    steps:
+      - name: cleanup cache
+        env:
+          GH_TOKEN: ${{ secrets.GH_CLEANUP_CACHE_TOKEN }}
+          PACKAGE_NAME: discourse_docker
+        run: |
+          if [[ -z "$GH_TOKEN" ]]; then
+            echo "no cleanup token set, set cleanup token by setting an access token for secrets.GH_CLEANUP_CACHE_TOKEN with delete:packages, read:org permissions"
+            exit 0
+          fi
+          # figure out if this is a user or organization repository
+          OWNER_TYPE=$(gh api /users/${{ github.repository_owner }} --jq '.type')
+          if [[ "$OWNER_TYPE" == "User" ]]; then
+            OWNER_TYPE="users"
+          else
+            OWNER_TYPE="orgs"
+          fi
+          gh api /${OWNER_TYPE}/${{ github.repository_owner }}/packages/container/discourse_docker/versions --paginate > /tmp/dangling_ids.txt
+          ids_to_delete=$(cat /tmp/dangling_ids.txt | jq -r '.[] | select(.metadata.container.tags==[]) | .id')
+          if [ "${ids_to_delete}" = "" ]
+          then
+            echo "There are no dangling images to remove for this package"
+            exit 0
+          fi
+          echo "Deleting dangling ids..."
+          while read -r id; do
+            gh api --method DELETE /${OWNER_TYPE}/${{ github.repository_owner }}/packages/container/${PACKAGE_NAME}/versions/${id}
+            echo Dangling image with ID $id deleted successfully
+          done <<< $ids_to_delete

--- a/image/base/Dockerfile
+++ b/image/base/Dockerfile
@@ -4,8 +4,10 @@
 ARG DEBIAN_RELEASE=bookworm
 ARG RUBY_VERSION=3.4.9
 ARG FROM_DOCKER_IMAGE_TAG=${RUBY_VERSION}-${DEBIAN_RELEASE}-slim
+ARG DATESTAMP=0
 
 FROM discourse/ruby:${FROM_DOCKER_IMAGE_TAG} AS builder
+ARG DATESTAMP
 ARG DEBIAN_RELEASE
 ENV DEBIAN_RELEASE=${DEBIAN_RELEASE}
 RUN echo "deb http://deb.debian.org/debian ${DEBIAN_RELEASE}-backports main" > "/etc/apt/sources.list.d/${DEBIAN_RELEASE}-backports.list"
@@ -24,17 +26,17 @@ ADD install-libheif /tmp/install-libheif
 RUN /tmp/install-libheif
 
 FROM libheif-builder AS imagemagick_builder
-ADD install-imagemagick /tmp/install-imagemagick
+COPY install-imagemagick /tmp/install-imagemagick
 RUN /tmp/install-imagemagick
 
 FROM libheif-builder AS vips-builder
-ADD install-vips /tmp/install-vips
+COPY install-vips /tmp/install-vips
 RUN /tmp/install-vips
 
 FROM builder AS nginx-builder
 # From https://nginx.org/en/pgp_keys.html
-ADD nginx_public_keys.key /tmp/nginx_public_keys.key
-ADD install-nginx /tmp/install-nginx
+COPY nginx_public_keys.key /tmp/nginx_public_keys.key
+COPY install-nginx /tmp/install-nginx
 RUN gpg --import /tmp/nginx_public_keys.key &&\
   rm /tmp/nginx_public_keys.key &&\
   /tmp/install-nginx
@@ -43,23 +45,23 @@ FROM builder AS thpoff-builder
 # This tool allows us to disable huge page support for our current process
 # since the flag is preserved through forks and execs it can be used on any
 # process
-ADD thpoff.c /src/thpoff.c
+COPY thpoff.c /src/thpoff.c
 RUN gcc -o /usr/local/sbin/thpoff /src/thpoff.c && rm /src/thpoff.c
 
 FROM builder AS jemalloc-builder
-ADD install-jemalloc /tmp/install-jemalloc
+COPY install-jemalloc /tmp/install-jemalloc
 RUN /tmp/install-jemalloc
 
 FROM builder AS oxipng-builder
-ADD install-oxipng /tmp/install-oxipng
+COPY install-oxipng /tmp/install-oxipng
 RUN /tmp/install-oxipng
 
 FROM builder AS cjpegli-builder
-ADD install-cjpegli /tmp/install-cjpegli
+COPY install-cjpegli /tmp/install-cjpegli
 RUN /tmp/install-cjpegli
 
 FROM discourse/ruby:${FROM_DOCKER_IMAGE_TAG} AS discourse-runtime-base
-
+ARG DATESTAMP
 ARG DEBIAN_RELEASE
 ARG PG_MAJOR=15
 ENV PG_MAJOR=${PG_MAJOR} \
@@ -170,7 +172,7 @@ COPY --from=oxipng-builder /usr/local/bin/jhead /usr/local/bin
 COPY --from=oxipng-builder /usr/local/bin/oxipng /usr/local/bin
 COPY --from=cjpegli-builder /usr/local/bin/cjpegli /usr/local/bin
 
-ADD install-redis /tmp/install-redis
+COPY install-redis /tmp/install-redis
 
 # version check: https://rubygems.org/gems/pups
 RUN cd /tmp &&\
@@ -191,10 +193,10 @@ COPY sbin/ /sbin
 FROM discourse-runtime-base AS discourse-build-base
 # From https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key
 # fingerprint: 6F71 F525 2828 41EE DAF8 51B4 2F59 B5F9 9B1B E0B4
-ADD nodesource-repo.gpg.key /usr/share/keyrings/nodesource.asc
+COPY nodesource-repo.gpg.key /usr/share/keyrings/nodesource.asc
 # From https://dl.yarnpkg.com/debian/pubkey.gpg
 # fingerprint: 72EC F46A 56B4 AD39 C907 BBB7 1646 B01B 86E5 0310
-ADD yarn-pubkey.gpg.key /usr/share/keyrings/yarn.asc
+COPY yarn-pubkey.gpg.key /usr/share/keyrings/yarn.asc
 RUN --mount=type=tmpfs,target=/var/log \
   --mount=type=tmpfs,target=/var/cache/apt \
   --mount=type=tmpfs,target=/var/lib/apt \

--- a/image/base/Dockerfile
+++ b/image/base/Dockerfile
@@ -4,8 +4,10 @@
 ARG DEBIAN_RELEASE=trixie
 ARG RUBY_VERSION=3.4.10
 ARG FROM_DOCKER_IMAGE_TAG=${RUBY_VERSION}-${DEBIAN_RELEASE}-slim
+ARG DATESTAMP=0
 
 FROM discourse/ruby:${FROM_DOCKER_IMAGE_TAG} AS builder
+ARG DATESTAMP
 ARG DEBIAN_RELEASE
 ENV DEBIAN_RELEASE=${DEBIAN_RELEASE}
 RUN echo "deb http://deb.debian.org/debian ${DEBIAN_RELEASE}-backports main" > "/etc/apt/sources.list.d/${DEBIAN_RELEASE}-backports.list"
@@ -24,7 +26,7 @@ ADD install-libheif /tmp/install-libheif
 RUN /tmp/install-libheif
 
 FROM libheif-builder AS imagemagick_builder
-ADD install-imagemagick /tmp/install-imagemagick
+COPY install-imagemagick /tmp/install-imagemagick
 RUN /tmp/install-imagemagick
 
 FROM libheif-builder AS jpegli-builder
@@ -33,26 +35,26 @@ RUN /tmp/install-jpegli
 
 FROM libheif-builder AS vips-builder
 COPY --from=jpegli-builder /usr/local/lib/jpegli /usr/local/lib/jpegli
-ADD install-vips /tmp/install-vips
+COPY install-vips /tmp/install-vips
 RUN /tmp/install-vips
 
 FROM builder AS thpoff-builder
 # This tool allows us to disable huge page support for our current process
 # since the flag is preserved through forks and execs it can be used on any
 # process
-ADD thpoff.c /src/thpoff.c
+COPY thpoff.c /src/thpoff.c
 RUN gcc -o /usr/local/sbin/thpoff /src/thpoff.c && rm /src/thpoff.c
 
 FROM builder AS jemalloc-builder
-ADD install-jemalloc /tmp/install-jemalloc
+COPY install-jemalloc /tmp/install-jemalloc
 RUN /tmp/install-jemalloc
 
 FROM builder AS oxipng-builder
-ADD install-oxipng /tmp/install-oxipng
+COPY install-oxipng /tmp/install-oxipng
 RUN /tmp/install-oxipng
 
 FROM discourse/ruby:${FROM_DOCKER_IMAGE_TAG} AS discourse-runtime-base
-
+ARG DATESTAMP
 ARG DEBIAN_RELEASE
 ARG PG_MAJOR=18
 ARG PG_MAJOR_OLD=15
@@ -207,7 +209,7 @@ COPY sbin/ /sbin
 FROM discourse-runtime-base AS discourse-build-base
 # From https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key
 # fingerprint: 6F71 F525 2828 41EE DAF8 51B4 2F59 B5F9 9B1B E0B4
-ADD nodesource-repo.gpg.key /usr/share/keyrings/nodesource.asc
+COPY nodesource-repo.gpg.key /usr/share/keyrings/nodesource.asc
 RUN --mount=type=tmpfs,target=/var/log \
     --mount=type=tmpfs,target=/var/cache/apt \
     --mount=type=tmpfs,target=/var/lib/apt \

--- a/image/discourse_dev/Dockerfile
+++ b/image/discourse_dev/Dockerfile
@@ -23,7 +23,7 @@ RUN /tmp/install-redis
 RUN rm -rf /var/www/*
 
 # Give discourse user no-passwd sudo permissions (for bundle install)
-ADD sudoers.discourse /etc/sudoers.d/discourse
+COPY sudoers.discourse /etc/sudoers.d/discourse
 
 RUN sudo -u discourse bundle config set --global path /home/discourse/.bundle/gems
 
@@ -45,7 +45,7 @@ RUN sed -e 's/\(db_name: discourse\)/\1_development/' /pups/postgres.template.ym
 RUN LANG=en_US.UTF-8 /pups/bin/pups /pups/postgres.yml
 
 # add dev databases
-ADD postgres_dev.template.yml /pups/postgres_dev.yml
+COPY postgres_dev.template.yml /pups/postgres_dev.yml
 RUN /pups/bin/pups /pups/postgres_dev.yml
 
 # move default postgres_data out of the way
@@ -53,7 +53,7 @@ RUN mv /shared/postgres_data /shared/postgres_data_orig
 
 # re-instantiate data on boot if needed (this will allow it to persist across
 # invocations when used with a mounted volume)
-ADD ensure-database /etc/runit/1.d/ensure-database
+COPY ensure-database /etc/runit/1.d/ensure-database
 
 # Install & Configure MailHog (https://github.com/mailhog/MailHog)
 RUN wget -qO /tmp/mailhog https://github.com/mailhog/MailHog/releases/download/v1.0.1/MailHog_linux_amd64\

--- a/image/discourse_dev/Dockerfile
+++ b/image/discourse_dev/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get -y install redis
 RUN rm -rf /var/www/*
 
 # Give discourse user no-passwd sudo permissions (for bundle install)
-ADD sudoers.discourse /etc/sudoers.d/discourse
+COPY sudoers.discourse /etc/sudoers.d/discourse
 
 RUN sudo -u discourse bundle config set --global path /home/discourse/.bundle/gems
 
@@ -50,7 +50,7 @@ RUN sed -e 's/\(db_name: discourse\)/\1_development/' /pups/postgres.template.ym
 RUN LANG=en_US.UTF-8 /pups/bin/pups /pups/postgres.yml
 
 # add dev databases
-ADD postgres_dev.template.yml /pups/postgres_dev.yml
+COPY postgres_dev.template.yml /pups/postgres_dev.yml
 RUN /pups/bin/pups /pups/postgres_dev.yml
 
 # move default postgres_data out of the way
@@ -58,7 +58,7 @@ RUN mv /shared/postgres_data /shared/postgres_data_orig
 
 # re-instantiate data on boot if needed (this will allow it to persist across
 # invocations when used with a mounted volume)
-ADD ensure-database /etc/runit/1.d/ensure-database
+COPY ensure-database /etc/runit/1.d/ensure-database
 
 # Install Mailpit, retaining the old binary name for discourse/bin/docker compatibility
 COPY --from=mailpit --chmod=0755 /mailpit /usr/local/bin/mailpit

--- a/image/discourse_test/Dockerfile
+++ b/image/discourse_test/Dockerfile
@@ -26,12 +26,12 @@ FROM base AS with_browsers
 ENV TESTEM_DEFAULT_BROWSER=Chrome
 # From https://dl.google.com/linux/linux_signing_key.pub
 # fingerprint: EB4C 1BFD 4F04 2F6D DDCC EC91 7721 F63B D38B 4796
-ADD google-linux-signing-key.pub /usr/share/keyrings/google-chrome.asc
-ADD install-chrome /tmp/install-chrome
+COPY google-linux-signing-key.pub /usr/share/keyrings/google-chrome.asc
+COPY install-chrome /tmp/install-chrome
 # From https://archive.mozilla.org/pub/firefox/releases/<any version>/KEY
 # fingerprint: 14F2 6682 D091 6CDD 81E3 7B6D 61B7 B526 D98F 0353
-ADD mozilla-release-key.asc /tmp/mozilla-release-key.asc
-ADD install-firefox /tmp/install-firefox
+COPY mozilla-release-key.asc /tmp/mozilla-release-key.asc
+COPY install-firefox /tmp/install-firefox
 RUN /tmp/install-chrome &&\
     apt update &&\
     apt install -y libgconf-2-4 libxss1 firefox-esr &&\
@@ -41,6 +41,8 @@ RUN /tmp/install-chrome &&\
 FROM with_browsers AS release
 
 RUN cd /var/www/discourse &&\
+    sudo -u discourse bundle config --local deployment true &&\
+    sudo -u discourse bundle config --local path ./vendor/bundle &&\
     sudo -u discourse bundle install --jobs $(($(nproc) - 1)) &&\
     sudo -E -u discourse -H /bin/bash -c 'CI=1 pnpm install'
 

--- a/image/discourse_test/Dockerfile
+++ b/image/discourse_test/Dockerfile
@@ -29,12 +29,12 @@ FROM base AS with_browsers
 ENV TESTEM_DEFAULT_BROWSER=Chrome
 # From https://dl.google.com/linux/linux_signing_key.pub
 # fingerprint: EB4C 1BFD 4F04 2F6D DDCC EC91 7721 F63B D38B 4796
-ADD google-linux-signing-key.pub /usr/share/keyrings/google-chrome.asc
-ADD install-chrome /tmp/install-chrome
+COPY google-linux-signing-key.pub /usr/share/keyrings/google-chrome.asc
+COPY install-chrome /tmp/install-chrome
 # From https://archive.mozilla.org/pub/firefox/releases/<any version>/KEY
 # fingerprint: 14F2 6682 D091 6CDD 81E3 7B6D 61B7 B526 D98F 0353
-ADD mozilla-release-key.asc /tmp/mozilla-release-key.asc
-ADD install-firefox /tmp/install-firefox
+COPY mozilla-release-key.asc /tmp/mozilla-release-key.asc
+COPY install-firefox /tmp/install-firefox
 RUN /tmp/install-chrome &&\
     apt update &&\
     apt install -y libxss1 firefox-esr &&\
@@ -44,6 +44,8 @@ RUN /tmp/install-chrome &&\
 FROM with_browsers AS release
 
 RUN cd /var/www/discourse &&\
+    sudo -u discourse bundle config --local deployment true &&\
+    sudo -u discourse bundle config --local path ./vendor/bundle &&\
     sudo -u discourse bundle install --jobs $(nproc --ignore=1) &&\
     sudo -E -u discourse -H /bin/bash -c 'CI=1 pnpm install'
 

--- a/image/docker-bake.cache-write.hcl
+++ b/image/docker-bake.cache-write.hcl
@@ -1,0 +1,67 @@
+target "base-runtime-deps" {
+  cache-to = [{
+    type = "registry"
+    ref = "${CACHE_IMAGE}:cache-runtime-deps-${ARCH}"
+    mode = "max"
+  }]
+}
+target "base-build-deps" {
+  cache-to = [{
+    type = "registry"
+    ref = "${CACHE_IMAGE}:cache-build-deps-${ARCH}"
+    mode = "max"
+  }]
+}
+target "base-slim" {
+  name = "base-slim-${branch}"
+  matrix = {
+    branch = ["main", "stable"]
+  }
+  cache-to = [{
+    type = "registry"
+    ref = "${CACHE_IMAGE}:cache-slim-${branch}-${ARCH}"
+    mode = "max"
+  }]
+}
+target "base-web-only" {
+  name = "base-web-only-${branch}"
+  matrix = {
+    branch = ["main", "stable"]
+  }
+  cache-to = [{
+    type = "registry"
+    ref = "${CACHE_IMAGE}:cache-web-only-${branch}-${ARCH}"
+    mode = "max"
+  }]
+}
+target "base-release" {
+  name = "base-release-${branch}"
+  matrix = {
+    branch = ["main", "stable"]
+  }
+  cache-to = [{
+    type = "registry"
+    ref = "${CACHE_IMAGE}:cache-release-${branch}-${ARCH}"
+    mode = "max"
+  }]
+}
+
+target "test" {
+  name = "test-${tag}"
+  matrix = {
+    tag = ["slim", "slim-browsers", "release"]
+  }
+  cache-to = [{
+    type = "registry"
+    ref = "${CACHE_IMAGE}:cache-test-${tag}-${ARCH}"
+    mode = "max"
+  }]
+}
+
+target "dev" {
+  cache-to = [{
+    type = "registry"
+    ref = "${CACHE_IMAGE}:cache-dev-${ARCH}"
+    mode = "max"
+  }]
+}

--- a/image/docker-bake.cache.hcl
+++ b/image/docker-bake.cache.hcl
@@ -1,0 +1,88 @@
+variable "CACHE_IMAGE" {
+  default = ""
+  validation {
+    condition = CACHE_IMAGE != ""
+    error_message = "The variable 'CACHE_IMAGE' must not be empty."
+  }
+}
+
+variable "ARCH" {
+  deafault = ""
+  validation {
+    condition = ARCH != ""
+    error_message = "The variable 'ARCH' must not be empty."
+  }
+}
+
+target "base-runtime-deps" {
+  cache-from = [{
+    type = "registry"
+    ref = "${CACHE_IMAGE}:cache-runtime-deps-${ARCH}"
+  }]
+}
+target "base-build-deps" {
+  cache-from = [{
+    type = "registry"
+    ref = "${CACHE_IMAGE}:cache-build-deps-${ARCH}"
+  }]
+}
+target "base-slim" {
+  name = "base-slim-${branch}"
+  matrix = {
+    branch = ["main", "stable"]
+  }
+  cache-from = [{
+    type = "registry"
+    ref = "${CACHE_IMAGE}:cache-slim-${branch}-${ARCH}"
+  }]
+}
+target "base-web-only" {
+  name = "base-web-only-${branch}"
+  matrix = {
+    branch = ["main", "stable"]
+  }
+  cache-from = [{
+    type = "registry"
+    ref = "${CACHE_IMAGE}:cache-web-only-${branch}-${ARCH}"
+  }]
+}
+target "base-release" {
+  name = "base-release-${branch}"
+  matrix = {
+    branch = ["main", "stable"]
+  }
+  cache-from = [{
+    type = "registry"
+    ref = "${CACHE_IMAGE}:cache-release-${branch}-${ARCH}"
+  }]
+}
+
+target "test" {
+  name = "test-${tag}"
+  matrix = {
+    tag = ["slim", "slim-browsers", "release"]
+  }
+  cache-from = [
+    {
+      type = "registry"
+      ref = "${CACHE_IMAGE}:cache-test-${tag}-${ARCH}"
+    },
+    {
+      type = "registry"
+      ref = "${CACHE_IMAGE}:cache-slim-main-${ARCH}"
+    }
+  ]
+}
+
+target "dev" {
+  cache-from = [
+    {
+      type = "registry"
+      ref = "${CACHE_IMAGE}:cache-dev-${ARCH}"
+    },
+    {
+      type = "registry"
+      ref = "${CACHE_IMAGE}:cache-slim-main-${ARCH}"
+    }
+  ]
+}

--- a/image/docker-bake.cache.hcl
+++ b/image/docker-bake.cache.hcl
@@ -7,7 +7,7 @@ variable "CACHE_IMAGE" {
 }
 
 variable "ARCH" {
-  deafault = ""
+  default = ""
   validation {
     condition = ARCH != ""
     error_message = "The variable 'ARCH' must not be empty."

--- a/image/docker-bake.hcl
+++ b/image/docker-bake.hcl
@@ -1,11 +1,3 @@
-variable "ARCH" {
-  default = "amd64,arm64"
-}
-
-variable "ARCH_ARRAY" {
-  default = split(",", ARCH)
-}
-
 variable "BASE_IMAGE" {
   default = "local_discourse/base"
 }
@@ -22,96 +14,77 @@ variable "DEV_IMAGE" {
   default = "local_discourse/discourse_dev"
 }
 
-group "base" {
-  targets = ["base-slim", "base-web-only", "base-release"]
+variable "DATESTAMP" {
+  default = "0"
 }
 
 target "base-runtime-deps" {
-  name = "base-runtime-deps-${arch}"
-  matrix = {
-    arch = ARCH_ARRAY
-  }
   context = "./base"
-  tags = ["${BASE_IMAGE}:runtime-deps-${arch}"]
+  tags = ["${BASE_IMAGE}:runtime-deps"]
   target = "discourse-runtime-base"
-  platforms = ["linux/${arch}"]
+  args = {
+    "DATESTAMP" = DATESTAMP
+  }
 }
 
 target "base-build-deps" {
-  name = "base-build-deps-${arch}"
-  matrix = {
-    arch = ARCH_ARRAY
-  }
   context = "./base"
-  tags = ["${BASE_IMAGE}:build-deps-${arch}"]
+  tags = ["${BASE_IMAGE}:build-deps"]
   target = "discourse-build-base"
-  platforms = ["linux/${arch}"]
 }
 
 target "base-slim" {
-  name = "base-slim-${branch}-${arch}"
+  name = "base-slim-${branch}"
   matrix = {
-    arch = ARCH_ARRAY
     branch = ["main", "stable"]
   }
   context = "./base"
-  tags = ["${BASE_IMAGE}:slim-${branch}-${arch}"]
+  tags = ["${BASE_IMAGE}:slim-${branch}"]
   target = "discourse-slim"
-  platforms = ["linux/${arch}"]
   args = {
     "DISCOURSE_BRANCH" = "${branch}"
   }
 }
 
 target "base-web-only" {
-  name = "base-web-only-${branch}-${arch}"
+  name = "base-web-only-${branch}"
   matrix = {
-    arch = ARCH_ARRAY
     branch = ["main", "stable"]
   }
   context = "./base"
-  tags = ["${BASE_IMAGE}:web-only-${branch}-${arch}"]
+  tags = ["${BASE_IMAGE}:web-only-${branch}"]
   target = "discourse-web-only"
-  platforms = ["linux/${arch}"]
   args = {
     "DISCOURSE_BRANCH" = "${branch}"
   }
 }
 
 target "base-release" {
-  name = "base-release-${branch}-${arch}"
+  name = "base-release-${branch}"
   matrix = {
-    arch = ARCH_ARRAY
     branch = ["main", "stable"]
   }
   context = "./base"
-  tags = ["${BASE_IMAGE}:release-${branch}-${arch}"]
+  tags = ["${BASE_IMAGE}:release-${branch}"]
   target = "discourse-release"
-  platforms = ["linux/${arch}"]
   args = {
     "DISCOURSE_BRANCH" = "${branch}"
   }
 }
 
-# depends on raw arch image, canary build for test images when building base images
 target "test" {
-  name = "test-${build_target.tag}-${arch}"
+  name = "test-${build_target.tag}"
   matrix = {
-    arch = ARCH_ARRAY
-    branch = ["main"]
     build_target = [
       {
-        from_tag = "slim"
         target_name = "base"
         tag = "slim"
       },
       {
-        from_tag = "slim"
         target_name = "with_browsers"
         tag = "slim-browsers"
       },
       {
-        from_tag = "release"
         target_name = "release"
         tag = "release"
       }
@@ -119,40 +92,30 @@ target "test" {
   }
   target = build_target.target_name
   context = "./discourse_test"
-  platforms = ["linux/${arch}"]
-  tags = ["${TEST_IMAGE}:${build_target.tag}-${arch}"]
+  tags = ["${TEST_IMAGE}:${build_target.tag}"]
   args = {
     "from_tag" = "from"
+    "SOURCE_DATE_EPOCH" = 0
   }
   contexts = {
-    from = "target:base-${build_target.from_tag}-${branch}-${arch}"
+    from = "target:base-slim-main"
   }
 }
 
 target "dev" {
-  name = "dev-${arch}"
-  matrix = {
-    arch = ARCH_ARRAY
-    branch = ["main"]
-  }
   context = "./discourse_dev"
-  tags = ["${DEV_IMAGE}:release-${arch}"]
-  platforms = ["linux/${arch}"]
+  tags = ["${DEV_IMAGE}:release"]
   args = {
     "from_tag" = "from"
+    "SOURCE_DATE_EPOCH" = 0
   }
   contexts = {
-    from = "target:base-slim-${branch}-${arch}"
+    from = "target:base-slim-main"
     templates = "../templates"
   }
 }
 
 target "setup-wizard" {
-  name = "setup-wizard-${arch}"
-  matrix = {
-    arch = ARCH_ARRAY
-  }
   context = "./setup_wizard"
-  tags = ["${SETUP_WIZARD_IMAGE}:release-${arch}"]
-  platforms = ["linux/${arch}"]
+  tags = ["${SETUP_WIZARD_IMAGE}:release"]
 }

--- a/image/docker-bake.hcl
+++ b/image/docker-bake.hcl
@@ -31,6 +31,9 @@ target "base-build-deps" {
   context = "./base"
   tags = ["${BASE_IMAGE}:build-deps"]
   target = "discourse-build-base"
+  args = {
+    "DATESTAMP" = DATESTAMP
+  }
 }
 
 target "base-slim" {
@@ -43,6 +46,7 @@ target "base-slim" {
   target = "discourse-slim"
   args = {
     "DISCOURSE_BRANCH" = "${branch}"
+    "DATESTAMP" = DATESTAMP
   }
 }
 
@@ -56,6 +60,7 @@ target "base-web-only" {
   target = "discourse-web-only"
   args = {
     "DISCOURSE_BRANCH" = "${branch}"
+    "DATESTAMP" = DATESTAMP
   }
 }
 
@@ -69,6 +74,7 @@ target "base-release" {
   target = "discourse-release"
   args = {
     "DISCOURSE_BRANCH" = "${branch}"
+    "DATESTAMP" = DATESTAMP
   }
 }
 
@@ -96,6 +102,7 @@ target "test" {
   args = {
     "from_tag" = "from"
     "SOURCE_DATE_EPOCH" = 0
+    "DATESTAMP" = DATESTAMP
   }
   contexts = {
     from = "target:base-slim-main"
@@ -108,6 +115,7 @@ target "dev" {
   args = {
     "from_tag" = "from"
     "SOURCE_DATE_EPOCH" = 0
+    "DATESTAMP" = DATESTAMP
   }
   contexts = {
     from = "target:base-slim-main"

--- a/image/docker-bake.push.hcl
+++ b/image/docker-bake.push.hcl
@@ -1,0 +1,56 @@
+# push targets, push by digests
+target "_common-push" {
+  output = [{
+    type = "registry",
+    push-by-digest = true
+  }]
+}
+
+target "base-runtime-deps" {
+  inherits = ["_common-push"]
+  tags = [BASE_IMAGE]
+}
+target "base-build-deps" {
+  inherits = ["_common-push"]
+  tags = [BASE_IMAGE]
+}
+target "base-slim" {
+  name = "base-slim-${branch}"
+  matrix = {
+    branch = ["main", "stable"]
+  }
+  inherits = ["_common-push"]
+  tags = [BASE_IMAGE]
+}
+target "base-web-only" {
+  name = "base-web-only-${branch}"
+  matrix = {
+    branch = ["main", "stable"]
+  }
+  inherits = ["_common-push"]
+  tags = [BASE_IMAGE]
+}
+target "base-release" {
+  name = "base-release-${branch}"
+  matrix = {
+    branch = ["main", "stable"]
+  }
+  inherits = ["_common-push"]
+  tags = [BASE_IMAGE]
+}
+target "dev" {
+  inherits = ["dev", "_common-push"]
+  tags = [DEV_IMAGE]
+}
+target "test" {
+  name = "test-${tag}"
+  matrix = {
+    tag = ["slim", "slim-browsers", "release"]
+  }
+  inherits = ["_common-push"]
+  tags = [TEST_IMAGE]
+}
+target "setup-wizard" {
+  inherits = ["_common-push"]
+  tags = [SETUP_WIZARD_IMAGE]
+}


### PR DESCRIPTION
Add build cache to builds, cache to ghcr. Cache by current date.

Refactor bake config: remove references to arch, and split up bake configuration to be able to compose image building into parts:
* base bake
* push
* cache-read
* cache-write

Allows for cache-read on PR, cache-read+write on main builds, push after tests on main.

For caching, we unfortunately explicitly need to run docker buildx bake TARGET for EVERY target individually. Targeting a group or multiple targets at the same time results in cache misses with seemingly no rhyme or reason - I'm guessing that despite each target having a separate cache-from/cache-to config, the cache-* sections are all grouped together across the entire build. Docker build caches apparently take the first matching cache, and discard the rest despite a cache-hit being possibly available in a different cache.

Allow cache to be flushed by searching for untagged images on ghcr, and delete

Fix test build to build every step from slim, previously the test release would build from base:release. Now it builds from the previous test build step

Publish runtime-deps-only image

prefer COPY to ADD as COPY for explicitly for copying docker contexts.