### PR TITLE
FEATURE: Add PostgreSQL 18 to the base image

### DIFF
--- a/image/base/Dockerfile
+++ b/image/base/Dockerfile
@@ -61,7 +61,8 @@ RUN /tmp/install-cjpegli
 FROM discourse/ruby:${FROM_DOCKER_IMAGE_TAG} AS discourse-runtime-base
 
 ARG DEBIAN_RELEASE
-ARG PG_MAJOR=15
+ARG PG_MAJOR=18
+ARG PG_MAJOR_OLD=15
 ENV PG_MAJOR=${PG_MAJOR} \
     RUBY_ALLOCATOR=/usr/lib/libjemalloc.so \
     LEFTHOOK=0 \
@@ -123,7 +124,7 @@ RUN --mount=type=tmpfs,target=/var/log \
     dpkg-divert --local --rename --add /sbin/initctl; \
     sh -c "test -f /sbin/initctl || ln -s /bin/true /sbin/initctl"; \
     apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get -y install runit socat \
-    libpq-dev postgresql-client-${PG_MAJOR} postgresql-client-18 &&\
+    libpq-dev postgresql-client-${PG_MAJOR} postgresql-client-${PG_MAJOR_OLD} &&\
     mkdir -p /etc/runit/1.d &&\
     apt-mark hold libheif1 discourse-libheif-guard &&\
     rm /tmp/libheif1.deb /tmp/discourse-libheif-guard.deb &&\

--- a/image/discourse_dev/Dockerfile
+++ b/image/discourse_dev/Dockerfile
@@ -40,7 +40,7 @@ ENV LANG=en_US.UTF-8 \
     LC_ALL=en_US.UTF-8
 
 # get postgres going
-COPY --from=templates /postgres.template.yml /pups/postgres.template.yml
+COPY --from=templates /postgres.${PG_MAJOR}.template.yml /pups/postgres.template.yml
 RUN sed -e 's/\(db_name: discourse\)/\1_development/' /pups/postgres.template.yml > /pups/postgres.yml
 RUN LANG=en_US.UTF-8 /pups/bin/pups /pups/postgres.yml
 

--- a/image/discourse_dev/postgres_dev.template.yml
+++ b/image/discourse_dev/postgres_dev.template.yml
@@ -1,12 +1,12 @@
 run:
 
   - replace:
-      filename: "/etc/postgresql/15/main/postgresql.conf"
+      filename: "/etc/postgresql/18/main/postgresql.conf"
       from: /#?full_page_writes *=.*/
       to: "full_page_writes = off"
 
   - replace:
-      filename: "/etc/postgresql/15/main/postgresql.conf"
+      filename: "/etc/postgresql/18/main/postgresql.conf"
       from: /#?fsync *=.*/
       to: "fsync = off"
 
@@ -14,7 +14,7 @@ run:
       background: true
       # use fast shutdown for pg
       stop_signal: INT
-      cmd: HOME=/var/lib/postgresql USER=postgres exec chpst -u postgres:postgres:ssl-cert -U postgres:postgres:ssl-cert /usr/lib/postgresql/15/bin/postmaster -D /etc/postgresql/15/main
+      cmd: HOME=/var/lib/postgresql USER=postgres exec chpst -u postgres:postgres:ssl-cert -U postgres:postgres:ssl-cert /usr/lib/postgresql/18/bin/postgres -D /etc/postgresql/18/main
 
   - exec:
       background: true


### PR DESCRIPTION
This is a prerequisite for using PG18 in the base image. Once the new image has been built and published we will update the templates to use it.

The dev image does not use a pinned version so has been updated for PG18 already.

Note we are still installing the PG15 client alongside PG18 for now. This allows the app to backup/restore to both versions on our hosted platform during the upgrade period.