### PR TITLE
FIX: create /shared dirs on migrate

### DIFF
--- a/templates/web.template.yml
+++ b/templates/web.template.yml
@@ -128,7 +128,7 @@ run:
 
   - exec:
       cd: $home
-      tag: precompile
+      tag: migrate
       cmd:
         - mkdir -p                    /shared/log/rails
         - bash -c "touch -a           /shared/log/rails/{production,production_errors,unicorn.stdout,unicorn.stderr,sidekiq}.log"


### PR DESCRIPTION
fixes rare cases of running without proper /shared dirs earlier, on migrate, rather than on precompile