### PR TITLE
DEV: build and pin libheif 1.23.1

### DIFF
--- a/image/base/Dockerfile
+++ b/image/base/Dockerfile
@@ -19,11 +19,15 @@ DEBIAN_FRONTEND=noninteractive apt-get -y install wget \
     libfreetype6-dev \
     libbrotli-dev
 
-FROM builder AS imagemagick_builder
+FROM builder AS libheif-builder
+ADD install-libheif /tmp/install-libheif
+RUN /tmp/install-libheif
+
+FROM libheif-builder AS imagemagick_builder
 ADD install-imagemagick /tmp/install-imagemagick
 RUN /tmp/install-imagemagick
 
-FROM builder AS vips-builder
+FROM libheif-builder AS vips-builder
 ADD install-vips /tmp/install-vips
 RUN /tmp/install-vips
 
@@ -75,11 +79,15 @@ RUN groupadd --gid 104 postgres &&\
 RUN echo 2.0.`date +%Y%m%d` > /VERSION
 RUN echo "deb http://deb.debian.org/debian ${DEBIAN_RELEASE}-backports main" > "/etc/apt/sources.list.d/${DEBIAN_RELEASE}-backports.list"
 
+COPY --from=libheif-builder /tmp/libheif-packages/libheif1.deb /tmp/libheif1.deb
+COPY --from=libheif-builder /tmp/libheif-packages/discourse-libheif-guard.deb /tmp/discourse-libheif-guard.deb
+
 RUN --mount=type=tmpfs,target=/var/log \
   --mount=type=tmpfs,target=/var/cache/apt \
   --mount=type=tmpfs,target=/var/lib/apt \
     echo "debconf debconf/frontend select Teletype" | debconf-set-selections; \
     apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
+    /tmp/libheif1.deb /tmp/discourse-libheif-guard.deb \
 # discourse runtime requirements
   gnupg sudo curl fping locales \
   ca-certificates rsync \
@@ -92,7 +100,7 @@ RUN --mount=type=tmpfs,target=/var/log \
 # imagemagick runtime dependencies
     libjbig0 libtiff6 libpng16-16 libfontconfig1 \
     libwebpdemux2 libwebpmux3 libxext6 librsvg2-2 libgomp1 \
-    fonts-urw-base35 libheif1/${DEBIAN_RELEASE}-backports \
+    fonts-urw-base35 \
 # oxipng dependencies \
     advancecomp jpegoptim libjpeg-turbo-progs \
 # libvips runtime dependencies (safe_image; vips itself is built from source)
@@ -116,7 +124,10 @@ RUN --mount=type=tmpfs,target=/var/log \
     sh -c "test -f /sbin/initctl || ln -s /bin/true /sbin/initctl"; \
     apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get -y install runit socat \
     libpq-dev postgresql-client-${PG_MAJOR} postgresql-client-18 &&\
-    mkdir -p /etc/runit/1.d
+    mkdir -p /etc/runit/1.d &&\
+    apt-mark hold libheif1 discourse-libheif-guard &&\
+    rm /tmp/libheif1.deb /tmp/discourse-libheif-guard.deb &&\
+    test "$(dpkg-query -W -f='${Version}' libheif1)" = "1.23.1-1discourse1"
 
 ENV LC_ALL=en_US.UTF-8
 ENV LANG=en_US.UTF-8
@@ -147,6 +158,7 @@ RUN ln -s /usr/local/bin/magick /usr/local/bin/animate &&\
 
 COPY --from=vips-builder /usr/local/lib/libvips.so.42 /usr/local/lib/libvips.so.42
 RUN ldconfig &&\
+  ruby -rfiddle -e 'lib = Fiddle.dlopen("libheif.so.1"); version = Fiddle::Function.new(lib["heif_get_version"], [], Fiddle::TYPE_VOIDP); abort "unexpected libheif version" unless Fiddle::Pointer.new(version.call).to_s == "1.23.1"' &&\
   ruby -rfiddle -e 'Fiddle.dlopen("libvips.so.42")' &&\
   if dpkg-query -W -f '${Package} ${db:Status-Status}\n' ghostscript libgs10 libgs-common libgs10-common 2>/dev/null | grep -q ' installed$' || command -v gs >/dev/null; then \
     echo "ERROR: ghostscript must not be present in this image"; exit 1; \

--- a/image/base/install-imagemagick
+++ b/image/base/install-imagemagick
@@ -2,8 +2,8 @@
 set -e
 
 # version check: https://github.com/ImageMagick/ImageMagick/releases
-IMAGE_MAGICK_VERSION="7.1.2-25"
-IMAGE_MAGICK_HASH="ff33d227d2e1744327280e956ec9f7abaebbd8f48277d16cdad906e05e4794b6"
+IMAGE_MAGICK_VERSION="7.1.2-27"
+IMAGE_MAGICK_HASH="485dad5226fda2417ea65f3eb6e3f63e7d5dfacacdf6f57f9c39b6ef1e3cb667"
 
 LIBJPEGTURBO=$(cat /etc/issue | grep -qi Debian && echo 'libjpeg62-turbo libjpeg62-turbo-dev' || echo 'libjpeg-turbo8 libjpeg-turbo8-dev')
 
