### PR TITLE
PERF: Skip chown for files that already have the right ownership

### DIFF
--- a/templates/web.template.yml
+++ b/templates/web.template.yml
@@ -122,7 +122,7 @@ run:
         - bash -c "ln    -s           /shared/{uploads,backups} $home/public"
         - bash -c "mkdir -p           /shared/tmp/{backups,restores}"
         - bash -c "ln    -s           /shared/tmp/{backups,restores} $home/tmp"
-        - chown -R discourse:www-data /shared/log/rails /shared/uploads /shared/backups /shared/tmp
+        - find /shared/log/rails /shared/uploads /shared/backups /shared/tmp ! \( -user discourse -group www-data \) -exec chown discourse:www-data {} \+
         # scrub broken symlinks from plugins that have been removed
         - "[ ! -d public/plugins ] || find public/plugins/ -maxdepth 1 -xtype l -delete"
 


### PR DESCRIPTION
The web template runs `chown -R discourse:www-data` over many directories on every rebuild. This rewrites the ownership even when it's already correct.

Instead, we can use `find` to select only the files with wrong ownership. We already use this pattern for `$home` in the `web:` hook of this template. (see aef8682f1e9961d82b98aab87c7e47e0f08a6c52)