### PR TITLE
FIX: install PostgreSQL 15 server in postgres.15 template

### DIFF
--- a/templates/postgres.15.template.yml
+++ b/templates/postgres.15.template.yml
@@ -23,8 +23,9 @@ hooks:
 
 run:
   - exec: DEBIAN_FRONTEND=noninteractive apt-get purge -y postgresql-18 postgresql-contrib-18 postgresql-18-pgvector
-
+  
   - exec: apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y postgresql-15 postgresql-contrib-15 postgresql-15-pgvector
+  
   - file:
      path: /etc/service/postgres/run
      chmod: "+x"

--- a/templates/postgres.15.template.yml
+++ b/templates/postgres.15.template.yml
@@ -22,6 +22,9 @@ hooks:
          sv start postgres || exit 1
 
 run:
+  - exec: DEBIAN_FRONTEND=noninteractive apt-get purge -y postgresql-18 postgresql-contrib-18 postgresql-18-pgvector
+
+  - exec: apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y postgresql-15 postgresql-contrib-15 postgresql-15-pgvector
   - file:
      path: /etc/service/postgres/run
      chmod: "+x"


### PR DESCRIPTION
`postgres.15.template.yml` currently assumes that the PostgreSQL 15 server
packages are installed by the base image.

Since the base image moved to PostgreSQL 18, selecting
`templates/postgres.15.template.yml` to postpone the PostgreSQL 18 upgrade
fails during bootstrap with:

    Errno::ENOENT: No such file or directory @ rb_sysopen -
    /etc/postgresql/15/main/postgresql.conf

Install the PostgreSQL 15 server packages in the PostgreSQL 15 template,
after removing the PostgreSQL 18 server packages.

This restores the intended PostgreSQL 15 holdback path.