### PR TITLE
SECURITY: Update libheif to 1.23.4

### DIFF
--- a/image/base/Dockerfile
+++ b/image/base/Dockerfile
@@ -121,7 +121,7 @@ RUN --mount=type=tmpfs,target=/var/log \
     mkdir -p /etc/runit/1.d &&\
     apt-mark hold libheif1 discourse-libheif-guard &&\
     rm /tmp/libheif1.deb /tmp/discourse-libheif-guard.deb &&\
-    test "$(dpkg-query -W -f='${Version}' libheif1)" = "1.23.1-1discourse1"
+    test "$(dpkg-query -W -f='${Version}' libheif1)" = "1.23.4-1discourse1"
 
 ENV LC_ALL=en_US.UTF-8
 ENV LANG=en_US.UTF-8
@@ -167,7 +167,7 @@ COPY --from=vips-builder /usr/local/bin/vipsheader /usr/local/bin/vipsheader
 COPY --from=vips-builder /usr/local/lib/libvips.so.42 /usr/local/lib/libvips.so.42
 COPY --from=vips-builder /usr/local/lib/jpegli/lib/libjpeg.so.62.3.0 /usr/local/lib/jpegli/lib/libjpeg.so.62
 RUN ldconfig &&\
-  ruby -rfiddle -e 'lib = Fiddle.dlopen("libheif.so.1"); version = Fiddle::Function.new(lib["heif_get_version"], [], Fiddle::TYPE_VOIDP); abort "unexpected libheif version" unless Fiddle::Pointer.new(version.call).to_s == "1.23.1"' &&\
+  ruby -rfiddle -e 'lib = Fiddle.dlopen("libheif.so.1"); version = Fiddle::Function.new(lib["heif_get_version"], [], Fiddle::TYPE_VOIDP); abort "unexpected libheif version" unless Fiddle::Pointer.new(version.call).to_s == "1.23.4"' &&\
   ruby -rfiddle -e 'Fiddle.dlopen("libvips.so.42")' &&\
   sudo -u discourse vips --version &&\
   sudo -u discourse vipsheader --version &&\

--- a/image/base/install-libheif
+++ b/image/base/install-libheif
@@ -2,9 +2,9 @@
 set -e
 
 # version check: https://github.com/strukturag/libheif/releases
-LIBHEIF_VERSION="1.23.1"
+LIBHEIF_VERSION="1.23.4"
 PACKAGE_VERSION="$LIBHEIF_VERSION-1discourse1"
-LIBHEIF_HASH="0de0327f60fcd47de90d5654c6fe152232738d60d84fe084ec3e0f35e03b166a"
+LIBHEIF_HASH="d0c02b4b0e978f34a1974b6f3eea7975a537bf7a9195ffeea38e7242ff316fdd"
 
 PREFIX=/usr
 WDIR=/tmp/libheif


### PR DESCRIPTION
The base image pins libheif 1.23.1, which predates the security fixes in the latest release, [1.23.4](https://github.com/strukturag/libheif/releases/tag/v1.23.4). Upstream rates three fixes in 1.23.4 as high severity and advises all users to upgrade.

This commit updates libheif to 1.23.4, replaces the source archive SHA-256, and updates the Debian package and loaded-library version assertions.
