### PR TITLE
Postgres: Fix free disk calculation before upgrade

### DIFF
--- a/templates/postgres.18.template.yml
+++ b/templates/postgres.18.template.yml
@@ -113,7 +113,7 @@ run:
 
           echo Upgrading PostgreSQL from version ${PG_MAJOR_OLD} to 18
           free_disk=$(df -P -B1 /shared | tail -n 1 | awk '{print $4}')
-          required=$(($(du -sb /shared/postgres_data | awk '{print $1}') * 3))
+          required=$(($(du -sb /shared/postgres_data | awk '{print $1}') * 2))
 
           if [ "$free_disk" -lt "$required" ]; then
             echo

--- a/templates/postgres.template.yml
+++ b/templates/postgres.template.yml
@@ -114,7 +114,7 @@ run:
 
           echo Upgrading PostgreSQL from version ${PG_MAJOR_OLD} to 18
           free_disk=$(df -P -B1 /shared | tail -n 1 | awk '{print $4}')
-          required=$(($(du -sb /shared/postgres_data | awk '{print $1}') * 3))
+          required=$(($(du -sb /shared/postgres_data | awk '{print $1}') * 2))
 
           if [ "$free_disk" -lt "$required" ]; then
             echo


### PR DESCRIPTION
We need enough space to store the old DB, new DB and the dump. The old DB is already on disk. pg_dump output is usually smaller than the data directory size (no indices or bloat) so 2x the current DB size should be enough free space.