### PR TITLE
DEV: run precompile:prettytext during build

### DIFF
--- a/templates/web.template.yml
+++ b/templates/web.template.yml
@@ -249,7 +249,7 @@ run:
       tag: build
       hook: assets_precompile_build
       cmd:
-        - su discourse -c 'bundle exec rake assets:precompile:build'
+        - su discourse -c 'SKIP_DB_AND_REDIS=1 bundle exec rake assets:precompile:build assets:precompile:pretty_text'
   - exec:
       cd: $home
       tag: precompile


### PR DESCRIPTION
Run asset:precompile:pretty_text alongside precompile:build during build time.

Ensures that the prebuilt prettytext cache is present in /tmp after build time.