### PR TITLE
FIX: Gem installs in import templates

### DIFF
--- a/templates/import/mbox.template.yml
+++ b/templates/import/mbox.template.yml
@@ -34,4 +34,5 @@ hooks:
           - apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y libsqlite3-dev
           - echo "gem 'sqlite3'" >> Gemfile
           - su discourse -c 'bundle config unset deployment'
-          - su discourse -c 'bundle install --no-deployment --path vendor/bundle --jobs $(nproc --ignore=1) --without test development'
+          - su discourse -c 'bundle config set --local frozen false'
+          - su discourse -c 'bundle install --jobs $(nproc --ignore=1)'

--- a/templates/import/mssql-dep.template.yml
+++ b/templates/import/mssql-dep.template.yml
@@ -22,4 +22,5 @@ hooks:
         cmd:
           - echo "gem 'tiny_tds'" >> Gemfile
           - su discourse -c 'bundle config unset deployment'
-          - su discourse -c 'bundle install --no-deployment --path vendor/bundle --jobs $(nproc --ignore=1) --without test development'
+          - su discourse -c 'bundle config set --local frozen false'
+          - su discourse -c 'bundle install --jobs $(nproc --ignore=1)'

--- a/templates/import/mysql-dep.template.yml
+++ b/templates/import/mysql-dep.template.yml
@@ -11,4 +11,5 @@ hooks:
           - echo "gem 'mysql2'" >> Gemfile
           - apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y libmariadb-dev
           - su discourse -c 'bundle config unset deployment'
-          - su discourse -c 'bundle install --no-deployment --path vendor/bundle --jobs $(nproc --ignore=1) --without test development'
+          - su discourse -c 'bundle config set --local frozen false'
+          - su discourse -c 'bundle install --jobs $(nproc --ignore=1)'

--- a/templates/import/phpbb3.template.yml
+++ b/templates/import/phpbb3.template.yml
@@ -115,4 +115,5 @@ hooks:
           - echo "gem 'mysql2'" >> Gemfile
           - echo "gem 'ruby-bbcode-to-md', :github => 'nlalonde/ruby-bbcode-to-md'" >> Gemfile
           - su discourse -c 'bundle config unset deployment'
-          - su discourse -c 'bundle install --no-deployment --path vendor/bundle --jobs $(nproc --ignore=1) --without test development'
+          - su discourse -c 'bundle config set --local frozen false'
+          - su discourse -c 'bundle install --jobs $(nproc --ignore=1)'

--- a/templates/import/vanilla.template.yml
+++ b/templates/import/vanilla.template.yml
@@ -114,7 +114,8 @@ hooks:
           - echo "gem 'mysql2'" >> Gemfile
           - echo "gem 'ruby-bbcode-to-md', :github => 'nlalonde/ruby-bbcode-to-md'" >> Gemfile
           - su discourse -c 'bundle config unset deployment'
-          - su discourse -c 'bundle install --no-deployment --path vendor/bundle --jobs $(nproc --ignore=1) --without test development'
+          - su discourse -c 'bundle config set --local frozen false'
+          - su discourse -c 'bundle install --jobs $(nproc --ignore=1)'
           - service mariadb start
           # imports the DB into mysql
           - sh /usr/local/bin/import_flarum_test.sh


### PR DESCRIPTION
The `--path` and `--without` flags have been removed in the latest version of Bundler included in the base image, causing the `after_bundle_exec` hook to fail across all import templates.