### PR TITLE
FIX: Add libvips build dependencies for safe_image

### DIFF
--- a/image/base/Dockerfile
+++ b/image/base/Dockerfile
@@ -208,6 +208,7 @@ RUN --mount=type=tmpfs,target=/var/log \
 # gem build dependencies
     cmake g++ pkg-config patch \
     libtool \
+    libglib2.0-dev \
     libxslt-dev \
     libcurl4-openssl-dev \
     libssl-dev \
@@ -217,6 +218,14 @@ RUN --mount=type=tmpfs,target=/var/log \
     libunwind-dev \
 # node
     nodejs yarn
+
+# safe_image gem build dependencies
+COPY --from=vips-builder /usr/local/include/vips /usr/local/include/vips
+COPY --from=vips-builder /usr/local/lib/pkgconfig/vips.pc /usr/local/lib/pkgconfig/vips.pc
+# Dynamic consumers need the linker name but not metadata for private codec dependencies.
+RUN ln -s libvips.so.42 /usr/local/lib/libvips.so &&\
+    sed -i '/^Requires.private:/d' /usr/local/lib/pkgconfig/vips.pc
+
 # pnpm
 RUN --mount=type=tmpfs,target=/root/.npm \
     npm install -g pnpm@10


### PR DESCRIPTION
The build image had the libvips runtime library but omitted the development files required to compile safe_image's native helper, leaving the vips backend unavailable after Bundler installed the gem.

This commit copies the source-built headers and pkg-config metadata into the build stage, installs the public GLib development dependency, and provides the unversioned linker name from the existing runtime library. It drops private pkg-config requirements because the image dynamically links libvips and does not need development metadata for libvips' private codec dependencies.