### PR TITLE
FIX: update /shared dir configurations at mount time

### DIFF
--- a/templates/web.template.yml
+++ b/templates/web.template.yml
@@ -127,6 +127,19 @@ run:
         - "[ ! -d public/plugins ] || find public/plugins/ -maxdepth 1 -xtype l -delete"
 
   - exec:
+      cd: $home
+      tag: precompile
+      cmd:
+        - mkdir -p                    /shared/log/rails
+        - bash -c "touch -a           /shared/log/rails/{production,production_errors,unicorn.stdout,unicorn.stderr,sidekiq}.log"
+        - bash -c "ln    -s           /shared/log/rails/{production,production_errors,unicorn.stdout,unicorn.stderr,sidekiq}.log $home/log"
+        - bash -c "mkdir -p           /shared/{uploads,backups}"
+        - bash -c "ln    -s           /shared/{uploads,backups} $home/public"
+        - bash -c "mkdir -p           /shared/tmp/{backups,restores}"
+        - bash -c "ln    -s           /shared/tmp/{backups,restores} $home/tmp"
+        - find /shared/log/rails /shared/uploads /shared/backups /shared/tmp ! \( -user discourse -group www-data \) -exec chown discourse:www-data {} \+
+
+  - exec:
       cmd:
         - "cp $home/config/nginx.sample.conf /etc/nginx/conf.d/discourse.conf"
         - "rm /etc/nginx/sites-enabled/default"


### PR DESCRIPTION
/shared dir is not guaranteed to be mounted/modifiable during `build` times. The above dir commands may be a no-op after build due to read-only filesystems.

Add a stanza targeting precompile steps that mirrors the /shared dir updates.