### PR TITLE
DEV: Require Linux 5.13 for Landlock support

### DIFF
--- a/launcher
+++ b/launcher
@@ -122,7 +122,7 @@ docker_min_version='20.10.0'
 docker_rec_version='24.0.7'
 git_min_version='1.8.0'
 git_rec_version='1.8.0'
-kernel_min_version='4.4.0'
+kernel_min_version='5.13.0'
 
 config_file=containers/"$config".yml
 cidbootstrap=cids/"$config"_bootstrap.cid
@@ -281,7 +281,7 @@ check_prereqs() {
     echo "WARNING: Git version ${test} deprecated, recommend upgrade to ${git_rec_version} or newer."
   fi
 
-  # Check minimum kernel version due to https://bugs.ruby-lang.org/issues/13885
+  # Landlock support requires Linux 5.13 or later
   test=($(uname -r))
 
   # At least minimum version


### PR DESCRIPTION
## What changed

Raise the minimum Linux kernel version in `launcher` from 4.4.0 to 5.13.0.

## Why

Linux 5.13 introduced Landlock. Discourse uses Landlock to confine external commands and apply the resource limits supplied by image-processing wrappers. Without Landlock, `SafeExec` falls back to ordinary command execution and cannot enforce those limits.

This requirement must land before Discourse moves low-risk image processing to libvips.

The version check covers the upstream kernel requirement. Custom kernels must also enable `CONFIG_SECURITY_LANDLOCK` and include Landlock in the active LSM list.

## Impact

`launcher` will stop before a rebuild on hosts running kernels older than 5.13. Administrators must upgrade the host kernel or operating system, reboot, and retry.

## Validation

- `bash -n launcher`
- Version boundary checks for Linux 5.12, 5.13, and 6.8
- `git diff --check`