@@ -17,15 +17,6 @@ apt -y -q install git make gcc pkg-config autoconf curl g++ yasm cmake \
     libpng16-16 libpng-dev libwebp-dev libgomp1 libaom-dev \
     libwebpmux3 libwebpdemux2 libxml2-dev libxml2-utils librsvg2-dev \
     libltdl7-dev libbz2-dev gsfonts libtiff-dev libfreetype6-dev libjpeg-dev
-
-if cat /etc/issue | grep -qi Debian; then
-  # Get VERSION_CODENAME
-  . /etc/os-release
-  # Use backports
-  apt -y -q install libheif1/$VERSION_CODENAME-backports libheif-dev/$VERSION_CODENAME-backports
-else
-  apt -y -q install libheif1 libheif-dev
-fi
 
 mkdir -p $WDIR
 cd $WDIR

--- a/image/base/install-libheif
+++ b/image/base/install-libheif
@@ -1,0 +1,124 @@
+#!/bin/bash
+set -e
+
+# version check: https://github.com/strukturag/libheif/releases
+LIBHEIF_VERSION="1.23.1"
+PACKAGE_VERSION="$LIBHEIF_VERSION-1discourse1"
+LIBHEIF_HASH="0de0327f60fcd47de90d5654c6fe152232738d60d84fe084ec3e0f35e03b166a"
+
+PREFIX=/usr
+WDIR=/tmp/libheif
+PACKAGE_DIR=/tmp/libheif-packages
+
+export DEBIAN_FRONTEND=noninteractive
+apt -y -q install ninja-build pkg-config dpkg-dev libde265-dev libx265-dev libaom-dev
+
+MULTIARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH)
+ARCHITECTURE=$(dpkg --print-architecture)
+test -n "$MULTIARCH"
+test -n "$ARCHITECTURE"
+
+mkdir -p "$WDIR" "$PACKAGE_DIR"
+cd "$WDIR"
+
+wget -q -O "$WDIR/libheif.tar.gz" "https://github.com/strukturag/libheif/releases/download/v$LIBHEIF_VERSION/libheif-$LIBHEIF_VERSION.tar.gz"
+echo "$LIBHEIF_HASH $WDIR/libheif.tar.gz" | sha256sum -c
+tar xzf "$WDIR/libheif.tar.gz" -C "$WDIR"
+cd "$WDIR/libheif-$LIBHEIF_VERSION"
+
+cmake -S . -B build -G Ninja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX=$PREFIX \
+  "-DCMAKE_INSTALL_LIBDIR=lib/$MULTIARCH" \
+  -DBUILD_SHARED_LIBS=ON \
+  -DBUILD_TESTING=OFF \
+  -DBUILD_DOCUMENTATION=OFF \
+  -DENABLE_PLUGIN_LOADING=OFF \
+  -DWITH_EXAMPLES=OFF \
+  -DWITH_GDK_PIXBUF=OFF \
+  -DWITH_LIBDE265=ON \
+  -DWITH_X265=ON \
+  -DWITH_AOM_DECODER=ON \
+  -DWITH_AOM_ENCODER=ON \
+  -DWITH_X264=OFF \
+  -DWITH_OpenH264_DECODER=OFF
+
+cmake --build build -j"$(nproc)"
+DESTDIR="$WDIR/install" cmake --install build
+
+RUNTIME_ROOT="$WDIR/package-libheif1"
+DEV_ROOT="$WDIR/package-libheif-dev"
+GUARD_ROOT="$WDIR/package-discourse-libheif-guard"
+LIBDIR="usr/lib/$MULTIARCH"
+mkdir -p "$RUNTIME_ROOT/$LIBDIR" "$DEV_ROOT" "$GUARD_ROOT/DEBIAN"
+cp -a "$WDIR/install/." "$DEV_ROOT"
+mv "$DEV_ROOT/$LIBDIR"/libheif.so.1* "$RUNTIME_ROOT/$LIBDIR/"
+
+mkdir -p debian
+cat > debian/control <<EOF
+Source: libheif
+Section: libs
+Priority: optional
+Maintainer: Discourse Team <team@discourse.org>
+
+Package: libheif1
+Architecture: any
+Description: HEIF and AVIF codec library built for Discourse
+EOF
+RUNTIME_DEPENDS=$(dpkg-shlibdeps -O "$RUNTIME_ROOT/$LIBDIR/libheif.so.$LIBHEIF_VERSION" | sed -n 's/^shlibs:Depends=//p')
+test -n "$RUNTIME_DEPENDS"
+
+mkdir -p "$RUNTIME_ROOT/DEBIAN" "$DEV_ROOT/DEBIAN"
+cat > "$RUNTIME_ROOT/DEBIAN/control" <<EOF
+Package: libheif1
+Version: $PACKAGE_VERSION
+Architecture: $ARCHITECTURE
+Maintainer: Discourse Team <team@discourse.org>
+Section: libs
+Priority: optional
+Depends: $RUNTIME_DEPENDS
+Description: HEIF and AVIF codec library built for Discourse
+ Pinned libheif build used by Discourse's ImageMagick and libvips.
+EOF
+cat > "$DEV_ROOT/DEBIAN/control" <<EOF
+Package: libheif-dev
+Version: $PACKAGE_VERSION
+Architecture: $ARCHITECTURE
+Maintainer: Discourse Team <team@discourse.org>
+Section: libdevel
+Priority: optional
+Depends: libheif1 (= $PACKAGE_VERSION)
+Description: HEIF and AVIF codec development files built for Discourse
+ Development headers and metadata for the pinned Discourse libheif build.
+EOF
+cat > "$GUARD_ROOT/DEBIAN/control" <<EOF
+Package: discourse-libheif-guard
+Version: $PACKAGE_VERSION
+Architecture: all
+Maintainer: Discourse Team <team@discourse.org>
+Section: libs
+Priority: optional
+Depends: libheif1 (= $PACKAGE_VERSION)
+Conflicts: libheif1 (<< $PACKAGE_VERSION)
+Description: Prevent replacement of Discourse's pinned libheif build
+ This guard makes direct installation of an older libheif1 package fail.
+EOF
+
+dpkg-deb --build --root-owner-group "$RUNTIME_ROOT" "$PACKAGE_DIR/libheif1.deb"
+dpkg-deb --build --root-owner-group "$DEV_ROOT" "$PACKAGE_DIR/libheif-dev.deb"
+dpkg-deb --build --root-owner-group "$GUARD_ROOT" "$PACKAGE_DIR/discourse-libheif-guard.deb"
+dpkg -i "$PACKAGE_DIR/libheif1.deb" "$PACKAGE_DIR/libheif-dev.deb" "$PACKAGE_DIR/discourse-libheif-guard.deb"
+ldconfig
+
+# Keep HEVC and AV1 support built into the library so no libheif plugins need
+# to be installed in the runtime image.
+test "$(pkg-config --modversion libheif)" = "$LIBHEIF_VERSION"
+ldd "$PREFIX/lib/$MULTIARCH/libheif.so.1" | grep -q 'libde265\.so'
+ldd "$PREFIX/lib/$MULTIARCH/libheif.so.1" | grep -q 'libx265\.so'
+ldd "$PREFIX/lib/$MULTIARCH/libheif.so.1" | grep -q 'libaom\.so'
+
+dpkg-query -W -f='${Version}\n' libheif1 | grep -qx "$PACKAGE_VERSION"
+dpkg-query -S "$PREFIX/lib/$MULTIARCH/libheif.so.$LIBHEIF_VERSION" | grep -q '^libheif1:'
+
+cd "$HOME"
+rm -rf "$WDIR"

