### PR TITLE
PERF: Refresh Fontconfig cache after package installation

### DIFF
--- a/image/base/Dockerfile
+++ b/image/base/Dockerfile
@@ -134,6 +134,7 @@ RUN apt update &&\
     libnginx-mod-http-brotli-filter \
     libnginx-mod-http-brotli-static
 
+# Keep this in a separate layer so the cache records the exported font-directory timestamps.
 RUN fc-cache -f
 
 # Copy binary and configuration files for magick

--- a/image/base/Dockerfile
+++ b/image/base/Dockerfile
@@ -134,6 +134,8 @@ RUN apt update &&\
     libnginx-mod-http-brotli-filter \
     libnginx-mod-http-brotli-static
 
+RUN fc-cache -f
+
 # Copy binary and configuration files for magick
 COPY --from=imagemagick_builder /usr/local/bin/magick /usr/local/bin/magick
 COPY --from=imagemagick_builder /usr/local/etc/ImageMagick-7 /usr/local/etc/ImageMagick-7

--- a/image/base/Dockerfile
+++ b/image/base/Dockerfile
@@ -134,8 +134,12 @@ RUN apt update &&\
     libnginx-mod-http-brotli-filter \
     libnginx-mod-http-brotli-static
 
-# Keep this in a separate layer so the cache records the exported font-directory timestamps.
-RUN fc-cache -f
+# Fontconfig caches include font-directory mtimes with nanoseconds. BuildKit keeps
+# these between RUNs, but containerd truncates them during layer export, making
+# caches stale. Normalize the mtimes before generating the caches.
+RUN find /usr/local/share/fonts /usr/share/fonts -type d \
+      -exec sh -c 'for dir do touch -d "@$(stat -c %Y "$dir")" "$dir"; done' sh {} + && \
+    fc-cache -f
 
 # Copy binary and configuration files for magick
 COPY --from=imagemagick_builder /usr/local/bin/magick /usr/local/bin/magick


### PR DESCRIPTION
Observed for 100 sandboxed LetterAvatar.generate_fullsize("A") calls on arm64:

Cache | p50 | p95
-- | -- | --
Before | 98.34 ms | 107.09 ms
After fc-cache -f | 24.23 ms | 27.52 ms