### PR TITLE
Bump default base image to discourse/base:2.0.20260811-0917

### DIFF
--- a/launcher
+++ b/launcher
@@ -127,7 +127,7 @@ kernel_min_version='4.4.0'
 config_file=containers/"$config".yml
 cidbootstrap=cids/"$config"_bootstrap.cid
 local_discourse=local_discourse
-image="discourse/base:2.0.20260803-0122"
+image="discourse/base:2.0.20260811-0620"
 docker_path=`which docker.io 2> /dev/null || which docker`
 git_path=`which git`
 

--- a/launcher
+++ b/launcher
@@ -127,7 +127,7 @@ kernel_min_version='4.4.0'
 config_file=containers/"$config".yml
 cidbootstrap=cids/"$config"_bootstrap.cid
 local_discourse=local_discourse
-image="discourse/base:2.0.20260811-0620"
+image="discourse/base:2.0.20260811-0917"
 docker_path=`which docker.io 2> /dev/null || which docker`
 git_path=`which git`
 

--- a/templates/postgres.template.yml
+++ b/templates/postgres.template.yml
@@ -1,4 +1,4 @@
-base_image: discourse/base:2.0.20260803-0122
+base_image: discourse/base:2.0.20260811-0620
 params:
   db_synchronous_commit: "off"
   db_shared_buffers: "256MB"

--- a/templates/postgres.template.yml
+++ b/templates/postgres.template.yml
@@ -1,4 +1,4 @@
-base_image: discourse/base:2.0.20260811-0620
+base_image: discourse/base:2.0.20260811-0917
 params:
   db_synchronous_commit: "off"
   db_shared_buffers: "256MB"

--- a/templates/redis.template.yml
+++ b/templates/redis.template.yml
@@ -1,4 +1,4 @@
-base_image: discourse/base:2.0.20260803-0122
+base_image: discourse/base:2.0.20260811-0620
 params:
   redis_io_threads: "1"
 

--- a/templates/redis.template.yml
+++ b/templates/redis.template.yml
@@ -1,4 +1,4 @@
-base_image: discourse/base:2.0.20260811-0620
+base_image: discourse/base:2.0.20260811-0917
 params:
   redis_io_threads: "1"
 

--- a/templates/web.template.yml
+++ b/templates/web.template.yml
@@ -1,4 +1,4 @@
-base_image: discourse/base:2.0.20260803-0122
+base_image: discourse/base:2.0.20260811-0620
 env:
   # You can have redis on a different box
   RAILS_ENV: 'production'

--- a/templates/web.template.yml
+++ b/templates/web.template.yml
@@ -1,4 +1,4 @@
-base_image: discourse/base:2.0.20260811-0620
+base_image: discourse/base:2.0.20260811-0917
 env:
   # You can have redis on a different box
   RAILS_ENV: 'production'


### PR DESCRIPTION
This updates the default base image to Debian Trixie.