--- a/image/base/install-redis
+++ b/image/base/install-redis
@@ -2,8 +2,8 @@
 set -e
 
 # version check: https://redis.io/
-REDIS_VERSION=7.4.9
-REDIS_HASH="a71a67b47b2705d3448f0400573e3ad5c4c9f8c18236f426dc6acc7284bf42ad"
+REDIS_VERSION=7.4.10
+REDIS_HASH="669ab6689b5e7d0c479e8d526ccbadae36b69a11370742ffe23822b9df8d85ba"
 
 cd /tmp
 # Prepare Redis source.

--- a/image/base/install-vips
+++ b/image/base/install-vips
@@ -2,8 +2,8 @@
 set -e
 
 # version check: https://github.com/libvips/libvips/releases
-VIPS_VERSION="8.18.3"
-VIPS_HASH="f41285b61bfb495605494f074ca341f7791a1d406e2f157dcea606ef1ae1b146"
+VIPS_VERSION="8.18.4"
+VIPS_HASH="2677bad6c422617fd1172d359c16af34e736965d042c214203a87187d26ff037"
 
 LIBJPEGTURBO=$(cat /etc/issue | grep -qi Debian && echo 'libjpeg62-turbo-dev' || echo 'libjpeg-turbo8-dev')
 
@@ -16,13 +16,6 @@ apt -y -q install meson ninja-build pkg-config xz-utils \
     libpng-dev libwebp-dev libtiff-dev libjxl-dev librsvg2-dev \
     libcgif-dev libexif-dev liblcms2-dev liborc-0.4-dev \
     libimagequant-dev libpango1.0-dev
-
-if cat /etc/issue | grep -qi Debian; then
-  . /etc/os-release
-  apt -y -q install libheif1/$VERSION_CODENAME-backports libheif-dev/$VERSION_CODENAME-backports
-else
-  apt -y -q install libheif1 libheif-dev
-fi
 
 mkdir -p $WDIR
 cd $WDIR


### PR DESCRIPTION
Build libheif with HEVC and AV1 support for ImageMagick and libvips instead of relying on Debian backports. Package and hold the runtime library with a guard package to prevent accidental downgrades, and verify the expected version in the final image.

Also bump ImageMagick to 7.1.2-27, libvips to 8.18.4, and Redis to 7.4.10.
