### PR TITLE
Fix CPU count detection for single core machines

### DIFF
--- a/image/base/Dockerfile
+++ b/image/base/Dockerfile
@@ -253,7 +253,7 @@ RUN cd /var/www/discourse &&\
     sudo -u discourse bundle config --local deployment true &&\
     sudo -u discourse bundle config --local path ./vendor/bundle &&\
     sudo -u discourse bundle config --local without test development &&\
-    sudo -u discourse bundle install --jobs $(($(nproc) - 1)) &&\
+    sudo -u discourse bundle install --jobs $(nproc --ignore=1) &&\
     find /var/www/discourse/vendor/bundle -name cache -not -path '*/gems/*' -type d -exec rm -rf {} + &&\
     find /var/www/discourse/vendor/bundle -name tmp -type d -exec rm -rf {} +
 

--- a/image/discourse_test/Dockerfile
+++ b/image/discourse_test/Dockerfile
@@ -42,7 +42,7 @@ RUN /tmp/install-chrome &&\
 FROM with_browsers AS release
 
 RUN cd /var/www/discourse &&\
-    sudo -u discourse bundle install --jobs $(($(nproc) - 1)) &&\
+    sudo -u discourse bundle install --jobs $(nproc --ignore=1) &&\
     sudo -E -u discourse -H /bin/bash -c 'CI=1 pnpm install'
 
 RUN cd /var/www/discourse && sudo -E -u discourse -H bundle exec rake plugin:install_all_official &&\

--- a/templates/import/mbox.template.yml
+++ b/templates/import/mbox.template.yml
@@ -34,4 +34,4 @@ hooks:
           - apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y libsqlite3-dev
           - echo "gem 'sqlite3'" >> Gemfile
           - su discourse -c 'bundle config unset deployment'
-          - su discourse -c 'bundle install --no-deployment --path vendor/bundle --jobs $(($(nproc) - 1)) --without test development'
+          - su discourse -c 'bundle install --no-deployment --path vendor/bundle --jobs $(nproc --ignore=1) --without test development'

--- a/templates/import/mssql-dep.template.yml
+++ b/templates/import/mssql-dep.template.yml
@@ -22,4 +22,4 @@ hooks:
         cmd:
           - echo "gem 'tiny_tds'" >> Gemfile
           - su discourse -c 'bundle config unset deployment'
-          - su discourse -c 'bundle install --no-deployment --path vendor/bundle --jobs $(($(nproc) - 1)) --without test development'
+          - su discourse -c 'bundle install --no-deployment --path vendor/bundle --jobs $(nproc --ignore=1) --without test development'

--- a/templates/import/mysql-dep.template.yml
+++ b/templates/import/mysql-dep.template.yml
@@ -11,4 +11,4 @@ hooks:
           - echo "gem 'mysql2'" >> Gemfile
           - apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y libmariadb-dev
           - su discourse -c 'bundle config unset deployment'
-          - su discourse -c 'bundle install --no-deployment --path vendor/bundle --jobs $(($(nproc) - 1)) --without test development'
+          - su discourse -c 'bundle install --no-deployment --path vendor/bundle --jobs $(nproc --ignore=1) --without test development'

--- a/templates/import/phpbb3.template.yml
+++ b/templates/import/phpbb3.template.yml
@@ -115,4 +115,4 @@ hooks:
           - echo "gem 'mysql2'" >> Gemfile
           - echo "gem 'ruby-bbcode-to-md', :github => 'nlalonde/ruby-bbcode-to-md'" >> Gemfile
           - su discourse -c 'bundle config unset deployment'
-          - su discourse -c 'bundle install --no-deployment --path vendor/bundle --jobs $(($(nproc) - 1)) --without test development'
+          - su discourse -c 'bundle install --no-deployment --path vendor/bundle --jobs $(nproc --ignore=1) --without test development'

--- a/templates/import/vanilla.template.yml
+++ b/templates/import/vanilla.template.yml
@@ -114,7 +114,7 @@ hooks:
           - echo "gem 'mysql2'" >> Gemfile
           - echo "gem 'ruby-bbcode-to-md', :github => 'nlalonde/ruby-bbcode-to-md'" >> Gemfile
           - su discourse -c 'bundle config unset deployment'
-          - su discourse -c 'bundle install --no-deployment --path vendor/bundle --jobs $(($(nproc) - 1)) --without test development'
+          - su discourse -c 'bundle install --no-deployment --path vendor/bundle --jobs $(nproc --ignore=1) --without test development'
           - service mariadb start
           # imports the DB into mysql
           - sh /usr/local/bin/import_flarum_test.sh

