### PR TITLE
DEV: bump nginx to v1.30.4

### DIFF
--- a/image/base/install-nginx
+++ b/image/base/install-nginx
@@ -2,7 +2,7 @@
 set -e
 
 # version check: https://nginx.org/en/download.html
-VERSION=1.30.2
+VERSION=1.30.4
 
 cd /tmp
 wget -q https://nginx.org/download/nginx-$VERSION.tar.gz


### PR DESCRIPTION
Resolves CVE-2026-42533, CVE-2026-60005, and CVE-2026-56434 (fixed in 1.30.4), along with CVE-2026-42055 and CVE-2026-48142 (fixed in 1.30.3).

https://nginx.org/en/security_advisories.html