### PR TITLE
FIX: Ensure Redis log directory is created

### DIFF
--- a/image/base/Dockerfile
+++ b/image/base/Dockerfile
@@ -250,5 +250,5 @@ RUN cd /var/www/discourse &&\
 FROM discourse-web-only AS discourse-release
 RUN --mount=type=tmpfs,target=/var/log \
   apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
-  postgresql-${PG_MAJOR} postgresql-contrib-${PG_MAJOR} postgresql-${PG_MAJOR}-pgvector \
-  redis
+  postgresql-${PG_MAJOR} postgresql-contrib-${PG_MAJOR} postgresql-${PG_MAJOR}-pgvector
+RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get -y install redis

--- a/image/discourse_dev/Dockerfile
+++ b/image/discourse_dev/Dockerfile
@@ -15,11 +15,13 @@ FROM $from_tag
 
 #LABEL maintainer="Sam Saffron \"https://twitter.com/samsaffron\""
 
-# Install Postgres and Redis
+# Install Postgres
 RUN --mount=type=tmpfs,target=/var/log \
   apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
-  postgresql-${PG_MAJOR} postgresql-contrib-${PG_MAJOR} postgresql-${PG_MAJOR}-pgvector \
-  redis
+  postgresql-${PG_MAJOR} postgresql-contrib-${PG_MAJOR} postgresql-${PG_MAJOR}-pgvector
+
+# Install Redis
+RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get -y install redis
 
 # Remove the code added on base image
 RUN rm -rf /var/www/*

--- a/image/discourse_test/Dockerfile
+++ b/image/discourse_test/Dockerfile
@@ -10,12 +10,14 @@ ENV LANG=en_US.UTF-8
 RUN sudo -E -u discourse -H git config --global user.email "you@example.com" &&\
     sudo -E -u discourse -H git config --global user.name "Your Name"
 
-# Include postgres and redis on test images
+# Include postgres on test images
 RUN --mount=type=tmpfs,target=/var/log \
   apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
   postgresql-${PG_MAJOR} postgresql-contrib-${PG_MAJOR} postgresql-${PG_MAJOR}-pgvector \
-  postgresql-${PG_MAJOR_OLD} postgresql-contrib-${PG_MAJOR_OLD} postgresql-${PG_MAJOR_OLD}-pgvector \
-  redis
+  postgresql-${PG_MAJOR_OLD} postgresql-contrib-${PG_MAJOR_OLD} postgresql-${PG_MAJOR_OLD}-pgvector
+
+# Install Redis
+RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get -y install redis
 
 RUN chown -R discourse . &&\
     chown -R discourse /var/run/postgresql &&\


### PR DESCRIPTION
/var/log/redis needs to exist for certain tests in discourse/discourse to succeed. We were piggybacking off the Postgres install which discards the contents of /var/log via a tmpfs.