--- a/templates/postgres.18.template.yml
+++ b/templates/postgres.18.template.yml
@@ -151,13 +151,13 @@ run:
         
           su postgres -c "/usr/lib/postgresql/${PG_MAJOR_OLD}/bin/pg_ctl start -D /shared/postgres_data -o '-p 5432'"
           su postgres -c "/usr/lib/postgresql/${PG_MAJOR_OLD}/bin/pg_dumpall --globals-only --clean --if-exists -f /shared/postgres_dump/globals.sql"
-          su postgres -c "/usr/lib/postgresql/${PG_MAJOR_OLD}/bin/pg_dump -Fd -j$(($(nproc) - 1)) discourse -f /shared/postgres_dump/discourse"
+          su postgres -c "/usr/lib/postgresql/${PG_MAJOR_OLD}/bin/pg_dump -Fd -j$(nproc --ignore=1) discourse -f /shared/postgres_dump/discourse"
           su postgres -c "/usr/lib/postgresql/${PG_MAJOR_OLD}/bin/pg_ctl stop -D /shared/postgres_data"
         
           su postgres -c "/usr/lib/postgresql/18/bin/pg_ctl start -D /shared/postgres_data_new"
           su postgres -c "/usr/lib/postgresql/18/bin/psql -c \"CREATE DATABASE discourse WITH TEMPLATE = template0 ENCODING = 'UTF8'\""
           su postgres -c "/usr/lib/postgresql/18/bin/psql -f /shared/postgres_dump/globals.sql"
-          su postgres -c "/usr/lib/postgresql/18/bin/pg_restore -e -j$(($(nproc) - 1)) -d discourse /shared/postgres_dump/discourse"
+          su postgres -c "/usr/lib/postgresql/18/bin/pg_restore -e -j$(nproc --ignore=1) -d discourse /shared/postgres_dump/discourse"
           su postgres -c "/usr/lib/postgresql/18/bin/pg_ctl stop -D /shared/postgres_data_new"
         
           rm -fr /shared/postgres_dump

--- a/templates/postgres.template.yml
+++ b/templates/postgres.template.yml
@@ -152,13 +152,13 @@ run:
         
           su postgres -c "/usr/lib/postgresql/${PG_MAJOR_OLD}/bin/pg_ctl start -D /shared/postgres_data -o '-p 5432'"
           su postgres -c "/usr/lib/postgresql/${PG_MAJOR_OLD}/bin/pg_dumpall --globals-only --clean --if-exists -f /shared/postgres_dump/globals.sql"
-          su postgres -c "/usr/lib/postgresql/${PG_MAJOR_OLD}/bin/pg_dump -Fd -j$(($(nproc) - 1)) discourse -f /shared/postgres_dump/discourse"
+          su postgres -c "/usr/lib/postgresql/${PG_MAJOR_OLD}/bin/pg_dump -Fd -j$(nproc --ignore=1) discourse -f /shared/postgres_dump/discourse"
           su postgres -c "/usr/lib/postgresql/${PG_MAJOR_OLD}/bin/pg_ctl stop -D /shared/postgres_data"
         
           su postgres -c "/usr/lib/postgresql/18/bin/pg_ctl start -D /shared/postgres_data_new"
           su postgres -c "/usr/lib/postgresql/18/bin/psql -c \"CREATE DATABASE discourse WITH TEMPLATE = template0 ENCODING = 'UTF8'\""
           su postgres -c "/usr/lib/postgresql/18/bin/psql -f /shared/postgres_dump/globals.sql"
-          su postgres -c "/usr/lib/postgresql/18/bin/pg_restore -e -j$(($(nproc) - 1)) -d discourse /shared/postgres_dump/discourse"
+          su postgres -c "/usr/lib/postgresql/18/bin/pg_restore -e -j$(nproc --ignore=1) -d discourse /shared/postgres_dump/discourse"
           su postgres -c "/usr/lib/postgresql/18/bin/pg_ctl stop -D /shared/postgres_data_new"
         
           rm -fr /shared/postgres_dump

--- a/templates/web.template.yml
+++ b/templates/web.template.yml
@@ -206,7 +206,7 @@ run:
       tag: build
       hook: bundle_exec
       cmd:
-        - su discourse -c 'bundle install --jobs $(($(nproc) - 1)) --retry 3'
+        - su discourse -c 'bundle install --jobs $(nproc --ignore=1) --retry 3'
         - su discourse -c 'bundle clean'
         - su discourse -c 'find /var/www/discourse/vendor/bundle -name cache -not -path "*/gems/*" -type d -exec rm -rf {} +'
         - su discourse -c 'find /var/www/discourse/vendor/bundle -name tmp -type d -exec rm -rf {} +'


### PR DESCRIPTION
Job counts of zero were causing failures. nproc's --ignore option is a cleaner solution, allowing us to define how many cores to reserve where possible.