### PR TITLE
FIX: Include PostgreSQL 15 in the dev image

### DIFF
--- a/image/discourse_dev/Dockerfile
+++ b/image/discourse_dev/Dockerfile
@@ -18,7 +18,8 @@ FROM $from_tag
 # Install Postgres
 RUN --mount=type=tmpfs,target=/var/log \
   apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
-  postgresql-${PG_MAJOR} postgresql-contrib-${PG_MAJOR} postgresql-${PG_MAJOR}-pgvector
+  postgresql-${PG_MAJOR} postgresql-contrib-${PG_MAJOR} postgresql-${PG_MAJOR}-pgvector \
+  postgresql-${PG_MAJOR_OLD} postgresql-contrib-${PG_MAJOR_OLD} postgresql-${PG_MAJOR_OLD}-pgvector
 
 # Install Redis
 RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get -y install redis


### PR DESCRIPTION
Same as a2e8beb8cbdfd1545a7b2971bf277fbcfe2a0d67, but for the discourse_dev image. Needed for core's structure-dump tasks.