### PR TITLE
SECURITY: Remove TIFF support from libvips

### DIFF
--- a/image/base/Dockerfile
+++ b/image/base/Dockerfile
@@ -175,9 +175,12 @@ RUN ldconfig &&\
   sudo -u discourse vips black /tmp/vips-jpegli.jpg 1 1 &&\
   sudo -u discourse vipsheader /tmp/vips-jpegli.jpg >/dev/null &&\
   rm /tmp/vips-jpegli.jpg &&\
-  for op in jpegload jpegsave pngload gifload webpload tiffload heifload jxlload svgload text thumbnail autorot gravity flatten; do \
+  for op in jpegload jpegsave pngload gifload webpload heifload jxlload svgload text thumbnail autorot gravity flatten; do \
     sudo -u discourse vips -l "$op" >/dev/null || { echo "ERROR: vips is missing operation: $op"; exit 1; }; \
   done &&\
+  if sudo -u discourse vips -l tiffload >/dev/null 2>&1; then \
+    echo "ERROR: vips must not include the unsupported TIFF loader"; exit 1; \
+  fi &&\
   if dpkg-query -W -f '${Package} ${db:Status-Status}\n' ghostscript libgs10 libgs-common libgs10-common 2>/dev/null | grep -q ' installed$' || command -v gs >/dev/null; then \
     echo "ERROR: ghostscript must not be present in this image"; exit 1; \
   fi

--- a/image/base/install-vips
+++ b/image/base/install-vips
@@ -13,7 +13,7 @@ export DEBIAN_FRONTEND=noninteractive
 export PKG_CONFIG_PATH="$JPEGLI_PREFIX/lib/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
 apt -y -q install meson ninja-build pkg-config xz-utils \
     libglib2.0-dev libexpat1-dev \
-    libpng-dev libwebp-dev libtiff-dev libjxl-dev librsvg2-dev \
+    libpng-dev libwebp-dev libjxl-dev librsvg2-dev \
     libcgif-dev libexif-dev liblcms2-dev liborc-0.4-dev \
     libimagequant-dev libpango1.0-dev
 
@@ -46,7 +46,7 @@ meson setup build \
   -Djpeg=enabled \
   -Dpng=enabled \
   -Dwebp=enabled \
-  -Dtiff=enabled \
+  -Dtiff=disabled \
   -Dheif=enabled \
   -Djpeg-xl=enabled \
   -Drsvg=enabled \
@@ -65,9 +65,14 @@ ldconfig $PREFIX/lib
 
 ldd "$PREFIX/lib/libvips.so.42" | grep -q "$JPEGLI_PREFIX/lib/libjpeg.so.62"
 
-for op in jpegload jpegsave pngload gifload webpload tiffload heifload jxlload svgload text; do
+for op in jpegload jpegsave pngload gifload webpload heifload jxlload svgload text; do
   vips -l | grep -q "$op" || { echo "ERROR: vips is missing operation: $op"; exit 1; }
 done
+
+if vips -l | grep -q tiffload; then
+  echo "ERROR: vips must not include the unsupported TIFF loader"
+  exit 1
+fi
 
 if vips -l | grep -qi magick || ldd $PREFIX/lib/libvips.so.42 | grep -Eqi 'libMagick|libgs\.so'; then
   echo "ERROR: vips must not link to ImageMagick or Ghostscript"


### PR DESCRIPTION
Discourse does not accept TIFF uploads, but the libvips build included the TIFF loader. libvips marks this loader as trusted, so `VIPS_BLOCK_UNTRUSTED` does not prevent content detection from selecting it.

This commit disables TIFF support at build time, removes the unused build dependency, and checks both the builder and final image to ensure that `tiffload` is absent. ImageMagick keeps its existing TIFF runtime dependency and behavior.